### PR TITLE
Implement Feature Request: Upload Only Option that does not perform remote delete (Issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,12 @@ no option        		   No Sync and exit
              --local-first Synchronize from the local directory source first, before downloading changes from OneDrive.
                   --logout Logout the current user
 -m               --monitor Keep monitoring for local and remote changes
+        --no-remote-delete Do not delete local file 'deletes' from OneDrive when using --upload-only
              --print-token Print the access token, useful for debugging
                   --resync Forget the last saved state, perform a full sync
         --remove-directory Remove a directory on OneDrive - no sync will be performed.
         --single-directory Specify a single local directory within the OneDrive root to sync.
+           --skip-symlinks Skip syncing of symlinks
         --source-directory Source directory to rename or move on OneDrive - no sync will be performed.
                  --syncdir Set the directory used to sync the files that are synced
              --synchronize Perform a synchronization

--- a/src/main.d
+++ b/src/main.d
@@ -58,6 +58,8 @@ int main(string[] args)
 	bool uploadOnly;
 	// Add a check mounts option to resolve https://github.com/abraunegg/onedrive/issues/8
 	bool checkMount;
+	// Add option for no remote delete
+	bool noRemoteDelete;
 		
 	try {
 		auto opt = getopt(
@@ -73,6 +75,7 @@ int main(string[] args)
 			"local-first", "Synchronize from the local directory source first, before downloading changes from OneDrive.", &localFirst,
 			"logout", "Logout the current user", &logout,
 			"monitor|m", "Keep monitoring for local and remote changes", &monitor,
+			"no-remote-delete", "Do not delete local file 'deletes' from OneDrive when using --upload-only", &noRemoteDelete,
 			"print-token", "Print the access token, useful for debugging", &printAccessToken,
 			"resync", "Forget the last saved state, perform a full sync", &resync,
 			"remove-directory", "Remove a directory on OneDrive - no sync will be performed.", &removeDirectory,
@@ -119,6 +122,9 @@ int main(string[] args)
 	
 	// command line parameters override the config
 	if (syncDirName) cfg.setValue("sync_dir", syncDirName.expandTilde().absolutePath());
+	
+	// we should only set noRemoteDelete in an upload-only scenario
+	if ((uploadOnly)&&(noRemoteDelete)) cfg.setValue("no-remote-delete", "true");
 
 	// upgrades
 	if (exists(configDirName ~ "/items.db")) {

--- a/src/main.d
+++ b/src/main.d
@@ -60,7 +60,7 @@ int main(string[] args)
 	bool checkMount;
 	// Add option to skip symlinks
 	bool skipSymlinks;
-  // Add option for no remote delete
+	// Add option for no remote delete
 	bool noRemoteDelete;
 		
 	try {

--- a/src/main.d
+++ b/src/main.d
@@ -125,7 +125,7 @@ int main(string[] args)
 	
 	// command line parameters override the config
 	if (syncDirName) cfg.setValue("sync_dir", syncDirName.expandTilde().absolutePath());
-  if (skipSymlinks) cfg.setValue("skip_symlinks", "true");
+	if (skipSymlinks) cfg.setValue("skip_symlinks", "true");
   
 	// we should only set noRemoteDelete in an upload-only scenario
 	if ((uploadOnly)&&(noRemoteDelete)) cfg.setValue("no-remote-delete", "true");

--- a/src/sync.d
+++ b/src/sync.d
@@ -910,7 +910,12 @@ final class SyncEngine
 			}
 		} else {
 			log.vlog("The file has been deleted locally");
-			uploadDeleteItem(item, path);
+			if (cfg.getValue("no-remote-delete") == "true") {
+				// do not process remote delete
+				log.vlog("Skipping remote delete as --upload-only & --no-remote-delete configured");
+			} else {
+				uploadDeleteItem(item, path);
+			}
 		}
 	}
 


### PR DESCRIPTION
* Implement --no-remote-delete so that local deletes are not processed to delete the corresponding file on OneDrive when using --upload-only