### PR TITLE
Fix package creation and improve Makefile a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ clean:
 	rm -f onedrive onedrive.o onedrive.service
 
 install: all
-	mkdir -p /var/log/onedrive
-	chown root.users /var/log/onedrive
-	chmod 0775 /var/log/onedrive
+	mkdir -p $(DESTDIR)/var/log/onedrive
+	chown root.users $(DESTDIR)/var/log/onedrive
+	chmod 0775 $(DESTDIR)/var/log/onedrive
 	install -D onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
-	install -D -m 644 logrotate/onedrive.logrotate /etc/logrotate.d/onedrive
+	install -D -m 644 logrotate/onedrive.logrotate $(DESTDIR)/etc/logrotate.d/onedrive
 	cp -af *.service $(DESTDIR)/usr/lib/systemd/user/
 	chmod 0644 $(DESTDIR)/usr/lib/systemd/user/onedrive*.service
 	
@@ -41,7 +41,7 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive@.service
-	rm -f /etc/logrotate.d/onedrive
+	rm -f $(DESTDIR)/etc/logrotate.d/onedrive
 	rm -rf ~/.config/onedrive
 
 version: .git/HEAD .git/index

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ uninstall:
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive@.service
 	rm -f $(DESTDIR)/etc/logrotate.d/onedrive
-	rm -rf ~/.config/onedrive
 
 version: .git/HEAD .git/index
 	echo $(shell git describe --tags) >version


### PR DESCRIPTION
Makefile improvements:
* fixed DESTDIR variable support - source can be used for package creation and user installs now (tested on Arch Linux with both manual `make DESTDIR=~/out install` and PKGBUILD),
* removed uneccessary `rm -rvf ~/.config/onedrive`, because in most cases, it's ineffective - `make uninstall` is called via `su` or `sudo` commands, and user-level configuration definitively isn't in `/root/.config`

I'm not sure still about directory creation and permission changes in Makefile -  I think those should be managed by application itself, and not use `/var/log` path except when ran as system-level daemon.