### PR TITLE
Fix config folder.

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -8,15 +8,15 @@ int main(string[] args)
 {
 	// Determine the user home directory. 
 	// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d scripts
-	string homePath = environment.get("XDG_CONFIG_HOME");
-	if (homePath == ""){
+	string configPath = environment.get("XDG_CONFIG_HOME");
+	if (configPath == ""){
 		// XDG_CONFIG_HOME does not exist on systems where X11 is not present - ie - headless systems / servers
 		// Get HOME environment variable
-		homePath = environment.get("HOME");
+		configPath = environment.get("HOME") ~ "/.config";
 	}
 	
 	// configuration directory
-	string configDirName = homePath ~ "/.config/onedrive";
+	string configDirName = configPath ~ "/onedrive";
 	// only download remote changes
 	bool downloadOnly;
 	// override the sync directory


### PR DESCRIPTION
I noticed the following rather strange behaviour on my system when launching onedrive:

```
$ ./onedrive -v --monitor
Loading config ...
Using Config Dir: /home/xxx/.config/.config/onedrive
```

Note the bugged location of the config dir.

The problem is that XDG_CONFIG_HOME defaults to $HOME/.config and not to $HOME (see https://wiki.archlinux.org/index.php/XDG_Base_Directory_support) and this caused the onedrive config folder to be set to ~/.config/.config/onedrive instead of just ~/.config/ondrive - this patch will fix this.

EDIT: This is meant to go on top of https://github.com/skilion/onedrive/pull/314