### PR TITLE
notification on incoming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Config option 'sync_dir'            = /home/alex/OneDrive
 Config option 'skip_file'           = ~*
 Config option 'skip_symlinks'       = false
 Config option 'monitor_interval'    = 45
+Config option 'min_notif_changes'   = 5
 Config option 'log_dir'             = /var/log/onedrive/
 Selective sync configured           = false
 ```
@@ -380,6 +381,7 @@ Available options:
 *   `skip_file`: any files or directories that match this pattern will be skipped during sync
 *   `skip_symlinks`: any files or directories that are symlinked will be skipped during sync
 *   `monitor_interval`: time interval in seconds by which the monitor process will process local and remote changes
+*   `min_notif_changes`: minimum number of pending incoming changes to trigger a desktop notification
 
 ### sync_dir
 Example: `sync_dir="~/MyDirToSync"`
@@ -405,6 +407,11 @@ Setting this to `"true"` will skip all symlinks while syncing.
 Example: `monitor_interval = "300"`
 
 The monitor interval is defined as the wait time 'between' sync's when running in monitor mode. By default without configuration, the monitor_interval is set to 45 seconds. Setting this value to 300 will run the sync process every 5 minutes.
+
+### min_notif_changes
+Example: `min_notif_changes = "5"`
+
+This option defines the minimum number of pending incoming changes necessary to trigger a desktop notification. This allows controlling the frequency of notifications.
 
 ### Selective sync
 Selective sync allows you to sync only specific files and directories.

--- a/onedrive.1.in
+++ b/onedrive.1.in
@@ -147,6 +147,10 @@ skip symbolic links during sync, defaults to \fB"false"\fP
 the number of seconds by which each sync operation is undertaken when
 idle under monitor mode, defaults to \fB"45"\fP
 .TP
+\fBmin_notif_changes\fP
+the minimum number of pending incoming changes necessary to trigger
+a desktop notification, defaults to \fB"5"\fP
+.TP
 \fBlog_dir\fP
 defines the directory where logging output is saved to, needs to end with a slash
 .PP

--- a/src/config.d
+++ b/src/config.d
@@ -41,6 +41,8 @@ final class Config
 		setValue("log_dir", "/var/log/onedrive/");
 		// Configure a default empty value for drive_id
 		setValue("drive_id", "");
+		// Minimal changes that trigger a log and notification on sync
+		setValue("min_changes_for_notification", "5");
 		
 		if (!load(userConfigFilePath)) {
 			// What was the reason for failure?

--- a/src/config.d
+++ b/src/config.d
@@ -42,7 +42,7 @@ final class Config
 		// Configure a default empty value for drive_id
 		setValue("drive_id", "");
 		// Minimal changes that trigger a log and notification on sync
-		setValue("min_changes_for_notification", "5");
+		setValue("min_notif_changes", "5");
 		
 		if (!load(userConfigFilePath)) {
 			// What was the reason for failure?

--- a/src/main.d
+++ b/src/main.d
@@ -298,6 +298,7 @@ int main(string[] args)
 		writeln("Config option 'skip_file'           = ", cfg.getValue("skip_file"));
 		writeln("Config option 'skip_symlinks'       = ", cfg.getValue("skip_symlinks"));
 		writeln("Config option 'monitor_interval'    = ", cfg.getValue("monitor_interval"));
+		writeln("Config option 'min_notif_changes'   = ", cfg.getValue("min_notif_changes"));
 		writeln("Config option 'log_dir'             = ", cfg.getValue("log_dir"));
 		
 		// Is config option drive_id configured?

--- a/src/sync.d
+++ b/src/sync.d
@@ -582,7 +582,6 @@ final class SyncEngine
 			if (("value" in changes) != null) {
 				auto nrChanges = count(changes["value"].array);
 
-
 				if (nrChanges >= to!long(cfg.getValue("min_notif_changes"))) {
 					log.logAndNotify("Processing ", nrChanges, " changes");
 				} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -583,7 +583,7 @@ final class SyncEngine
 				auto nrChanges = count(changes["value"].array);
 
 
-				if (nrChanges >= to!int(cfg.getValue("min_changes_for_notification", "5"))) {
+				if (nrChanges >= to!long(cfg.getValue("min_notif_changes"))) {
 					log.logAndNotify("Processing ", nrChanges, " changes");
 				} else {
 					// There are valid changes

--- a/src/sync.d
+++ b/src/sync.d
@@ -5,6 +5,7 @@ import std.exception: enforce;
 import std.file, std.json, std.path;
 import std.regex;
 import std.stdio, std.string, std.uni, std.uri;
+import std.conv;
 import core.time, core.thread;
 import core.stdc.stdlib;
 import config, itemdb, onedrive, selective, upload, util;
@@ -579,8 +580,15 @@ final class SyncEngine
 			
 			// Are there any changes to process?
 			if (("value" in changes) != null) {
-				// There are valid changes
-				log.vdebug("Number of changes from OneDrive to process: ", count(changes["value"].array));
+				auto nrChanges = count(changes["value"].array);
+
+
+				if (nrChanges >= to!int(cfg.getValue("min_changes_for_notification", "5"))) {
+					log.logAndNotify("Processing ", nrChanges, " changes");
+				} else {
+					// There are valid changes
+					log.vdebug("Number of changes from OneDrive to process: ", nrChanges);
+				}
 				
 				foreach (item; changes["value"].array) {
 					bool isRoot = false;


### PR DESCRIPTION
This pull request implements notifications when changes are incoming from the cloud.
A new configuration option `min_notif_changes` has been added, controlling the minimum
number of incoming changes to trigger a desktop notification. If there are less than this
number, no notification will be shown.