### PR TITLE
signal handling and database shutdown

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1,8 +1,9 @@
-import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE;
+import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.memory, core.time, core.thread;
 import std.getopt, std.file, std.path, std.process, std.stdio, std.conv, std.algorithm.searching, std.string;
 import config, itemdb, monitor, onedrive, selective, sync, util;
 import std.net.curl: CurlException;
+import core.stdc.signal;
 static import log;
 
 int main(string[] args)
@@ -482,6 +483,12 @@ int main(string[] args)
 					log.logAndNotify("Cannot move item:, ", e.msg);
 				}
 			};
+			extern(C) @nogc void exitHandler(int value) {
+				printf("Ooohhhh got %d\n", value);
+				exit(0);
+			}
+			signal(SIGINT, &exitHandler);
+
 			// initialise the monitor class
 			if (cfg.getValue("skip_symlinks") == "true") skipSymlinks = true;
 			if (!downloadOnly) m.init(cfg, verbose, skipSymlinks);


### PR DESCRIPTION
This PR fixes https://github.com/abraunegg/onedrive/issues/311 : when onedrive in monitor mode is killed via SIGINT or SIGTERM (Ctrl-C or via systemctl stop), the database connection is not properly closed, and the .waf fail remains.

While this is not by itself a problem, and would be fixed by the next normal (not monitor) run, it is still undesirable to have uncommitted transaction in the waf file, which might not be properly read by other sqlite clients.

This PR adds a signal handler that destroys the itemDb object, shuts down the Curl http module, and terminates.

With this patch and running as systemd service and stopping it, the log shows:
```
Dec 26 23:08:24 bulldog onedrive[15878]: OneDrive monitor interval (seconds): 45
Dec 26 23:09:09 bulldog onedrive[15878]: Syncing changes from OneDrive ...
Dec 26 23:09:28 bulldog onedrive[15878]: Got termination signal, shutting down db connection
Dec 26 23:09:28 bulldog systemd[2294]: Stopping OneDrive Free Client...
Dec 26 23:09:28 bulldog systemd[2294]: onedrive.service: Succeeded.
Dec 26 23:09:28 bulldog systemd[2294]: Stopped OneDrive Free Client.
```

The .waf files are properly cleaned up.

Implementation details:
- I had to move the onedrive and itemdb variables outside the main function to have it available in the signal handler.
- this triggered a necessary renaming due to name conflict (module and variable)
- the tricky code about `@nogc` was taken from https://p0nce.github.io/d-idioms/#Bypassing-@nogc after I have inquired at the D language forum https://forum.dlang.org/post/vzszlzoqblmckxpqlgme@forum.dlang.org