### PR TITLE
Update 'skip_dir' handling to check against OneDrive new downloads

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -755,11 +755,15 @@ final class SyncEngine
 		unwanted |= skippedItems.find(item.parentId).length != 0;
 		if (unwanted) log.vdebug("Flagging as unwanted: find(item.parentId).length != 0");
 		// Check if this is a directory to skip
-		unwanted |= selectiveSync.isDirNameExcluded(item.name);
-		if (unwanted) log.vlog("Skipping item - excluded by skip_dir config: ", item.name);
+		if (!unwanted) {
+			unwanted = selectiveSync.isDirNameExcluded(item.name);
+			if (unwanted) log.vlog("Skipping item - excluded by skip_dir config: ", item.name);
+		}
 		// Check if this is a file to skip
-		unwanted |= selectiveSync.isFileNameExcluded(item.name);
-		if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+		if (!unwanted) {
+			unwanted = selectiveSync.isFileNameExcluded(item.name);
+			if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+		}
 		
 		// check the item type
 		if (!unwanted) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -754,9 +754,13 @@ final class SyncEngine
 		bool unwanted;
 		unwanted |= skippedItems.find(item.parentId).length != 0;
 		if (unwanted) log.vdebug("Flagging as unwanted: find(item.parentId).length != 0");
+		// Check if this is a directory to skip
+		unwanted |= selectiveSync.isDirNameExcluded(item.name);
+		if (unwanted) log.vlog("Skipping item - excluded by skip_dir config: ", item.name);
+		// Check if this is a file to skip
 		unwanted |= selectiveSync.isFileNameExcluded(item.name);
-		if (unwanted) log.vdebug("Flagging as unwanted: item name is excluded: ", item.name);
-
+		if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+		
 		// check the item type
 		if (!unwanted) {
 			if (isItemFile(driveItem)) {


### PR DESCRIPTION
* Add check for directories to match skip_dir entries for OneDrive objects to download
* Update logging as to why a OneDrive object was skipped