### PR TITLE
Resolve unhandled application crash when invalid auth response is used (Issue #399)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -358,11 +358,17 @@ final class OneDriveApi
 	private void acquireToken(const(char)[] postData)
 	{
 		JSONValue response = post(tokenUrl, postData);
-		accessToken = "bearer " ~ response["access_token"].str();
-		refreshToken = response["refresh_token"].str();
-		accessTokenExpiration = Clock.currTime() + dur!"seconds"(response["expires_in"].integer());
-		std.file.write(cfg.refreshTokenFilePath, refreshToken);
-		if (printAccessToken) writeln("New access token: ", accessToken);
+		if ("access_token" in response){
+			accessToken = "bearer " ~ response["access_token"].str();
+			refreshToken = response["refresh_token"].str();
+			accessTokenExpiration = Clock.currTime() + dur!"seconds"(response["expires_in"].integer());
+			std.file.write(cfg.refreshTokenFilePath, refreshToken);
+			if (printAccessToken) writeln("New access token: ", accessToken);
+		} else {
+			log.error("\nInvalid authentication response from OneDrive. Please check the response uri\n");
+			// re-authorize
+			authorize();
+		}
 	}
 
 	private void checkAccessTokenExpired()

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -692,6 +692,12 @@ final class OneDriveApi
 	{
 		switch(http.statusLine.code)
 		{
+			// 400 - Bad Request
+			case 400:
+				// Bad Request .. how should we act?
+				log.vlog("OneDrive returned a 'HTTP 400 - Bad Request' - gracefully handling error");
+				break;	
+			
 			//	412 - Precondition Failed
 			case 412:
 				log.vlog("OneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error");


### PR DESCRIPTION
* When authorising the application, if using `--logout` and pasting back the previous response URI, the application would crash. Handle the 400 response from OneDrive & request to re-authenticate