### PR TITLE
Resolve handling of maximum path length calculation (Issue #134)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -946,6 +946,8 @@ final class SyncEngine
 		//  430 Character Limit for OneDrive Personal
 		auto maxPathLength = 0;
 		string check_path;
+		import std.range : walkLength;
+		import std.uni : byGrapheme;
 		if (accountType == "business"){
 			// Business Account
 			maxPathLength = 400;
@@ -956,7 +958,7 @@ final class SyncEngine
 			check_path = path;
 		}
 		
-		if(check_path.length < maxPathLength){
+		if(check_path.byGrapheme.walkLength < maxPathLength){
 			// path is less than maxPathLength
 
 			if (isSymlink(path)) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -945,17 +945,15 @@ final class SyncEngine
 		//  400 Character Limit for OneDrive Business / Office 365
 		//  430 Character Limit for OneDrive Personal
 		auto maxPathLength = 0;
-		string check_path;
+		string check_path = path;
 		import std.range : walkLength;
 		import std.uni : byGrapheme;
 		if (accountType == "business"){
 			// Business Account
 			maxPathLength = 400;
-			check_path = encodeComponent(path);
 		} else {
 			// Personal Account
 			maxPathLength = 430;
-			check_path = path;
 		}
 		
 		if(check_path.byGrapheme.walkLength < maxPathLength){

--- a/src/sync.d
+++ b/src/sync.d
@@ -945,7 +945,6 @@ final class SyncEngine
 		//  400 Character Limit for OneDrive Business / Office 365
 		//  430 Character Limit for OneDrive Personal
 		auto maxPathLength = 0;
-		string check_path = path;
 		import std.range : walkLength;
 		import std.uni : byGrapheme;
 		if (accountType == "business"){
@@ -956,7 +955,7 @@ final class SyncEngine
 			maxPathLength = 430;
 		}
 		
-		if(check_path.byGrapheme.walkLength < maxPathLength){
+		if(path.byGrapheme.walkLength < maxPathLength){
 			// path is less than maxPathLength
 
 			if (isSymlink(path)) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -945,15 +945,18 @@ final class SyncEngine
 		//  400 Character Limit for OneDrive Business / Office 365
 		//  430 Character Limit for OneDrive Personal
 		auto maxPathLength = 0;
+		string check_path;
 		if (accountType == "business"){
 			// Business Account
 			maxPathLength = 400;
+			check_path = encodeComponent(path);
 		} else {
 			// Personal Account
 			maxPathLength = 430;
+			check_path = path;
 		}
 		
-		if(encodeComponent(path).length < maxPathLength){
+		if(check_path.length < maxPathLength){
 			// path is less than maxPathLength
 
 			if (isSymlink(path)) {


### PR DESCRIPTION
The maximum length of full path for a file/folder should determined after encoding URI only for OneDrive Business. For OneDrive Personal just the length of the plain unencoded path matters. See details in the issue #134 