### PR TITLE
Fix sed replacement call in systemd unit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ ifeq ($(completions),1)
 endif
 
 onedrive.service:
-	sed "s|@PREFIX@|$(PREFIX)|g" systemd.units/onedrive.service.in > onedrive.service
-	sed "s|@PREFIX@|$(PREFIX)|g" systemd.units/onedrive@.service.in > onedrive@.service
+	sed "s|@prefix@|$(PREFIX)|g" systemd.units/onedrive.service.in > onedrive.service
+	sed "s|@prefix@|$(PREFIX)|g" systemd.units/onedrive@.service.in > onedrive@.service
 
 onedrive.1: onedrive.1.in
 	sed "s|@DOCDIR@|$(DOCDIR)|g" onedrive.1.in > onedrive.1


### PR DESCRIPTION
Commit c8e47a4 changed the values in the systemd service files
(systemd.units/onedrive{,@}.service.in) from 'PREFIX' to 'prefix'
without changing the associated `sed` call in the Makefile