### PR TITLE
deal with items that disappear during upload (Issue: #258)

### DIFF
--- a/src/monitor.d
+++ b/src/monitor.d
@@ -66,6 +66,12 @@ final class Monitor
 
 	private void addRecursive(string dirname)
 	{
+		// skip non existing/disappeared items
+		if (!exists(dirname)) {
+			log.vlog("Not adding non-existing/disappeared directory: ", dirname);
+			return;
+		}
+
 		// skip filtered items
 		if (dirname != ".") {
 			if (selectiveSync.isNameExcluded(baseName(dirname))) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -1430,21 +1430,21 @@ final class SyncEngine
 									// Original file upload logic
 									if (thisFileSize <= thresholdFileSize) {
 										try {
-												response = onedrive.simpleUpload(path, parent.driveId, parent.id, baseName(path));
-											} catch (OneDriveException e) {
-												if (e.httpStatusCode == 504) {
-													// HTTP request returned status code 504 (Gateway Timeout)
-													// Try upload as a session
-													try {
-														response = session.upload(path, parent.driveId, parent.id, baseName(path));
-													} catch (OneDriveException e) {
-														// error uploading file
-														return;
-													}
+											response = onedrive.simpleUpload(path, parent.driveId, parent.id, baseName(path));
+										} catch (OneDriveException e) {
+											if (e.httpStatusCode == 504) {
+												// HTTP request returned status code 504 (Gateway Timeout)
+												// Try upload as a session
+												try {
+													response = session.upload(path, parent.driveId, parent.id, baseName(path));
+												} catch (OneDriveException e) {
+													// error uploading file
+													return;
 												}
-												else throw e;
 											}
-											writeln(" done.");
+											else throw e;
+										}
+										writeln(" done.");
 									} else {
 										// File larger than threshold - use a session to upload
 										writeln("");

--- a/src/sync.d
+++ b/src/sync.d
@@ -1238,6 +1238,12 @@ final class SyncEngine
 					uploadCreateDir(path);
 				}
 				// recursively traverse children
+				// the above operation takes time and the directory might have
+				// disappeared in the meantime
+				if (!exists(path)) {
+					log.vlog("Directory disappeared during upload: ", path);
+					return;
+				}
 				auto entries = dirEntries(path, SpanMode.shallow, false);
 				foreach (DirEntry entry; entries) {
 					uploadNewItems(entry.name);
@@ -1369,7 +1375,6 @@ final class SyncEngine
 	private void uploadNewFile(string path)
 	{
 		Item parent;
-		
 		// Check the database for the parent
 		//enforce(itemdb.selectByPath(dirName(path), defaultDriveId, parent), "The parent item is not in the local database");
 		if (itemdb.selectByPath(dirName(path), defaultDriveId, parent)) {
@@ -1423,7 +1428,7 @@ final class SyncEngine
 								// check what 'account type' this is as this issue only affects OneDrive Business so we need some extra logic here
 								if (accountType == "personal"){
 									// Original file upload logic
-									if (getSize(path) <= thresholdFileSize) {
+									if (thisFileSize <= thresholdFileSize) {
 										try {
 												response = onedrive.simpleUpload(path, parent.driveId, parent.id, baseName(path));
 											} catch (OneDriveException e) {
@@ -1448,6 +1453,10 @@ final class SyncEngine
 											writeln(" done.");
 										} catch (OneDriveException e) {
 											// error uploading file
+											log.vlog("Upload failed with OneDriveException: ", e.msg);
+											return;
+										} catch (FileException e) {
+											log.vlog("Upload failed with File Exception: ", e.msg);
 											return;
 										}
 									}
@@ -1493,9 +1502,14 @@ final class SyncEngine
 								// Update the item's metadata on OneDrive
 								string id = response["id"].str;
 								string cTag = response["cTag"].str;
-								SysTime mtime = timeLastModified(path).toUTC();
-								// use the cTag instead of the eTag because OneDrive may update the metadata of files AFTER they have been uploaded
-								uploadLastModifiedTime(parent.driveId, id, cTag, mtime);
+								if (exists(path)) {
+									SysTime mtime = timeLastModified(path).toUTC();
+									// use the cTag instead of the eTag because OneDrive may update the metadata of files AFTER they have been uploaded
+									uploadLastModifiedTime(parent.driveId, id, cTag, mtime);
+								} else {
+									// will be removed in different event!
+									log.log("File disappeared after upload: ", path);
+								}
 								return;
 							} else {
 								// OneDrive Business Account - always use a session to upload


### PR DESCRIPTION
There are several places where a disappearing directory of file might be stat-ed for file size etc, raising an exception.

If the entry is removed between the creation and the run of the monitor loop, `addRecursive` is called on a non-existing path, deal with this.

If the entry is a directory is removed after the directory entry is created but before the children are dealt with, `dirEntries` raises an exception, deal with this.

If a file disappears during the upload, the upload process has a file handle open, so can finish the upload, but the following file size computation and time stamp update fails. The file size computation can be fixed by re-using the already done call to `getSize` before the file upload, the time stamp update is again protected with checking for the existence of the file.