### PR TITLE
Resolve JSONException when using --get-O365-drive-id command (Issue #289)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1760,9 +1760,9 @@ final class SyncEngine
 		JSONValue siteQuery = onedrive.o365SiteSearch(o365SharedLibraryName);
 		
 		foreach (searchResult; siteQuery["value"].array) {
-			// Need an 'exclusive' match here with as entered
-			if (o365SharedLibraryName == searchResult["description"].str){
-				// 'description' matches search request
+			// Need an 'exclusive' match here with o365SharedLibraryName as entered
+			if (o365SharedLibraryName == searchResult["displayName"].str){
+				// 'displayName' matches search request
 				site_id = searchResult["id"].str;
 				JSONValue siteDriveQuery = onedrive.o365SiteDrives(site_id);
 				foreach (driveResult; siteDriveQuery["value"].array) {


### PR DESCRIPTION
* In testing, 'description' and 'displayName' were the same, but in reality we are checking against the 'displayName' value as this is what we are asking the user to input, thus we need to check against displayName