### PR TITLE
Update sync_dir handling

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -118,7 +118,7 @@ int main(string[] args)
 	cfg.init();
 	
 	// command line parameters override the config
-	if (syncDirName) cfg.setValue("sync_dir", syncDirName);
+	if (syncDirName) cfg.setValue("sync_dir", syncDirName.expandTilde().absolutePath());
 
 	// upgrades
 	if (exists(configDirName ~ "/items.db")) {


### PR DESCRIPTION
* Update sync_dir handling to use the absolute path for setting parameter to something other than ~/OneDrive via config file or command line