### PR TITLE
Add handling for HTTP Code 302 generated by HTTP/2 calls

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -251,8 +251,11 @@ final class OneDriveApi
 		}
 		http.method = HTTP.Method.put;
 		http.url = uploadUrl;
-		// when using microsoft graph the auth code is different
-		//addAccessTokenHeader();
+
+		// Specify which HTTP version to use for session uploads
+		// Curl 7.62.0 defaults to HTTP/2, we need to use HTTP/1.1
+		http.handle.set(CurlOption.http_version,2);
+
 		import std.conv;
 		string contentRange = "bytes " ~ to!string(offset) ~ "-" ~ to!string(offset + offsetSize - 1) ~ "/" ~ to!string(fileSize);
 		http.addRequestHeader("Content-Range", contentRange);


### PR DESCRIPTION
* Update curl 7.62.0 fix with a better solution which handles the redirect's given by HTTP/2 connections (credit @Popa21)