### PR TITLE
Resolve build warning & support CentOS 6.x for installation (Issue #350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A complete tool to interact with OneDrive on Linux. Built following the UNIX phi
 ## Build Requirements
 *   Build environment must have at least 1GB of memory & 1GB swap space
 *   [libcurl](http://curl.haxx.se/libcurl/)
-*   [SQLite 3](https://www.sqlite.org/)
+*   [SQLite 3](https://www.sqlite.org/) >= 3.7.15
 *   [Digital Mars D Compiler (DMD)](http://dlang.org/download.html)
 
 ### Dependencies: Ubuntu/Debian - x86_64
@@ -80,6 +80,17 @@ curl -fsS https://dlang.org/install.sh | bash -s dmd
 For notifications the following is necessary:
 ```text
 sudo yum install libnotify-devel
+```
+
+### Dependencies: CentOS 6.x / RHEL 6.x
+In addition to the above requirements, the `sqlite` version used on CentOS 6.x / RHEL 6.x needs to be upgraded. Use the following instructions to update your version of `sqlite` so that it can support the client:
+```text
+sudo yum -y update
+sudo yum -y install epel-release, wget
+sudo yum -y install mock
+wget https://kojipkgs.fedoraproject.org//packages/sqlite/3.7.15.2/2.fc19/src/sqlite-3.7.15.2-2.fc19.src.rpm
+sudo mock --rebuild sqlite-3.7.15.2-2.fc19.src.rpm
+sudo yum -y upgrade /var/lib/mock/epel-6-{arch}/result/sqlite-*
 ```
 
 ### Dependencies: Fedora > Version 18

--- a/init.d/onedrive.init
+++ b/init.d/onedrive.init
@@ -24,6 +24,7 @@ STOP_TIMEOUT=${STOP_TIMEOUT-5}
 RETVAL=0
 
 start() {
+	export PATH=/usr/local/bin/:$PATH
         echo -n $"Starting $APP_NAME: "
         daemon --user root onedrive_service.sh
         RETVAL=$?

--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -3,6 +3,7 @@ import std.stdio;
 import etc.c.sqlite3;
 import std.string: fromStringz, toStringz;
 import core.stdc.stdlib;
+import std.conv;
 static import log;
 
 extern (C) immutable(char)* sqlite3_errstr(int); // missing from the std library
@@ -176,9 +177,9 @@ struct Statement
 				// https://www.sqlite.org/c3ref/data_count.html
 				int count = sqlite3_data_count(pStmt);
 				row = new const(char)[][count];
-				foreach (int i, ref column; row) {
+				foreach (size_t i, ref column; row) {
 					// https://www.sqlite.org/c3ref/column_blob.html
-					column = fromStringz(sqlite3_column_text(pStmt, i));
+					column = fromStringz(sqlite3_column_text(pStmt, to!int(i)));
 				}
 			} else {
 				string errorMessage = ifromStringz(sqlite3_errmsg(sqlite3_db_handle(pStmt)));


### PR DESCRIPTION
* Update Makefile to support RHEL / CentOS 6 installation for init.d
* Update init.d file to include additional search path
* Update Readme regarding additional requirements for building client (upgrade sqlite & how)
* Fix "Deprecation: foreach: loop index implicitly converted from size_t to int" warning given by dmd-2.084.0