### PR TITLE
Handle short lived files (Issue #273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ no option                      No sync and exit
             --create-directory Create a directory on OneDrive - no sync will be performed.
        --destination-directory Destination directory for renamed or move on OneDrive - no sync will be performed.
                  --debug-https Debug OneDrive HTTPS communication.
+       --disable-notifications Do not use desktop notifications in monitor mode.
 -d             --download-only Only download remote changes
    --disable-upload-validation Disable upload validation when uploading to OneDrive
               --enable-logging Enable client activity to a separate log file

--- a/src/main.d
+++ b/src/main.d
@@ -365,6 +365,12 @@ int main(string[] args)
 				log.vlog("[M] Item deleted: ", path);
 				try {
 					sync.deleteByPath(path);
+				} catch(SyncException e) {
+					if (e.msg == "The item to delete is not in the local database") {
+						log.vlog("Item cannot be deleted because not found in database");
+					} else {
+						log.log(e.msg);
+					}
 				} catch(Exception e) {
 					log.logAndNotify(e.msg);
 				}

--- a/src/main.d
+++ b/src/main.d
@@ -369,7 +369,7 @@ int main(string[] args)
 					if (e.msg == "The item to delete is not in the local database") {
 						log.vlog("Item cannot be deleted because not found in database");
 					} else {
-						log.log(e.msg);
+						log.logAndNotify(e.msg);
 					}
 				} catch(Exception e) {
 					log.logAndNotify(e.msg);

--- a/src/sync.d
+++ b/src/sync.d
@@ -1177,6 +1177,12 @@ final class SyncEngine
 			maxPathLength = 430;
 		}
 		
+		// A short lived file that has disappeared will cause an error - is the path valid?
+		if (!exists(path)) {
+			log.log("Skipping item - has disappeared: ", path);
+			return;
+		}
+		
 		if(path.byGrapheme.walkLength < maxPathLength){
 			// path is less than maxPathLength
 


### PR DESCRIPTION
* When in monitor mode, short lived files can generate error messages if these files are detected & then deleted before the client has had an opportunity to process them

Credit: norbusan