### PR TITLE
Handle object error response from OneDrive (Issue #464)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1746,6 +1746,12 @@ final class SyncEngine
 						// test if the local path exists on OneDrive
 						fileDetailsFromOneDrive = onedrive.getPathDetails(path);
 					} catch (OneDriveException e) {
+						if (e.httpStatusCode == 401) {
+							// OneDrive returned a 'HTTP/1.1 401 Unauthorized Error' - no error message logged
+							log.error("ERROR: OneDrive returned a 'HTTP 401 - Unauthorized' - gracefully handling error");
+							return;
+						}
+					
 						if (e.httpStatusCode == 404) {
 							// The file was not found on OneDrive, need to upload it		
 							write("Uploading new file ", path, " ...");


### PR DESCRIPTION
* Add specific check to ensure that variable is of type object before JSON parsing attempts
* Add error logging to indicate error response from OneDrive was received
* Update error logging in saveItem to match