### PR TITLE
Update skip_dir config handling

### DIFF
--- a/src/selective.d
+++ b/src/selective.d
@@ -39,7 +39,19 @@ final class SelectiveSync
 		// Does the directory name match skip_dir config entry?
 		// Returns true if the name matches a skip_dir config entry
 		// Returns false if no match
-		return !name.matchFirst(dirmask).empty;
+		
+		// Try full path match first
+		if (!name.matchFirst(dirmask).empty) {
+			return true;
+		} else {
+			// check just the file name
+			string filename = baseName(name);
+			if(!filename.matchFirst(dirmask).empty) {
+				return true;
+			}
+		}
+		// no match
+		return false;
 	}
 	
 	// config file skip_file parameter

--- a/src/sync.d
+++ b/src/sync.d
@@ -1485,12 +1485,14 @@ final class SyncEngine
 			// filter out user configured items to skip
 			if (path != ".") {
 				if (isDir(path)) {
+					log.vdebug("Checking path: ", path);
 					if (selectiveSync.isDirNameExcluded(strip(path,"./"))) {
 						log.vlog("Skipping item - excluded by skip_dir config: ", path);
 						return;
 					}
 				}
 				if (isFile(path)) {
+					log.vdebug("Checking file: ", path);
 					if (selectiveSync.isFileNameExcluded(strip(path,"./"))) {
 						log.vlog("Skipping item - excluded by skip_file config: ", path);
 						return;


### PR DESCRIPTION
* Original skip_dir handling expected an explicit match to path to match. With this patch, wildcard matching for any directory matching the path entry will be skipped