### PR TITLE
Update 'resume_upload' handling in the event of bad OneDrive response (Issue #468)

### DIFF
--- a/src/upload.d
+++ b/src/upload.d
@@ -75,6 +75,7 @@ struct UploadSession
 					try {
 						response = onedrive.requestUploadStatus(session["uploadUrl"].str);
 					} catch (OneDriveException e) {
+						// handle any onedrive error response
 						if (e.httpStatusCode == 400) {
 							log.vlog("Upload session not found");
 							return false;
@@ -82,10 +83,23 @@ struct UploadSession
 							throw e;
 						}
 					}
-					session["expirationDateTime"] = response["expirationDateTime"];
-					session["nextExpectedRanges"] = response["nextExpectedRanges"];
-					if (session["nextExpectedRanges"].array.length == 0) {
-						log.vlog("The upload session is completed");
+					// do we have a valid response from OneDrive?
+					if (response.object()){
+						// JSON object
+						if (("expirationDateTime" in response) && ("nextExpectedRanges" in response)){
+							// has the elements we need
+							session["expirationDateTime"] = response["expirationDateTime"];
+							session["nextExpectedRanges"] = response["nextExpectedRanges"];
+							if (session["nextExpectedRanges"].array.length == 0) {
+								log.vlog("The upload session is completed");
+								return false;
+							}
+						} else {
+							// bad data
+							return false;
+						}
+					} else {
+						// not a JSON object
 						return false;
 					}
 					return true;


### PR DESCRIPTION
* Add JSON response checks in the event OneDrive sends malformed data which malforms 'resume_upload'