### PR TITLE
Fix: Crash if file is locked by online editing (status code 423) (Issue #36)

### DIFF
--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -68,7 +68,7 @@ struct Database
 	{
 		int userVersion;
 		extern (C) int callback(void* user_version, int count, char** column_text, char** column_name) {
-			import std.c.stdlib: atoi;
+			import core.stdc.stdlib;
 			*(cast(int*) user_version) = atoi(*column_text);
 			return 0;
 		}

--- a/src/sync.d
+++ b/src/sync.d
@@ -834,6 +834,17 @@ final class SyncEngine
 								try {
 									response = onedrive.simpleUploadReplace(path, item.driveId, item.id, item.eTag);
 								} catch (OneDriveException e) {
+									// Resolve https://github.com/abraunegg/onedrive/issues/36
+									if ((e.httpStatusCode == 409) || (e.httpStatusCode == 423)) {
+										// The file is currently checked out or locked for editing by another user
+										// We cant upload this file at this time
+										writeln(" skipped.");
+										log.fileOnly("Uploading file ", path, " ... skipped.");
+										write("", path, " is currently checked out or locked for editing by another user.");
+										log.fileOnly(path, " is currently checked out or locked for editing by another user.");
+										return;
+									}
+								
 									if (e.httpStatusCode == 504) {
 										// HTTP request returned status code 504 (Gateway Timeout)
 										// Try upload as a session
@@ -850,7 +861,23 @@ final class SyncEngine
 						} else {
 							// OneDrive Business Account - always use a session to upload
 							writeln("");
-							response = session.upload(path, item.driveId, item.parentId, baseName(path));
+							
+							try {
+								response = session.upload(path, item.driveId, item.parentId, baseName(path));
+							} catch (OneDriveException e) {
+							
+								// Resolve https://github.com/abraunegg/onedrive/issues/36
+								if ((e.httpStatusCode == 409) || (e.httpStatusCode == 423)) {
+									// The file is currently checked out or locked for editing by another user
+									// We cant upload this file at this time
+									writeln(" skipped.");
+									log.fileOnly("Uploading file ", path, " ... skipped.");
+									writeln("", path, " is currently checked out or locked for editing by another user.");
+									log.fileOnly(path, " is currently checked out or locked for editing by another user.");
+									return;
+								}
+							}
+														
 							writeln(" done.");
 							// As the session.upload includes the last modified time, save the response
 							saveItem(response);


### PR DESCRIPTION
* Resolve crash if file is locked by online editing (status code 423) which is encountered when a file is being edited online via OneDrive and has been synced locally and edited locally. The 'onedrive' application now skips over files that cannot be uploaded due to being locked by OneDrive in edit mode.