### PR TITLE
Resolve 'sync_dir' not read from 'config' file when run in Docker container #306

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -170,7 +170,7 @@ int main(string[] args)
 		if (canFind(configDirName,"~")) {
 			// A ~ was found
 			log.vdebug("configDirName: A '~' was found in configDirName, using the calculated 'homePath' to replace '~'");
-			configDirName = homePath ~ strip(configDirName,"~");
+			configDirName = homePath ~ strip(configDirName,"~","~");
 		}
 	} else {
 		// Set the default application configuration directory
@@ -229,7 +229,7 @@ int main(string[] args)
 	} else {
 		// A shell and user is set, expand any ~ as this will be expanded correctly if present
 		log.vdebug("sync_dir: Getting syncDir from config value sync_dir");
-		if (canFind(cfg.getValue("sync_dir"),"~","~")) {
+		if (canFind(cfg.getValue("sync_dir"),"~")) {
 			log.vdebug("sync_dir: A '~' was found in configured sync_dir, automatically expanding as SHELL and USER environment variable is set");
 			syncDir = expandTilde(cfg.getValue("sync_dir"));
 		} else {

--- a/src/main.d
+++ b/src/main.d
@@ -45,7 +45,7 @@ int main(string[] args)
 	}
 	
 	// Output configDirBase calculation
-	log.vdebug("configDirBase: ", homePath);
+	log.vdebug("configDirBase: ", configDirBase);
 	
 	// configuration directory
 	string configDirName = configDirBase ~ "/onedrive";

--- a/src/main.d
+++ b/src/main.d
@@ -197,7 +197,7 @@ int main(string[] args)
 	// sync_dir environment handling to handle ~ expansion properly
 	string syncDir;
 	if ((environment.get("SHELL") == "") && (environment.get("USER") == "")){
-		log.vdebug("sync_dir: No SHELL or USER detected");
+		log.vdebug("sync_dir: No SHELL or USER environment variable configuration detected");
 		// No shell or user set, so expandTilde() will fail - usually headless system running under init.d / systemd or potentially Docker
 		// Does the 'currently configured' sync_dir include a ~
 		if (canFind(cfg.getValue("sync_dir"),"~")) {
@@ -213,7 +213,7 @@ int main(string[] args)
 		// A shell and user is set, expand any ~ as this will be expanded correctly if present
 		log.vdebug("sync_dir: Getting syncDir from config value sync_dir");
 		if (canFind(cfg.getValue("sync_dir"),"~")) {
-			log.vdebug("sync_dir: A '~' was found in configured sync_dir, automatically expanding as SHELL and USER is set");
+			log.vdebug("sync_dir: A '~' was found in configured sync_dir, automatically expanding as SHELL and USER environment variable is set");
 			syncDir = expandTilde(cfg.getValue("sync_dir"));
 		} else {
 			syncDir = cfg.getValue("sync_dir");


### PR DESCRIPTION
* Fix logic for sync_dir handling on headless systems
* Fix logic where potentially a 'default' ~/OneDrive sync_dir could be set despite 'config' file configured for an alternate on headless / Docker containers
* Add debug handling for sync_dir operations
* Add debug handling for homePath calculation
* Add debug handling for configDirBase calculation