### PR TITLE
Fix renaming of files sync issues

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -740,9 +740,22 @@ final class SyncEngine
 			if (oldPath != newPath) {
 				log.log("Moving ", oldPath, " to ", newPath);
 				if (exists(newPath)) {
-					// TODO: force remote sync by deleting local item
-					log.vlog("The destination is occupied, renaming the conflicting file...");
-					safeRename(newPath);
+					Item localNewItem;
+					if (itemdb.selectByPath(newPath, defaultDriveId, localNewItem)) {
+						if (isItemSynced(localNewItem, newPath)) {
+							log.vlog("Destination is in sync and will be overwritten");
+						} else {
+							// TODO: force remote sync by deleting local item
+							log.vlog("The destination is occupied, renaming the conflicting file...");
+							safeRename(newPath);
+						}
+					} else {
+						// to be overwritten item is not already in the itemdb, so it should
+						// be synced. Do a safe rename here, too.
+						// TODO: force remote sync by deleting local item
+						log.vlog("The destination is occupied by new file, renaming the conflicting file...");
+						safeRename(newPath);
+					}
 				}
 				rename(oldPath, newPath);
 			}


### PR DESCRIPTION
As discussed in the issue #249 here is the pull request split into two commit fixing the following issues:

- the first commit makes sure that if a rename action would clobber a local file, we do not use `safeRename` in case the file is in sync

- the second commit makes sure that if an item is removed, we only remove the associated path if the item associated with this path is the one to be deleted
