### PR TITLE
Fix: skip_file config entry needs to be checked for any characters to escape (Issue #15)

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -95,6 +95,9 @@ Regex!char wild2regex(const(char)[] pattern)
 		case '|':
 			str ~= "$|^";
 			break;
+		case '+':
+			str ~= "\\+";
+			break;	
 		default:
 			str ~= c;
 			break;


### PR DESCRIPTION
* Add '+' as a character to escape when using the wild2regex function