### PR TITLE
better help output formatting (Issue #298)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -101,7 +101,7 @@ int main(string[] args)
 			"single-directory", "Specify a single local directory within the OneDrive root to sync.", &singleDirectory,
 			"skip-symlinks", "Skip syncing of symlinks", &skipSymlinks,
 			"source-directory", "Source directory to rename or move on OneDrive - no sync will be performed.", &sourceDirectory,
-			"syncdir", "Set the local directory used to sync the files that are synced", &syncDirName,
+			"syncdir", "Specify the local directory used for synchronization to OneDrive", &syncDirName,
 			"synchronize", "Perform a synchronization", &synchronize,
 			"upload-only", "Only upload to OneDrive, do not sync changes from OneDrive locally", &uploadOnly,
 			"verbose|v+", "Print more details, useful for debugging (repeat for extra debugging)", &log.verbose,

--- a/src/main.d
+++ b/src/main.d
@@ -108,11 +108,7 @@ int main(string[] args)
 			"version", "Print the version and exit", &printVersion
 		);
 		if (opt.helpWanted) {
-			defaultGetoptPrinter(
-				"Usage: onedrive [OPTION]...\n\n" ~
-				"no option        No sync and exit",
-				opt.options
-			);
+			outputLongHelp(opt.options);
 			return EXIT_SUCCESS;
 		}
 	} catch (GetOptException e) {
@@ -675,3 +671,41 @@ extern(C) nothrow @nogc @system void exitHandler(int value) {
 	} catch(Exception e) {}
 	exit(0);
 }
+void outputLongHelp(Option[] opt)
+{
+	auto argsNeedingOptions = [
+		"--confdir",
+		"--create-directory",
+		"--destination-directory",
+		"--get-O365-drive-id",
+		"--remove-directory",
+		"--single-directory",
+		"--source-directory",
+		"--syncdir" ];
+	writeln(`OneDrive - a client for OneDrive Cloud Services
+
+Usage:
+  onedrive [options] --synchronize
+      Do a one time synchronization
+  onedrive [options] --monitor
+      Monitor filesystem and sync regularly
+  onedrive [options] --display-config
+      Display the currently used configuration
+  onedrive [options] --display-sync-status
+      Query OneDrive service and report on pending changes
+  onedrive -h | --help
+      Show this help screen
+  onedrive --version
+      Show version
+
+Options:
+`);
+	foreach (it; opt) {
+		writefln("  %s%s%s%s\n      %s",
+				it.optShort == "" ? "" : it.optShort ~ " ",
+				it.optLong,
+				argsNeedingOptions.canFind(it.optLong) ? " ARG" : "",
+				it.required ? " (required)" : "", it.help);
+	}
+}
+

--- a/src/main.d
+++ b/src/main.d
@@ -101,7 +101,7 @@ int main(string[] args)
 			"single-directory", "Specify a single local directory within the OneDrive root to sync.", &singleDirectory,
 			"skip-symlinks", "Skip syncing of symlinks", &skipSymlinks,
 			"source-directory", "Source directory to rename or move on OneDrive - no sync will be performed.", &sourceDirectory,
-			"syncdir", "Set the directory used to sync the files that are synced", &syncDirName,
+			"syncdir", "Set the local directory used to sync the files that are synced", &syncDirName,
 			"synchronize", "Perform a synchronization", &synchronize,
 			"upload-only", "Only upload to OneDrive, do not sync changes from OneDrive locally", &uploadOnly,
 			"verbose|v+", "Print more details, useful for debugging (repeat for extra debugging)", &log.verbose,


### PR DESCRIPTION
Instead of the rejected docopt help formatting, here is a version that still uses getopt but not the default option formatter. Output of -h is as follows:
```
$ ./onedrive -h
OneDrive - a client for OneDrive Cloud Services

Usage:
  onedrive [options] --synchronize
      Do a one time synchronization
  onedrive [options] --monitor
      Monitor filesystem and sync regularly
  onedrive [options] --display-config
      Display the currently used configuration
  onedrive [options] --display-sync-status
      Query OneDrive service and report on pending changes
  onedrive -h | --help
      Show this help screen
  onedrive --version
      Show version

Options:

  --check-for-nomount
      Check for the presence of .nosync in the syncdir root. If found, do not perform sync.
  --confdir ARG
      Set the directory used to store the configuration files
  --create-directory ARG
      Create a directory on OneDrive - no sync will be performed.
  --destination-directory ARG
      Destination directory for renamed or move on OneDrive - no sync will be performed.
  --debug-https
      Debug OneDrive HTTPS communication.
  --disable-notifications
      Do not use desktop notifications in monitor mode.
  --display-config
      Display what options the client will use as currently configured - no sync will be performed.
  --display-sync-status
      Display the sync status of the client - no sync will be performed.
  -d --download-only
      Only download remote changes
  --disable-upload-validation
      Disable upload validation when uploading to OneDrive
  --enable-logging
      Enable client activity to a separate log file
  --get-O365-drive-id ARG
      Query and return the Office 365 Drive ID for a given Office 365 SharePoint Shared Library
  --local-first
      Synchronize from the local directory source first, before downloading changes from OneDrive.
  --logout
      Logout the current user
  -m --monitor
      Keep monitoring for local and remote changes
  --no-remote-delete
      Do not delete local file 'deletes' from OneDrive when using --upload-only
  --print-token
      Print the access token, useful for debugging
  --resync
      Forget the last saved state, perform a full sync
  --remove-directory ARG
      Remove a directory on OneDrive - no sync will be performed.
  --single-directory ARG
      Specify a single local directory within the OneDrive root to sync.
  --skip-symlinks
      Skip syncing of symlinks
  --source-directory ARG
      Source directory to rename or move on OneDrive - no sync will be performed.
  --syncdir ARG
      Set the directory used to sync the files that are synced
  --synchronize
      Perform a synchronization
  --upload-only
      Only upload to OneDrive, do not sync changes from OneDrive locally
  -v+ --verbose
      Print more details, useful for debugging (repeat for extra debugging)
  --version
      Print the version and exit
  -h --help
      This help information.
```

I had to hard-code the list of options that take arguments because this information is not available in the opts structure.