### PR TITLE
Fix JSONValue is not an object crash when a 5xx error is returned when uploading files

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1682,6 +1682,8 @@ final class SyncEngine
 			auto maxUploadFileSize = 16106127360; // 15GB
 			//auto maxUploadFileSize = 21474836480; // 20GB
 			auto thisFileSize = getSize(path);
+			// To avoid a 409 Conflict error - does the file actually exist on OneDrive already?
+			JSONValue fileDetailsFromOneDrive;
 			
 			// Can we read the file - as a permissions issue or file corruption will cause a failure
 			// https://github.com/abraunegg/onedrive/issues/113
@@ -1689,10 +1691,6 @@ final class SyncEngine
 				// able to read the file
 				if (thisFileSize <= maxUploadFileSize){
 					// Resolves: https://github.com/skilion/onedrive/issues/121, https://github.com/skilion/onedrive/issues/294, https://github.com/skilion/onedrive/issues/329
-				
-					// To avoid a 409 Conflict error - does the file actually exist on OneDrive already?
-					JSONValue fileDetailsFromOneDrive;
-					
 					// Does this 'file' already exist on OneDrive?
 					try {
 						// test if the local path exists on OneDrive
@@ -1839,7 +1837,8 @@ final class SyncEngine
 					// even though some file systems (such as a POSIX-compliant file system) may consider them as different. 
 					// Note that NTFS supports POSIX semantics for case sensitivity but this is not the default behavior.
 					
-					if (fileDetailsFromOneDrive["name"].str == baseName(path)){
+					// Check that 'name' is in the JSON response (validates data) and that 'name' == the path we are looking for
+					if (("name" in fileDetailsFromOneDrive) && (fileDetailsFromOneDrive["name"].str == baseName(path))) {
 						// OneDrive 'name' matches local path name
 						log.vlog("Requested file to upload exists on OneDrive - local database is out of sync for this file: ", path);
 						


### PR DESCRIPTION
* Fix JSONValue is not an object crash when a 5xx error is returned when uploading files