### PR TITLE
deal with deleted move targets (Issue: 273)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1677,6 +1677,10 @@ final class SyncEngine
 			uploadDeleteItem(fromItem, from);
 			uploadNewFile(to);
 		} else {
+			if (!exists(to)) {
+				log.vlog("uploadMoveItem target has disappeared: ", to);
+				return;
+			}
 			SysTime mtime = timeLastModified(to).toUTC();
 			JSONValue diff = [
 				"name": JSONValue(baseName(to)),


### PR DESCRIPTION
if the move target has been deleted before the monitor action completes,
the monitor action throws an exception when stat-ing the target for
mtime. Do not do anything in case the move target has disappeared