### PR TITLE
Add logging as to why resume upload failed (Issue #468)

### DIFF
--- a/src/upload.d
+++ b/src/upload.d
@@ -83,6 +83,7 @@ struct UploadSession
 							throw e;
 						}
 					}
+					
 					// do we have a valid response from OneDrive?
 					if (response.object()){
 						// JSON object
@@ -96,10 +97,18 @@ struct UploadSession
 							}
 						} else {
 							// bad data
+							log.vlog("Restore file upload session failed - invalid data response from OneDrive");
+							if (exists(sessionFilePath)) {
+								remove(sessionFilePath);
+							}
 							return false;
 						}
 					} else {
 						// not a JSON object
+						log.vlog("Restore file upload session failed - invalid response from OneDrive");
+						if (exists(sessionFilePath)) {
+							remove(sessionFilePath);
+						}
 						return false;
 					}
 					return true;


### PR DESCRIPTION
* Log 'why' the resume upload failed
* Remove the 'resume_upload' as it is invalid & contains bad data