### PR TITLE
Fix incorrectly nested configDir in X11 systems (Issue #181)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -10,27 +10,32 @@ int main(string[] args)
 	// Determine the users home directory. 
 	// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts
 	string homePath = "";
+
+	// Check for HOME environment variable
+	if (environment.get("HOME") != ""){
+		// Use HOME environment variable
+		homePath = environment.get("HOME");
+	} else {
+		if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
+			// No shell is set or username - observed case when running as systemd service under CentOS 7.x
+			homePath = "/root";
+		} else {
+			// A shell & valid user is set, but no XDG_CONFIG_HOME or HOME set
+			homePath = "~";
+		}
+	}
+
+	// Determine the base directory relative to which user specific configuration files should be stored.
+	string configDirBase = "";
 	if (environment.get("XDG_CONFIG_HOME") != ""){
-		homePath = environment.get("XDG_CONFIG_HOME");
+		configDirBase = environment.get("XDG_CONFIG_HOME");
 	} else {
 		// XDG_CONFIG_HOME does not exist on systems where X11 is not present - ie - headless systems / servers
-		// Check for HOME environment variable
-		if (environment.get("HOME") != ""){
-			// Use HOME environment variable
-			homePath = environment.get("HOME");
-		} else {
-			if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
-				// No shell is set or username - observed case when running as systemd service under CentOS 7.x
-				homePath = "/root";
-			} else {
-				// A shell & valid user is set, but no XDG_CONFIG_HOME or HOME set
-				homePath = "~";
-			}
-		}
+		configDirBase = homePath ~ "/.config";
 	}
 	
 	// configuration directory
-	string configDirName = homePath ~ "/.config/onedrive";
+	string configDirName = configDirBase ~ "/onedrive";
 	// only download remote changes
 	bool downloadOnly;
 	// override the sync directory

--- a/src/main.d
+++ b/src/main.d
@@ -20,7 +20,7 @@ int main(string[] args)
 			// No shell is set or username - observed case when running as systemd service under CentOS 7.x
 			homePath = "/root";
 		} else {
-			// A shell & valid user is set, but no XDG_CONFIG_HOME or HOME set
+			// A shell & valid user is set, but no HOME is set, use ~ which can be expanded
 			homePath = "~";
 		}
 	}


### PR DESCRIPTION
This is an attempt to fix the issue I reported: #181. 

This creates a new `configDirBase` variable for the path to one's `.config` directory. This should make it clear when a system's `$XDG_CONFIG_HOME` variable is used versus when `$HOME/.config` is used as the base configuration directory. 

I believe this should also leave unaffected the subsequent uses of `homePath` for determining the `syncDir`. 