### PR TITLE
Resolve ETag does not match current item's value

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -540,8 +540,14 @@ final class OneDriveApi
 
 	private void checkHttpCode(ref const JSONValue response)
 	{
-		if (http.statusLine.code / 100 != 2) {
-			throw new OneDriveException(http.statusLine.code, http.statusLine.reason, response);
+		if (http.statusLine.code == 412) {
+			// A precondition provided in the request (such as an if-match header) does not match the resource's current state.
+			log.vlog("OneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error");
+		} else {
+			// Original handling
+			if (http.statusLine.code / 100 != 2) {
+				throw new OneDriveException(http.statusLine.code, http.statusLine.reason, response);
+			}
 		}
 	}
 }

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -212,12 +212,13 @@ final class OneDriveApi
 	}
 	
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession
-	JSONValue createUploadSession(const(char)[] parentDriveId, const(char)[] parentId, const(char)[] filename, const(char)[] eTag = null)
+	JSONValue createUploadSession(const(char)[] parentDriveId, const(char)[] parentId, const(char)[] filename, const(char)[] eTag = null, JSONValue item = null)
 	{
 		checkAccessTokenExpired();
 		const(char)[] url = driveByIdUrl ~ parentDriveId ~ "/items/" ~ parentId ~ ":/" ~ encodeComponent(filename) ~ ":/createUploadSession";
 		if (eTag) http.addRequestHeader("If-Match", eTag);
-		return post(url, null);
+		http.addRequestHeader("Content-Type", "application/json");
+		return post(url, item.toString());
 	}
 
 	// https://dev.onedrive.com/items/upload_large_files.htm

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -542,7 +542,7 @@ final class OneDriveApi
 	{
 		if (http.statusLine.code == 412) {
 			// A precondition provided in the request (such as an if-match header) does not match the resource's current state.
-			log.vlog("OneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error");
+			log.vlog("\nOneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error\n");
 		} else {
 			// Original handling
 			if (http.statusLine.code / 100 != 2) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -785,9 +785,10 @@ final class SyncEngine
 									// OneDrive threw a 412 error, most likely: ETag does not match current item's value
 									// In some cases the file that was uploaded was not complete, but 'completed' without errors on OneDrive
 									// This has been seen with PNG / JPG files mainly, which then contributes to generating a 412 error
-									// Re-try upload as a session, but no eTag
-									string nullTag = null;
-									response = session.upload(path, item.driveId, item.parentId, baseName(path), nullTag);
+									// Remove file
+									onedrive.deleteById(item.driveId, item.id, eTag);
+									// Upload file
+									response = session.upload(path, item.driveId, item.parentId, baseName(path), eTag);
 								}
 								
 								if (e.httpStatusCode == 504) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -785,8 +785,9 @@ final class SyncEngine
 									// OneDrive threw a 412 error, most likely: ETag does not match current item's value
 									// In some cases the file that was uploaded was not complete, but 'completed' without errors on OneDrive
 									// This has been seen with PNG / JPG files mainly, which then contributes to generating a 412 error
-									// Re-try upload as a session
-									response = session.upload(path, item.driveId, item.parentId, baseName(path), eTag);
+									// Re-try upload as a session, but no eTag
+									string nullTag = null;
+									response = session.upload(path, item.driveId, item.parentId, baseName(path), nullTag);
 								}
 								
 								if (e.httpStatusCode == 504) {

--- a/src/upload.d
+++ b/src/upload.d
@@ -23,7 +23,23 @@ struct UploadSession
 
 	JSONValue upload(string localPath, const(char)[] parentDriveId, const(char)[] parentId, const(char)[] filename, const(char)[] eTag = null)
 	{
-		session = onedrive.createUploadSession(parentDriveId, parentId, filename, eTag);
+		// Fix https://github.com/abraunegg/onedrive/issues/2
+		// Fix https://github.com/abraunegg/onedrive/issues/24
+		// More Details https://github.com/OneDrive/onedrive-api-docs/issues/778
+		
+		SysTime localFileLastModifiedTime = timeLastModified(localPath).toUTC();
+		localFileLastModifiedTime.fracSecs = Duration.zero;
+		
+		JSONValue fileSystemInfo = [
+				"item": JSONValue([
+					"@name.conflictBehavior": JSONValue("replace"),
+					"fileSystemInfo": JSONValue([
+						"lastModifiedDateTime": localFileLastModifiedTime.toISOExtString()
+					])
+				])
+			];
+		
+		session = onedrive.createUploadSession(parentDriveId, parentId, filename, eTag, fileSystemInfo);
 		session["localPath"] = localPath;
 		save();
 		return upload();


### PR DESCRIPTION
* Resolve OneDrive throwing 'ETag does not match current item's value' when uploading changed local files (mainly JPG & PNG)