### PR TITLE
check config file keys for validity, use setValue instead of direct access

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -39,6 +39,8 @@ final class Config
 		setValue("monitor_interval", "45");
 		// Configure the default logging directory to be /var/log/onedrive/
 		setValue("log_dir", "/var/log/onedrive/");
+		// Configure a default empty value for drive_id
+		setValue("drive_id", "");
 		
 		if (!load(userConfigFilePath)) {
 			log.vlog("No config file found, using defaults");

--- a/src/config.d
+++ b/src/config.d
@@ -24,7 +24,7 @@ final class Config
 		syncListFilePath = configDirName ~ "/sync_list";
 	}
 
-	void init()
+	bool init()
 	{
 		// Default configuration directory
 		setValue("sync_dir", "~/OneDrive");
@@ -43,8 +43,16 @@ final class Config
 		setValue("drive_id", "");
 		
 		if (!load(userConfigFilePath)) {
-			log.vlog("No config file found, using defaults");
+			// What was the reason for failure?
+			if (!exists(userConfigFilePath)) {
+				log.vlog("No config file found, using application defaults");
+				return true;
+			} else {
+				log.log("Configuration file has errors - please check your configuration");
+				return false;
+			}
 		}
+		return true;
 	}
 
 	string getValue(string key)

--- a/src/config.d
+++ b/src/config.d
@@ -82,8 +82,13 @@ final class Config
 			if (!c.empty) {
 				c.popFront(); // skip the whole match
 				string key = c.front.dup;
-				c.popFront();
-				values[key] = c.front.dup;
+				auto p = key in values;
+				if (p) {
+					c.popFront();
+					setValue(key, c.front.dup);
+				} else {
+					log.log("Unknown key in config file: ", key);
+				}
 			} else {
 				log.log("Malformed config line: ", line);
 			}

--- a/src/config.d
+++ b/src/config.d
@@ -98,9 +98,11 @@ final class Config
 					setValue(key, c.front.dup);
 				} else {
 					log.log("Unknown key in config file: ", key);
+					return false;
 				}
 			} else {
 				log.log("Malformed config line: ", line);
+				return false;
 			}
 		}
 		return true;

--- a/src/main.d
+++ b/src/main.d
@@ -152,7 +152,11 @@ int main(string[] args)
 	log.vlog("Using Config Dir: ", configDirName);
 	if (!exists(configDirName)) mkdirRecurse(configDirName);
 	auto cfg = new config.Config(configDirName);
-	cfg.init();
+	if(!cfg.init()){
+		// There was an error loading the configuration
+		// Error message already printed
+		return EXIT_FAILURE;
+	}
 	
 	// Configure logging if enabled
 	if (enableLogFile){


### PR DESCRIPTION
All possible values are already initialized in `init` before the config file is loaded. Check the keys of the config files against the existing keys and warn in case of mismatch.

Furthermore, instead of directly changing the `values` array, use the `setValue` function to allow for easier reimplementation of the configuration storage.