### PR TITLE
fix activation of dmd

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ ENV GOSU_VERSION=1.11
 
 RUN yum install -y make git gcc libcurl-devel sqlite-devel && \
     rm -rf /var/cache/yum/ && \
-    curl -fsS https://dlang.org/install.sh | bash -s dmd && \
+    curl -fsS -o install.sh https://dlang.org/install.sh && \
+    bash install.sh dmd && \
     # gosu installation
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
@@ -15,7 +16,7 @@ RUN yum install -y make git gcc libcurl-devel sqlite-devel && \
     && gosu nobody true
 RUN mkdir -p /onedrive/conf /onedrive/data
 ADD onedrive /usr/src/onedrive
-RUN . /root/dlang/dmd-2.083.0/activate && \
+RUN . `bash install.sh -a` && \
     cd /usr/src/onedrive && \
     make install.noservice && \
     make clean


### PR DESCRIPTION
Currently the version of dmd is hard-coded, but has already
changed, and building docker images now fail. Re-using the install.sh
allows to get the install path and activation script.