### PR TITLE
Makefile: support building with ldc2, usage of pkg-config for lib finding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,30 @@
 DC ?= dmd
-ifdef NOTIFICATIONS
-	DFLAGSNOTIFICATIONS ?= -version=NoPragma -version=NoGdk -version=Notifications \
-		-L-lgmodule-2.0 -L-lglib-2.0 -L-lnotify
+
+ifdef PKGCONFIG
+	LIBS = $(shell pkg-config --libs sqlite3 libcurl)
+else
+	LIBS = -lcurl -lsqlite3
 endif
-DFLAGS += -w -g -ofonedrive -O -L-lcurl -L-lsqlite3 $(DFLAGSNOTIFICATIONS) -L-ldl -J.
+ifdef NOTIFICATIONS
+	NOTIF_VERSIONS = -version=NoPragma -version=NoGdk -version=Notifications
+ifdef PKGCONFIG
+	LIBS += $(shell pkg-config --libs libnotify)
+else
+	LIBS += -lgmodule-2.0 -lglib-2.0 -lnotify
+endif
+endif
+LIBS += -ldl
+
+# add the necessary prefix for the D compiler
+LIBS := $(addprefix -L,$(LIBS))
+
+# support ldc2 which needs -d prefix for version specification
+ifeq ($(notdir $(DC)),ldc2)
+	NOTIF_VERSIONS := $(addprefix -d,$(NOTIF_VERSIONS))
+endif
+
+DFLAGS += -w -g -ofonedrive -O $(NOTIF_VERSIONS) $(LIBS) -J.
+
 PREFIX ?= /usr/local
 DOCDIR ?= $(PREFIX)/share/doc/onedrive
 MANDIR ?= $(PREFIX)/share/man/man1

--- a/README.md
+++ b/README.md
@@ -169,11 +169,14 @@ sudo make install
 ```
 
 ### Build options
+
+By passing `PKGCONFIG=1` to the `make` call, necessary libraries (`sqlite3`,
+`curl`, and `libnotify` for notifications) are searched for using `pkg-config`
+instead of using the hard-coded values.
+
 By passing `NOTIFICATIONS=1` to the `make` call, notifications via
-libnotify are enabled. Necessary libraries are 
-`gmodule-2.0`, `glib-2.0`, and `notify`. If these libraries are
-named differently on the build system, the make variable
-`DFLAGSNOTIFICATIONS` can be adjusted.
+libnotify are enabled. If `pkg-config` is not used (see above), the necessary
+libraries are `gmodule-2.0`, `glib-2.0`, and `notify`.
 
 ### Building using a different compiler (for example [LDC](https://wiki.dlang.org/LDC))
 #### Debian - i386 / i686


### PR DESCRIPTION
* ldc2 support
the pragma versions passed to the compiler need an additional `-d` prefix in case of ldc2. Add it if the compiler component looks like ldc2.

* pkg-config support
By passing `PKGCONFIG=1` to the make call libraries are searched via `pkg-config` instead of hard-coded values.