### PR TITLE
add completion support (Issue: #454)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(pkgconfig),1)
 else
 	BASHCOMPLETIONDIR ?= $(PREFIX)/share/bash-completion/completions
 endif
-ZSHCOMPLETIONDIR ?= $(PREFIX)/share/zsh/site-functions
+ZSHCOMPLETIONDIR ?= /usr/local/share/zsh/site-functions
 endif
 
 DFLAGS += -w -g -ofonedrive -O $(NOTIF_VERSIONS) $(LIBS) -J.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DC ?= dmd
 RELEASEVER = v2.3.2
 pkgconfig := $(shell if [ $(PKGCONFIG) ] && [ "$(PKGCONFIG)" != 0 ] ; then echo 1 ; else echo "" ; fi)
 notifications := $(shell if [ $(NOTIFICATIONS) ] && [ "$(NOTIFICATIONS)" != 0 ] ; then echo 1 ; else echo "" ; fi)
+completions := $(shell if [ $(COMPLETIONS) ] && [ "$(COMPLETIONS)" != 0 ] ; then echo 1 ; else echo "" ; fi)
 gitversion := $(shell if [ -f .git/HEAD ] ; then echo 1 ; else echo "" ; fi)
 
 ifeq ($(pkgconfig),1)
@@ -33,6 +34,16 @@ DFLAGS += -d-debug -gc
 else
 DFLAGS += -debug -gs
 endif
+endif
+
+# set up completion directories
+ifeq ($(completions),1)
+ifeq ($(pkgconfig),1)
+	BASHCOMPLETIONDIR ?= $(shell pkg-config --variable=completionsdir bash-completion)
+else
+	BASHCOMPLETIONDIR ?= $(PREFIX)/share/bash-completion/completions
+endif
+ZSHCOMPLETIONDIR ?= $(PREFIX)/share/zsh/site-functions
 endif
 
 DFLAGS += -w -g -ofonedrive -O $(NOTIF_VERSIONS) $(LIBS) -J.
@@ -110,6 +121,11 @@ else
 	install -D -m 644 onedrive@.service $(DESTDIR)/usr/lib/systemd/system/
 	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 endif
+ifeq ($(completions),1)
+	mkdir -p $(DESTDIR)/$(ZSHCOMPLETIONDIR)
+	install -D -m 644 completions/complete.zsh $(DESTDIR)/$(ZSHCOMPLETIONDIR)/_onedrive
+	install -D -m 644 completions/complete.bash $(DESTDIR)/$(BASHCOMPLETIONDIR)/onedrive
+endif
 
 onedrive.service:
 	sed "s|@PREFIX@|$(PREFIX)|g" systemd.units/onedrive.service.in > onedrive.service
@@ -134,6 +150,10 @@ else
 endif
 	for i in $(DOCFILES) ; do rm -f $(DESTDIR)$(DOCDIR)/$$i ; done
 	rm -f $(DESTDIR)$(MANDIR)/onedrive.1
+ifeq ($(completions),1)
+	rm -f $(DESTDIR)/$(ZSHCOMPLETIONDIR)/_onedrive
+	rm -f $(DESTDIR)/$(BASHCOMPLETIONDIR)/onedrive
+endif
 
 version:
 ifeq ($(gitversion),1)

--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,8 @@ else
 	install -D -m 644 onedrive.service $(DESTDIR)/usr/lib/systemd/user/onedrive.service
 endif
 ifeq ($(completions),1)
-	mkdir -p $(DESTDIR)/$(ZSHCOMPLETIONDIR)
-	install -D -m 644 completions/complete.zsh $(DESTDIR)/$(ZSHCOMPLETIONDIR)/_onedrive
-	install -D -m 644 completions/complete.bash $(DESTDIR)/$(BASHCOMPLETIONDIR)/onedrive
+	install -D -m 644 completions/complete.zsh $(DESTDIR)$(ZSHCOMPLETIONDIR)/_onedrive
+	install -D -m 644 completions/complete.bash $(DESTDIR)$(BASHCOMPLETIONDIR)/onedrive
 endif
 
 onedrive.service:
@@ -151,8 +150,8 @@ endif
 	for i in $(DOCFILES) ; do rm -f $(DESTDIR)$(DOCDIR)/$$i ; done
 	rm -f $(DESTDIR)$(MANDIR)/onedrive.1
 ifeq ($(completions),1)
-	rm -f $(DESTDIR)/$(ZSHCOMPLETIONDIR)/_onedrive
-	rm -f $(DESTDIR)/$(BASHCOMPLETIONDIR)/onedrive
+	rm -f $(DESTDIR)$(ZSHCOMPLETIONDIR)/_onedrive
+	rm -f $(DESTDIR)$(BASHCOMPLETIONDIR)/onedrive
 endif
 
 version:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ libraries are `gmodule-2.0`, `glib-2.0`, and `notify`.
 By passing `DEBUG=1` to the `make` call, `onedrive` gets built with additional debug
 information, useful (for example) to get `perf`-issued figures.
 
+By passing `COMPLETIONS=1` to the `make` call, shell completion functions are
+installed for `bash` and `zsh`.
+
 ### Building using a different compiler (for example [LDC](https://wiki.dlang.org/LDC))
 #### Debian - i386 / i686
 ```text

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ By passing `DEBUG=1` to the `make` call, `onedrive` gets built with additional d
 information, useful (for example) to get `perf`-issued figures.
 
 By passing `COMPLETIONS=1` to the `make` call, shell completion functions are
-installed for `bash` and `zsh`.
+installed for `bash` and `zsh`. The installation directories are determined
+as far as possible automatically, but can be overridden by setting the
+environment variables `BASHCOMPLETIONDIR` and `ZSHCOMPLETIONDIR`.
 
 ### Building using a different compiler (for example [LDC](https://wiki.dlang.org/LDC))
 #### Debian - i386 / i686

--- a/completions/complete.bash
+++ b/completions/complete.bash
@@ -1,0 +1,36 @@
+_onedrive()
+{
+	local cur prev
+
+	COMPREPLY=()
+	cur=${COMP_WORDS[COMP_CWORD]}
+	prev=${COMP_WORDS[COMP_CWORD-1]}
+
+	options='--check-for-nomount   --check-for-nosync --debug-https --disable-notifications --display-config --display-sync-status -d --download-only --disable-upload-validation --dry-run --enable-logging --force-http-1.1 --local-first --logout -m --monitor --no-remote-delete --print-token --resync --skip-dot-files --skip-symlinks --synchronize --upload-only -v --verbose --version -h --help'
+	argopts='--create-directory --get-O365-drive-id --remove-directory --single-directory --source-directory'
+
+	# Loop on the arguments to manage conflicting options
+	for (( i=0; i < ${#COMP_WORDS[@]}-1; i++ )); do
+		#exclude some mutually exclusive options
+		[[ ${COMP_WORDS[i]} == '--synchronize' ]] && options=${options/--monitor}
+		[[ ${COMP_WORDS[i]} == '--monitor' ]] && options=${options/--synchronize}
+	done
+    
+	case "$prev" in
+	--confdir|--syncdir)
+		_filedir
+		return 0
+		;;
+	--create-directory|--get-O365-drive-id|--remove-directory|--single-directory|--source-directory)
+		return 0
+		;;
+	*)
+		COMPREPLY=( $( compgen -W "$options $argopts" -- $cur))
+		return 0
+		;;
+	esac
+	
+	# notreached
+	return 0
+}
+complete -F _onedrive onedrive

--- a/completions/complete.bash
+++ b/completions/complete.bash
@@ -1,3 +1,9 @@
+#!/bin/bash
+#
+# BASH completion code for OneDrive Linux Client
+# (c) 2019 Norbert Preining
+# License: GPLv3+ (as with the rest of the OneDrive Linux client project)
+
 _onedrive()
 {
 	local cur prev

--- a/completions/complete.zsh
+++ b/completions/complete.zsh
@@ -1,4 +1,8 @@
 #compdef onedrive
+#
+# ZSH completion code for OneDrive Linux Client
+# (c) 2019 Norbert Preining
+# License: GPLv3+ (as with the rest of the OneDrive Linux client project)
 
 local -a all_opts
 all_opts=(

--- a/completions/complete.zsh
+++ b/completions/complete.zsh
@@ -1,0 +1,40 @@
+#compdef onedrive
+
+local -a all_opts
+all_opts=(
+  '--check-for-nomount[Check for the presence of .nosync in the syncdir root. If found, do not perform sync.]'
+  '--check-for-nosync[Check for the presence of .nosync in each directory. If found, skip directory from sync.]'
+  '--confdir[Set the directory used to store the configuration files]:config directory:_files -/'
+  '--create-directory[Create a directory on OneDrive - no sync will be performed.]:directory name:'
+  '--debug-https[Debug OneDrive HTTPS communication.]'
+  '--destination-directory[Destination directory for renamed or move on OneDrive - no sync will be performed.]:directory name:'
+  '--disable-notifications[Do not use desktop notifications in monitor mode.]'
+  '--display-config[Display what options the client will use as currently configured - no sync will be performed.]'
+  '--display-sync-status[Display the sync status of the client - no sync will be performed.]'
+  '(-d --download-only)'{-d,--download-only}'[Only download remote changes]'
+  '--disable-upload-validation[Disable upload validation when uploading to OneDrive]'
+  '--dry-run[Perform a trial sync with no changes made]'
+  '--enable-logging[Enable client activity to a separate log file]'
+  '--force-http-1.1[Force the use of HTTP 1.1 for all operations]'
+  '--get-O365-drive-id[Query and return the Office 365 Drive ID for a given Office 365 SharePoint Shared Library]:'
+  '--local-first[Synchronize from the local directory source first, before downloading changes from OneDrive.]'
+  '--logout[Logout the current user]'
+  '(-m --monitor)'{-m,--monitor}'[Keep monitoring for local and remote changes]'
+  '--no-remote-delete[Do not delete local file deletes from OneDrive when using --upload-only]'
+  '--print-token[Print the access token, useful for debugging]'
+  '--resync[Forget the last saved state, perform a full sync]'
+  '--remove-directory[Remove a directory on OneDrive - no sync will be performed.]:directory name:'
+  '--single-directory[Specify a single local directory within the OneDrive root to sync.]:source directory:_files -/'
+  '--skip-dot-files[Skip dot files and folders from syncing]'
+  '--skip-symlinks[Skip syncing of symlinks]'
+  '--source-directory[Source directory to rename or move on OneDrive - no sync will be performed.]:source directory:'
+  '--syncdir[Specify the local directory used for synchronization to OneDrive]:sync directory:_files -/'
+  '--synchronize[Perform a synchronization]'
+  '--upload-only[Only upload to OneDrive, do not sync changes from OneDrive locally]'
+  '(-v --verbose)'{-v,--verbose}'[Print more details, useful for debugging (repeat for extra debugging)]'
+  '--version[Print the version and exit]'
+  '(-h --help)'{-h,--help}'[Print help information]'
+)
+
+_arguments -S "$all_opts[@]" && return 0
+


### PR DESCRIPTION
Add completions for bash and zsh, install them if `COMPLETIONS=1`
is passed to `make`. Installation directories can be overridden with
environment variables.