### PR TITLE
Resolve compilation issue with dmd-2.081.0

### DIFF
--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -68,7 +68,7 @@ struct Database
 	{
 		int userVersion;
 		extern (C) int callback(void* user_version, int count, char** column_text, char** column_name) {
-			import std.c.stdlib: atoi;
+			import core.stdc.stdlib;
 			*(cast(int*) user_version) = atoi(*column_text);
 			return 0;
 		}


### PR DESCRIPTION
* Resolve: Error: module `stdlib` is in file 'std/c/stdlib.d' which cannot be read when using dmd-2.081.0 due to deprication of function - https://dlang.org/changelog/2.081.0.html#remove_std_c