### PR TITLE
Update handling of --get-O365-drive-id for multi matching (Issue #351)

### DIFF
--- a/README.Office365.md
+++ b/README.Office365.md
@@ -8,8 +8,10 @@ onedrive --get-O365-drive-id '<your library name>'
 3.  This will return the following:
 ```bash
 Initializing the Synchronization Engine ...
-Office 365 Library Name: ab-github-odtest
-drive_id: b!6H.....l7vVxU5
+Office 365 Library Name Query: <your library name>
+SiteName: <your library name>
+drive_id: b!6H_y8B...xU5
+URL:      <your site URL>
 ```
 
 ## Configuring the onedrive client

--- a/src/sync.d
+++ b/src/sync.d
@@ -1891,24 +1891,30 @@ final class SyncEngine
 		
 		string site_id;
 		string drive_id;
+		string webUrl;
+		bool found = false;
 		JSONValue siteQuery = onedrive.o365SiteSearch(encodeComponent(o365SharedLibraryName));
+		
+		log.log("Office 365 Library Name Query: ", o365SharedLibraryName);
 		
 		foreach (searchResult; siteQuery["value"].array) {
 			// Need an 'exclusive' match here with o365SharedLibraryName as entered
 			if (o365SharedLibraryName == searchResult["displayName"].str){
 				// 'displayName' matches search request
 				site_id = searchResult["id"].str;
+				webUrl = searchResult["webUrl"].str;
 				JSONValue siteDriveQuery = onedrive.o365SiteDrives(site_id);
 				foreach (driveResult; siteDriveQuery["value"].array) {
-					drive_id = driveResult["id"].str;
+					// Display results
+					found = true;
+					writeln("SiteName: ", searchResult["displayName"].str);
+					writeln("drive_id: ", driveResult["id"].str);
+					writeln("URL:      ", webUrl);
 				}
 			}
 		}
 		
-		log.log("Office 365 Library Name: ", o365SharedLibraryName);
-		if(drive_id != null) {
-			log.log("drive_id: ", drive_id);
-		} else {
+		if(!found) {
 			writeln("ERROR: This site could not be found. Please check it's name and your permissions to access the site.");
 		}
 	}


### PR DESCRIPTION
* Update handling of --get-O365-drive-id to print out all 'site names' that match the explicit search entry rather than just the last match
* Add webUrl for site to output so that the 'right' site drive_id can be identified
* Update O365 readme with updated output