### PR TITLE
Fix --no-remote-delete implementation

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -36,9 +36,7 @@ final class Config
 		// Configure the monitor mode loop - the number of seconds by which
 		// each sync operation is undertaken when idle under monitor mode
 		setValue("monitor_interval", "45");
-		// By default we will process remote deletes
-		setValue("no-remote-delete", "false");
-    
+		    
 		if (!load(userConfigFilePath)) {
 			log.vlog("No config file found, using defaults");
 		}

--- a/src/main.d
+++ b/src/main.d
@@ -127,9 +127,6 @@ int main(string[] args)
 	if (syncDirName) cfg.setValue("sync_dir", syncDirName.expandTilde().absolutePath());
 	if (skipSymlinks) cfg.setValue("skip_symlinks", "true");
   
-	// we should only set noRemoteDelete in an upload-only scenario
-	if ((uploadOnly)&&(noRemoteDelete)) cfg.setValue("no-remote-delete", "true");
-	
 	// upgrades
 	if (exists(configDirName ~ "/items.db")) {
 		remove(configDirName ~ "/items.db");
@@ -213,6 +210,9 @@ int main(string[] args)
 			return EXIT_FAILURE;
 		}
 	}
+	
+	// We should only set noRemoteDelete in an upload-only scenario
+	if ((uploadOnly)&&(noRemoteDelete)) sync.setNoRemoteDelete();
 	
 	// Do we need to validate the syncDir to check for the presence of a '.nosync' file
 	if (checkMount) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -11,6 +11,9 @@ static import log;
 // threshold after which files will be uploaded using an upload session
 private long thresholdFileSize = 4 * 2^^20; // 4 MiB
 
+// flag to set whether local files should be deleted
+private bool noRemoteDelete = false;
+
 private bool isItemFolder(const ref JSONValue item)
 {
 	return ("folder" in item) != null;
@@ -180,6 +183,14 @@ final class SyncEngine
 		}
 	}
 
+	// Configure noRemoteDelete if function is called
+	// By default, noRemoteDelete = false;
+	// Meaning we will process local deletes to delete item on OneDrive
+	void setNoRemoteDelete()
+	{
+		noRemoteDelete = true;
+	}
+	
 	// download all new changes from OneDrive
 	void applyDifferences()
 	{
@@ -910,7 +921,7 @@ final class SyncEngine
 			}
 		} else {
 			log.vlog("The file has been deleted locally");
-			if (cfg.getValue("no-remote-delete") == "true") {
+			if (noRemoteDelete) {
 				// do not process remote delete
 				log.vlog("Skipping remote delete as --upload-only & --no-remote-delete configured");
 			} else {
@@ -1386,5 +1397,4 @@ final class SyncEngine
 		// Make the change on OneDrive
 		auto res = onedrive.moveByPath(sourcePath, moveData);	
 	}
-	
 }


### PR DESCRIPTION
* Original implementation of --no-remote-delete used a cfg value, however this introduced 2 issues - value could be set via a config parameter which was not the intention, but also could be set to a non true value causing application issues. This patch resolves how  --no-remote-delete should have originally been implemented