### PR TITLE
Resolve systemd/user is not supported on CentOS / RHEL (Issue #131)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DC = dmd
 DFLAGS = -g -ofonedrive -O -L-lcurl -L-lsqlite3 -L-ldl -J.
 PREFIX = /usr/local
-
+RHEL = $(shell cat /etc/redhat-release | grep -E "(Red Hat Enterprise Linux Server|CentOS Linux)" | wc -l)
 SOURCES = \
 	src/config.d \
 	src/itemdb.d \
@@ -28,12 +28,20 @@ install: all
 	chmod 0775 $(DESTDIR)/var/log/onedrive
 	install -D onedrive $(DESTDIR)$(PREFIX)/bin/onedrive
 	install -D -m 644 logrotate/onedrive.logrotate $(DESTDIR)/etc/logrotate.d/onedrive
+ifeq ($(RHEL),1)
+	mkdir -p $(DESTDIR)/etc/systemd/system/
+	chown root.root $(DESTDIR)/etc/systemd/system/
+	chmod 0755 $(DESTDIR)/etc/systemd/system/
+	cp -raf *.service $(DESTDIR)/etc/systemd/system/
+	chmod 0644 $(DESTDIR)/etc/systemd/system/onedrive*.service
+else
 	mkdir -p $(DESTDIR)/usr/lib/systemd/user/
 	chown root.root $(DESTDIR)/usr/lib/systemd/user/
 	chmod 0755 $(DESTDIR)/usr/lib/systemd/user/
 	cp -raf *.service $(DESTDIR)/usr/lib/systemd/user/
 	chmod 0644 $(DESTDIR)/usr/lib/systemd/user/onedrive*.service
-	
+endif
+
 onedrive: version $(SOURCES)
 	$(DC) $(DFLAGS) $(SOURCES)
 
@@ -43,9 +51,14 @@ onedrive.service:
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/onedrive
+	rm -f $(DESTDIR)/etc/logrotate.d/onedrive
+ifeq ($(RHEL),1)
+	rm -f $(DESTDIR)/etc/systemd/system/onedrive.service
+	rm -f $(DESTDIR)/etc/systemd/system/onedrive@.service
+else
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 	rm -f $(DESTDIR)/usr/lib/systemd/user/onedrive@.service
-	rm -f $(DESTDIR)/etc/logrotate.d/onedrive
+endif
 
 version: .git/HEAD .git/index
 	echo $(shell git describe --tags) >version

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 DC = dmd
 DFLAGS = -g -ofonedrive -O -L-lcurl -L-lsqlite3 -L-ldl -J.
 PREFIX = /usr/local
+
+ifneq ("$(wildcard /etc/redhat-release)","")
 RHEL = $(shell cat /etc/redhat-release | grep -E "(Red Hat Enterprise Linux Server|CentOS Linux)" | wc -l)
+else
+RHEL = 0
+endif
+
 SOURCES = \
 	src/config.d \
 	src/itemdb.d \

--- a/README.md
+++ b/README.md
@@ -310,16 +310,20 @@ systemctl --user enable onedrive
 systemctl --user start onedrive
 ```
 
+To see the logs run:
+```sh
+journalctl --user-unit onedrive -f
+```
+
 **systemd - Red Hat Enterprise Linux, CentOS Linux**
 ```sh
 systemctl enable onedrive
 systemctl start onedrive
 ```
 
-
 To see the logs run:
 ```sh
-journalctl --user-unit onedrive -f
+journalctl onedrive -f
 ```
 
 **Note:** systemd is supported on Ubuntu only starting from version 15.04

--- a/README.md
+++ b/README.md
@@ -304,11 +304,18 @@ tail -f /var/log/onedrive/<username>.onedrive.log
 ```
 To change what 'user' the client runs under (by default root), manually edit the init.d service file and modify `daemon --user root onedrive_service.sh` for the correct user.
 
-**systemd**
+**systemd - Arch, Ubuntu, Debian, OpenSuSE**
 ```sh
 systemctl --user enable onedrive
 systemctl --user start onedrive
 ```
+
+**systemd - Red Hat Enterprise Linux, CentOS Linux**
+```sh
+systemctl enable onedrive
+systemctl start onedrive
+```
+
 
 To see the logs run:
 ```sh

--- a/src/main.d
+++ b/src/main.d
@@ -9,26 +9,28 @@ int main(string[] args)
 {
 	// Determine the users home directory. 
 	// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts
-	string homePath = environment.get("XDG_CONFIG_HOME");
-	if (homePath == ""){
+	string homePath = "";
+	if (environment.get("XDG_CONFIG_HOME") != ""){
+		homePath = environment.get("XDG_CONFIG_HOME");
+	} else {
 		// XDG_CONFIG_HOME does not exist on systems where X11 is not present - ie - headless systems / servers
 		// Check for HOME environment variable
 		if (environment.get("HOME") != ""){
 			// Use HOME environment variable
-			homePath = environment.get("HOME") ~ "/";
+			homePath = environment.get("HOME");
 		} else {
 			if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
 				// No shell is set or username - observed case when running as systemd service under CentOS 7.x
-				homePath = "/root/";
+				homePath = "/root";
 			} else {
 				// A shell & valid user is set, but no XDG_CONFIG_HOME or HOME set
-				homePath = "~/";
+				homePath = "~";
 			}
 		}
 	}
 	
 	// configuration directory
-	string configDirName = homePath ~ ".config/onedrive";
+	string configDirName = homePath ~ "/.config/onedrive";
 	// only download remote changes
 	bool downloadOnly;
 	// override the sync directory

--- a/src/main.d
+++ b/src/main.d
@@ -7,17 +7,28 @@ static import log;
 
 int main(string[] args)
 {
-	// Determine the users configuration directory. 
-	// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d scripts
-	string configPath = environment.get("XDG_CONFIG_HOME");
-	if (configPath == ""){
+	// Determine the users home directory. 
+	// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts
+	string homePath = environment.get("XDG_CONFIG_HOME");
+	if (homePath == ""){
 		// XDG_CONFIG_HOME does not exist on systems where X11 is not present - ie - headless systems / servers
-		// Get HOME environment variable
-		configPath = environment.get("HOME") ~ "/.config";
+		// Check for HOME environment variable
+		if (environment.get("HOME") != ""){
+			// Use HOME environment variable
+			homePath = environment.get("HOME") ~ "/";
+		} else {
+			if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
+				// No shell is set or username - observed case when running as systemd service under CentOS 7.x
+				homePath = "/root/";
+			} else {
+				// A shell & valid user is set, but no XDG_CONFIG_HOME or HOME set
+				homePath = "~/";
+			}
+		}
 	}
 	
 	// configuration directory
-	string configDirName = configPath ~ "/onedrive";
+	string configDirName = homePath ~ ".config/onedrive";
 	// only download remote changes
 	bool downloadOnly;
 	// override the sync directory
@@ -190,8 +201,15 @@ int main(string[] args)
 	log.vlog("Opening the item database ...");
 	auto itemdb = new ItemDatabase(cfg.databaseFilePath);
 	
-	// Set the local path root
-	string syncDir = expandTilde(cfg.getValue("sync_dir"));
+	// Set the local path OneDrive root
+	string syncDir;
+	if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
+		// no shell or user set, so expandTilde() will fail
+		syncDir = homePath ~ "OneDrive";
+	} else {
+		// A shell and user is set
+		syncDir = expandTilde(cfg.getValue("sync_dir"));
+	}
 	log.vlog("All operations will be performed in: ", syncDir);
 	if (!exists(syncDir)) mkdirRecurse(syncDir);
 	chdir(syncDir);


### PR DESCRIPTION
* Initial work on resolving systemd issues on CentOS 

Actual error being resolved:

```
2018-Aug-19 13:46:38.8706412 Loading config ...
2018-Aug-19 13:46:38.8708594 Using Config Dir: /.config/onedrive
2018-Aug-19 13:46:38.8711192 No config file found, using defaults
2018-Aug-19 13:46:38.8711988 Initializing the OneDrive API ...
```

Note the **incorrect** Config Dir when running as a systemd service on CentOS

If application is authorised, application creates `/~/OneDrive/` as the sync dir, because `~` is not being correctly expanded due to reduced environment variables when running as a service