### PR TITLE
Add --upload-only check for sharepoint fix (Issue #452)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -728,6 +728,11 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 		localPath = singleDirectory;
 	}
 	
+	// Due to Microsoft Sharepoint 'enrichment' of files, we try to download the Microsoft modified file automatically
+	// Set flag if we are in upload only state to handle this differently
+	// See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details   
+	if (uploadOnly) sync.setUploadOnly();
+	
 	do {
 		try {
 			if (singleDirectory != ""){

--- a/src/sync.d
+++ b/src/sync.d
@@ -17,6 +17,9 @@ private long thresholdFileSize = 4 * 2^^20; // 4 MiB
 // flag to set whether local files should be deleted
 private bool noRemoteDelete = false;
 
+// flag to set if we are running as uploadOnly
+private bool uploadOnly = false;
+
 // Do we configure to disable the upload validation routine
 private bool disableUploadValidation = false;
 
@@ -297,6 +300,13 @@ final class SyncEngine
 	void setNoRemoteDelete()
 	{
 		noRemoteDelete = true;
+	}
+	
+	// Configure uploadOnly if function is called
+	// By default, uploadOnly = false;
+	void setUploadOnly()
+	{
+		uploadOnly = true;
 	}
 	
 	// Configure disableUploadValidation if function is called
@@ -1927,13 +1937,15 @@ final class SyncEngine
 										response = onedrive.simpleUpload(path, parent.driveId, parent.id, baseName(path));
 										writeln(" done.");
 										saveItem(response);
-										// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
-										// So - now the 'local' and 'remote' file is technically DIFFERENT ... thanks Microsoft .. NO way to disable this stupidity
-										// Download the Microsoft 'modified' file so 'local' is now in sync
-										log.vlog("Due to Microsoft Sharepoint 'enrichment' of files, downloading 'enriched' file to ensure local file is in-sync");
-										log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
-										auto fileSize = response["size"].integer;
-										onedrive.downloadById(response["parentReference"]["driveId"].str, response["id"].str, path, fileSize);
+										if(!uploadOnly){
+											// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
+											// So - now the 'local' and 'remote' file is technically DIFFERENT ... thanks Microsoft .. NO way to disable this stupidity
+											// Download the Microsoft 'modified' file so 'local' is now in sync
+											log.vlog("Due to Microsoft Sharepoint 'enrichment' of files, downloading 'enriched' file to ensure local file is in-sync");
+											log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
+											auto fileSize = response["size"].integer;
+											onedrive.downloadById(response["parentReference"]["driveId"].str, response["id"].str, path, fileSize);
+										}
 									}
 								}
 							} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -1937,14 +1937,18 @@ final class SyncEngine
 										response = onedrive.simpleUpload(path, parent.driveId, parent.id, baseName(path));
 										writeln(" done.");
 										saveItem(response);
+										// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
+										// So - now the 'local' and 'remote' file is technically DIFFERENT ... thanks Microsoft .. NO way to disable this stupidity
 										if(!uploadOnly){
-											// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
-											// So - now the 'local' and 'remote' file is technically DIFFERENT ... thanks Microsoft .. NO way to disable this stupidity
 											// Download the Microsoft 'modified' file so 'local' is now in sync
 											log.vlog("Due to Microsoft Sharepoint 'enrichment' of files, downloading 'enriched' file to ensure local file is in-sync");
 											log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
 											auto fileSize = response["size"].integer;
 											onedrive.downloadById(response["parentReference"]["driveId"].str, response["id"].str, path, fileSize);
+										} else {
+											// we are not downloading a file, warn that file differences will exist
+											log.vlog("WARNING: Due to Microsoft Sharepoint 'enrichment' of files, this file is now technically different to your local copy");
+											log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
 										}
 									}
 								}


### PR DESCRIPTION
* Add a check for --upload-only use when trying to work around https://github.com/OneDrive/onedrive-api-docs/issues/935