### PR TITLE
add detailed instructions for docker README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,16 +6,16 @@ This container offers simple monitoring-mode service for 'Free Client for OneDri
 
 ## Usage instructions
 
-0. Install the docker under your own platform's instructions
+### 0. Install the docker under your own platform's instructions 
 
-1. Pull the image
+### 1. Pull the image
 
 ```bash
 docker pull driveone/onedrive
 ```
 **NOTE:** SELinux context needs to be configured or disabled for Docker, to be able to write to OneDrive host directory.
 
-2. Prepare required stuff
+### 2. Prepare required stuff
 
 Onedrive needs two volumns. One is config volumn, which is recommanded to be a docker volumn. You can create it with:
 ```bash
@@ -26,7 +26,7 @@ This will create a docker volumn labeled 'onedrive_conf', which we will use it l
 
 The second one is your data folder that needs to sync with. The owner of the folder must not be root, and you must have permission to its parent directory (because onedrive will try to setup a monitor for the sync folder).
 
-3. First run
+### 3. First run
 
 Onedrive also needs to be authurized with your account. This is done by running docker in interactive mode. 
 
@@ -40,7 +40,7 @@ You will be asked to open a specific link using your web browser where you will 
 
 If your onedrive is working as expected, you can detach from the container with Ctrl+p, Ctrl+q.
 
-4. Status, stop, and restart, etc.
+### 4. Status, stop, and restart, etc.
 
 Check if monitor service is running
 ```bash
@@ -67,7 +67,7 @@ Unregister onedrive monitor
 docker rm -f onedrive
 ```
 
-5. Eidt the config
+### 5. Eidt the config
 
 Onedrive should run in default configuration, but however you can change your configuration. First download the default config from [https://raw.githubusercontent.com/abraunegg/onedrive/master/config] and put it into your onedrive_conf volumn. The detailed document can be found here: [https://github.com/abraunegg/onedrive#additional-configuration]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,12 +5,74 @@ Thats right folks onedrive is now dockerized ;)
 This container offers simple monitoring-mode service for 'Free Client for OneDrive on Linux'.
 
 ## Usage instructions
+
+0. Install the docker under your own platform's instructions
+
+1. Pull the image
+
 ```bash
 docker pull driveone/onedrive
 ```
 **NOTE:** SELinux context needs to be configured or disabled for Docker, to be able to write to OneDrive host directory.
 
-1.  Run or update onedrive container
+2. Prepare required stuff
+
+Onedrive needs two volumns. One is config volumn, which is recommanded to be a docker volumn. You can create it with:
+```bash
+docker volume create onedrive_conf;
+```
+
+This will create a docker volumn labeled 'onedrive_conf', which we will use it later.
+
+The second one is your data folder that needs to sync with. The owner of the folder must not be root, and you must have permission to its parent directory (because onedrive will try to setup a monitor for the sync folder).
+
+3. First run
+
+Onedrive also needs to be authurized with your account. This is done by running docker in interactive mode. 
+
+**make sure to change onedriveDir to your own.**
+```bash
+onedriveDir="${HOME}/OneDrive"
+docker run -it --restart unless-stopped --name onedrive -v onedrive_conf:/onedrive/conf -v "${onedriveDir}:/onedrive/data" driveone/onedrive
+```
+
+You will be asked to open a specific link using your web browser where you will have to login into your Microsoft Account and give the application the permission to access your files. After giving the permission, you will be redirected to a blank page. Copy the URI of the blank page into the application.
+
+If your onedrive is working as expected, you can detach from the container with Ctrl+p, Ctrl+q.
+
+4. Status, stop, and restart, etc.
+
+Check if monitor service is running
+```bash
+docker ps -f name=onedrive
+```
+
+Show monitor run logs
+```bash
+docker logs onedrive
+```
+
+Stop running monitor
+```bash
+docker stop onedrive
+```
+
+Resume monitor
+```bash
+docker start onedrive
+```
+
+Unregister onedrive monitor
+```bash
+docker rm -f onedrive
+```
+
+5. Eidt the config
+
+Onedrive should run in default configuration, but however you can change your configuration. First download the default config from [https://raw.githubusercontent.com/abraunegg/onedrive/master/config] and put it into your onedrive_conf volumn. The detailed document can be found here: [https://github.com/abraunegg/onedrive#additional-configuration]
+
+## Run or update with one script
+If you are experienced with docker and onedrive, you can use the following script:
 ```bash
 # Update onedriveDir with correct existing OneDrive directory path
 onedriveDir="${HOME}/OneDrive"
@@ -21,30 +83,10 @@ docker inspect onedrive_conf > /dev/null || { docker volume create onedrive_conf
 docker inspect onedrive > /dev/null && docker rm -f onedrive
 docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/onedrive/conf -v "${onedriveDir}:/onedrive/data" driveone/onedrive
 ```
-## Poweruser section
-1.  Check if monitor service is running
-```bash
-docker ps -f name=onedrive
-```
-2.  Show monitor run logs
-```bash
-docker logs onedrive
-```
-3.  Stop running monitor
-```bash
-docker stop onedrive
-```
-4.  Resume monitor
-```bash
-docker start onedrive
-```
-5.  Unregister onedrive monitor
-```bash
-docker rm -f onedrive
-```
+
 ## Build instructions
 ```bash
-cd docker
 git clone https://github.com/abraunegg/onedrive
+cd onedrive/docker
 docker build . -t driveone/onedrive
 ```


### PR DESCRIPTION
add detailed instructions for docker README.md so users don't need to read the long text in the main README.md.