### PR TITLE
Fix: Error when trying to upload a file with weird non printable characters present (Issue #35)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+# latest dmd
+d: 
+  - dmd
+
+language: d
+
+script: make
+ 

--- a/src/sync.d
+++ b/src/sync.d
@@ -743,7 +743,13 @@ final class SyncEngine
 			log.vlog("Skipping item - invalid name (Microsoft Naming Convention): ", path);
 			return;
 		}
-
+		
+		// Check for bad whitespace items
+		if (!containsBadWhiteSpace(path)) {
+			log.vlog("Skipping item - invalid name (Contains an invalid whitespace item): ", path);
+			return;
+		}
+		
 		final switch (item.type) {
 		case ItemType.dir:
 			uploadDirDifferences(item, path);
@@ -883,6 +889,12 @@ final class SyncEngine
 			// Restriction and limitations about windows naming files
 			if (!isValidName(path)) {
 				log.vlog("Skipping item - invalid name (Microsoft Naming Convention): ", path);
+				return;
+			}
+			
+			// Check for bad whitespace items
+			if (!containsBadWhiteSpace(path)) {
+				log.vlog("Skipping item - invalid name (Contains an invalid whitespace item): ", path);
 				return;
 			}
 

--- a/src/util.d
+++ b/src/util.d
@@ -9,6 +9,7 @@ import std.regex;
 import std.socket;
 import std.stdio;
 import std.string;
+import std.algorithm;
 import std.uri;
 import qxor;
 

--- a/src/util.d
+++ b/src/util.d
@@ -9,6 +9,7 @@ import std.regex;
 import std.socket;
 import std.stdio;
 import std.string;
+import std.uri;
 import qxor;
 
 private string deviceName;
@@ -154,6 +155,35 @@ bool isValidName(string path)
 
 	return m.empty;
 }
+
+bool containsBadWhiteSpace(string path)
+{
+	// allow root item
+	if (path == ".") {
+		return true;
+	}
+	
+	// https://github.com/abraunegg/onedrive/issues/35
+	// Issue #35 presented an interesting issue where the filename contained a newline item
+	//		'State-of-the-art, challenges, and open issues in the integration of Internet of'$'\n''Things and Cloud Computing.pdf'
+	// When the check to see if this file was present the GET request queries as follows:
+	//		/v1.0/me/drive/root:/.%2FState-of-the-art%2C%20challenges%2C%20and%20open%20issues%20in%20the%20integration%20of%20Internet%20of%0AThings%20and%20Cloud%20Computing.pdf
+	// The '$'\n'' is translated to %0A which causes the OneDrive query to fail
+	// Check for the presence of '%0A' via regex
+	
+	string itemName = encodeComponent(baseName(path));
+	
+	auto invalidWhitespaceReg =
+		ctRegex!(
+			// leading whitespace and trailing whitespace/dot
+			`%0A`
+		);
+	auto m = match(itemName, invalidWhitespaceReg);
+
+	return m.empty;
+	
+}
+
 
 unittest
 {

--- a/src/util.d
+++ b/src/util.d
@@ -175,7 +175,7 @@ bool containsBadWhiteSpace(string path)
 	
 	auto invalidWhitespaceReg =
 		ctRegex!(
-			// leading whitespace and trailing whitespace/dot
+			// Check for \n which is %0A when encoded
 			`%0A`
 		);
 	auto m = match(itemName, invalidWhitespaceReg);


### PR DESCRIPTION
* Implement an invalid whitespace filename check which currently checks for a 'new line' whitespace entry in a filename. Regex can be expanded if other files with similar characteristics are found.