### PR TITLE
Implement more meaningful 5xx error responses (Issue #445)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -711,10 +711,25 @@ final class OneDriveApi
 			// 	502 - Bad Gateway
 			//	503 - Service Unavailable
 			//  504 - Gateway Timeout (Issue #320)
-			case 500,502,503,504:
+			case 500:
 				// No actions
-				log.vlog("OneDrive returned a 'HTTP 5xx Server Side Error' - gracefully handling error");
-				break;	
+				log.vlog("OneDrive returned a 'HTTP 500 Internal Server Error' - gracefully handling error");
+				break;
+				
+			case 502:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 502 Bad Gateway Error' - gracefully handling error");
+				break;
+			
+			case 503:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 503 Service Unavailable Error' - gracefully handling error");
+				break;
+			
+			case 504:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 504 Gateway Timeout Error' - gracefully handling error");
+				break;
 
 			// "else"
 			default:
@@ -742,9 +757,24 @@ final class OneDriveApi
 			// 	502 - Bad Gateway
 			//	503 - Service Unavailable
 			//  504 - Gateway Timeout (Issue #320)
-			case 500,502,503,504:
+			case 500:
 				// No actions
-				log.vlog("OneDrive returned a 'HTTP 5xx Server Side Error' - gracefully handling error");
+				log.vlog("OneDrive returned a 'HTTP 500 Internal Server Error' - gracefully handling error");
+				break;
+				
+			case 502:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 502 Bad Gateway Error' - gracefully handling error");
+				break;
+			
+			case 503:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 503 Service Unavailable Error' - gracefully handling error");
+				break;
+			
+			case 504:
+				// No actions
+				log.vlog("OneDrive returned a 'HTTP 504 Gateway Timeout Error' - gracefully handling error");
 				break;
 			
 			// Default - all other errors that are not a 2xx or a 302


### PR DESCRIPTION
Issue #445 and https://github.com/OneDrive/onedrive-api-docs/issues/1035 highlight that the current 5xx error messages are too generic and need to be more specific. This patch makes those error messages more specific to the response code from OneDrive API