### PR TITLE
New build option to get more DEBUG symbolic information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ ifeq ($(notdir $(DC)),ldc2)
 	NOTIF_VERSIONS := $(addprefix -d,$(NOTIF_VERSIONS))
 endif
 
+ifeq ($(DEBUG),1)
+DFLAGS += -gs -debug
+endif
+
 DFLAGS += -w -g -ofonedrive -O $(NOTIF_VERSIONS) $(LIBS) -J.
 
 PREFIX ?= /usr/local

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ By passing `NOTIFICATIONS=1` to the `make` call, notifications via
 libnotify are enabled. If `pkg-config` is not used (see above), the necessary
 libraries are `gmodule-2.0`, `glib-2.0`, and `notify`.
 
+By passing `DEBUG=1` to the `make` call, `onedrive` gets built with additional debug
+information, useful (for example) to get `perf`-issued figures.
+
 ### Building using a different compiler (for example [LDC](https://wiki.dlang.org/LDC))
 #### Debian - i386 / i686
 ```text


### PR DESCRIPTION
Add a new build option (DEBUG=1) so that I can use `make` too when doing performance tests.