### PR TITLE
Resolve Key not found: nextExpectedRanges (Issue #408)

### DIFF
--- a/src/upload.d
+++ b/src/upload.d
@@ -111,8 +111,16 @@ struct UploadSession
 
 	JSONValue upload()
 	{
-		long offset = session["nextExpectedRanges"][0].str.splitter('-').front.to!long;
-		long fileSize = getSize(session["localPath"].str);
+		long offset;
+		long fileSize;
+		
+		if ("nextExpectedRanges" in session){
+			offset = session["nextExpectedRanges"][0].str.splitter('-').front.to!long;
+		}
+		
+		if ("localPath" in session){
+			fileSize = getSize(session["localPath"].str);
+		}
 		
 		// Upload Progress Bar
 		size_t iteration = (roundTo!int(double(fileSize)/double(fragmentSize)))+1;


### PR DESCRIPTION
* Dont 'assume' that the key value pairs exist. Check if they do before attempting to use them.