### PR TITLE
Fix exception when missing parameter from usage option (Issue #295)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -139,6 +139,11 @@ int main(string[] args)
 		log.error(e.msg);
 		log.error("Try 'onedrive -h' for more information");
 		return EXIT_FAILURE;
+	} catch (Exception e) {
+		// error
+		log.error(e.msg);
+		log.error("Try 'onedrive -h' for more information");
+		return EXIT_FAILURE;
 	}
 
 	// disable buffering on stdout


### PR DESCRIPTION
* Handle the exception generated when an option is used which is expecting an input parameter but none is given