### PR TITLE
Update 'root' item identification handling (Issue #456)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -634,9 +634,9 @@ final class SyncEngine
 					if(!isItemDeleted(item)){
 						// This is not a deleted item
 						// Test is this is the OneDrive Users Root?
-						// Use the global's as initialised via init() rather than performing unnecessary additional HTTPS calls
-						if ((id == defaultRootId) && (item["name"].str == "root")) { 
-							// This IS the OneDrive Root
+						// Use the global's as initialised via init() rather than performing unnecessary additional HTTPS calls 
+						if ((id == defaultRootId) && (isItemRoot(item)) && (item["name"].str == "root")) { 
+							// This IS a OneDrive Root item
 							isRoot = true;
 						}
 					}


### PR DESCRIPTION
* Add additional check to ensure item root we flag as 'root' is not just name checked as 'root'