### PR TITLE
gracefully handle connection errors in monitor mode

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -374,7 +374,13 @@ int main(string[] args)
 				if (!downloadOnly) m.update(online);
 				auto currTime = MonoTime.currTime();
 				if (currTime - lastCheckTime > checkInterval) {
-					online = testNetwork();
+					try {
+						online = testNetwork();
+					} catch (CurlException e) {
+						// No network connection to OneDrive Service
+						log.log("No network connection to Microsoft OneDrive Service, skipping sync");
+						online = false;
+					}
 					if (online) {
 						performSync(sync, singleDirectory, downloadOnly, localFirst, uploadOnly);
 						if (!downloadOnly) {


### PR DESCRIPTION
When the connection is down in monitor mode onedrive dies due to a CurlException not being caught. Change this and give a log message instead. Closes issue #234