### PR TITLE
Resolve JSONException when supplying --get-O365-drive-id option with a string containing spaces (Issue #304)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1757,7 +1757,7 @@ final class SyncEngine
 		
 		string site_id;
 		string drive_id;
-		JSONValue siteQuery = onedrive.o365SiteSearch(o365SharedLibraryName);
+		JSONValue siteQuery = onedrive.o365SiteSearch(encodeComponent(o365SharedLibraryName));
 		
 		foreach (searchResult; siteQuery["value"].array) {
 			// Need an 'exclusive' match here with o365SharedLibraryName as entered


### PR DESCRIPTION
* Resolve JSONException when supplying --get-O365-drive-id option with a string containing spaces