### PR TITLE
Changed the way Tilde expansion is handled in syncdir

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1,6 +1,6 @@
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE;
 import core.memory, core.time, core.thread;
-import std.getopt, std.file, std.path, std.process, std.stdio, std.conv;
+import std.getopt, std.file, std.path, std.process, std.stdio, std.conv, std.algorithm.searching;
 import config, itemdb, monitor, onedrive, selective, sync, util;
 import std.net.curl: CurlException;
 static import log;
@@ -205,12 +205,19 @@ int main(string[] args)
 	
 	// Set the local path OneDrive root
 	string syncDir;
-	if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
+	// at this point we ahve already done Tilde expansion.  
+	//if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
 		// no shell or user set, so expandTilde() will fail
+//		syncDir = homePath ~ "OneDrive";
+//	} else {
+//		// A shell and user is set
+//		syncDir = expandTilde(cfg.getValue("sync_dir"));
+//	}
+	// if the sync dir still contains a ~ after Tilde expansion, and 
+	if (canFind(cfg.getValue("sync_dir"),"~") ) {
 		syncDir = homePath ~ "OneDrive";
 	} else {
-		// A shell and user is set
-		syncDir = expandTilde(cfg.getValue("sync_dir"));
+		syncDir = cfg.getValue("sync_dir") ;
 	}
 	log.vlog("All operations will be performed in: ", syncDir);
 	if (!exists(syncDir)) mkdirRecurse(syncDir);


### PR DESCRIPTION
This fixed the issue where the syndir option is ignored when stating form systemd on Centos.