### PR TITLE
Better handling for initialisation errors (Issue #483)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -309,9 +309,6 @@ final class SyncEngine
 			defaultRootId = oneDriveRootDetails["id"].str;
 			remainingFreeSpace = oneDriveDetails["quota"]["remaining"].integer;
 			
-			// Make sure that defaultDriveId is in our driveIDs array to use when checking if item is in database
-			driveIDsArray ~= defaultDriveId;
-			
 			// In some cases OneDrive Business configurations 'restrict' quota details thus is empty / blank / negative value / zero
 			if (remainingFreeSpace <= 0) {
 				// quota details not available

--- a/src/sync.d
+++ b/src/sync.d
@@ -230,6 +230,7 @@ final class SyncEngine
 	{
 		// Set accountType, defaultDriveId, defaultRootId & remainingFreeSpace once and reuse where possible
 		JSONValue oneDriveDetails;
+		JSONValue oneDriveRootDetails;
 
 		if (initDone) {
 			return;
@@ -238,6 +239,7 @@ final class SyncEngine
 		session = UploadSession(onedrive, cfg.uploadStateFilePath);
 
 		// Need to catch 400 or 5xx server side errors at initialization
+		// Get Default Drive
 		try {
 			oneDriveDetails	= onedrive.getDefaultDrive();
 		} catch (OneDriveException e) {
@@ -266,45 +268,88 @@ final class SyncEngine
 			}
 		}
 		
-		// Debug OneDrive Account details response
-		log.vdebug("OneDrive Account Details: ", oneDriveDetails);
-		
-		// Successfully got details from OneDrive without a server side error such as HTTP/1.1 504 Gateway Timeout
-		accountType = oneDriveDetails["driveType"].str;
-		defaultDriveId = oneDriveDetails["id"].str;
-		defaultRootId = onedrive.getDefaultRoot["id"].str;
-		remainingFreeSpace = oneDriveDetails["quota"]["remaining"].integer;
-		
-		// In some cases OneDrive Business configurations 'restrict' quota details thus is empty / blank / negative value / zero
-		if (remainingFreeSpace <= 0) {
-			// quota details not available
-			log.error("ERROR: OneDrive quota information is being restricted. Please fix by speaking to your OneDrive / Office 365 Administrator.");
-			log.error("ERROR: Flagging to disable upload space checks - this MAY have undesirable results if a file cannot be uploaded due to out of space.");
-			quotaAvailable = false;
+		// Get Default Root
+		try {
+			oneDriveRootDetails = onedrive.getDefaultRoot();
+		} catch (OneDriveException e) {
+			if (e.httpStatusCode == 400) {
+				// OneDrive responded with 400 error: Bad Request
+				log.error("\nERROR: OneDrive returned a 'HTTP 400 Bad Request' - Cannot Initialize Sync Engine");
+				// Check this
+				if (cfg.getValueString("drive_id").length) {
+					log.error("ERROR: Check your 'drive_id' entry in your configuration file as it may be incorrect\n");
+				}
+				// Must exit here
+				exit(-1);
+			}
+			if (e.httpStatusCode == 401) {
+				// HTTP request returned status code 401 (Unauthorized)
+				log.error("\nERROR: OneDrive returned a 'HTTP 401 Unauthorized' - Cannot Initialize Sync Engine");
+				log.error("ERROR: Check your configuration as your access token may be empty or invalid\n");
+				// Must exit here
+				exit(-1);
+			}
+			if (e.httpStatusCode >= 500) {
+				// There was a HTTP 5xx Server Side Error
+				log.error("ERROR: OneDrive returned a 'HTTP 5xx Server Side Error' - Cannot Initialize Sync Engine");
+				// Must exit here
+				exit(-1);
+			}
 		}
 		
-		// Display accountType, defaultDriveId, defaultRootId & remainingFreeSpace for verbose logging purposes
-		log.vlog("Account Type: ", accountType);
-		log.vlog("Default Drive ID: ", defaultDriveId);
-		log.vlog("Default Root ID: ", defaultRootId);
-		log.vlog("Remaining Free Space: ", remainingFreeSpace);
-    
-		// If account type is documentLibrary - then most likely this is a SharePoint repository
-		// and files 'may' be modified after upload. See: https://github.com/abraunegg/onedrive/issues/205
-		if(accountType == "documentLibrary") {
-			setDisableUploadValidation();
+		if ((hasId(oneDriveDetails)) && (hasId(oneDriveRootDetails))) {
+			// JSON elements are valid
+			// Debug OneDrive Account details response
+			log.vdebug("OneDrive Account Details:      ", oneDriveDetails);
+			log.vdebug("OneDrive Account Root Details: ", oneDriveRootDetails);
+			
+			// Successfully got details from OneDrive without a server side error such as 'HTTP/1.1 500 Internal Server Error' or 'HTTP/1.1 504 Gateway Timeout' 
+			accountType = oneDriveDetails["driveType"].str;
+			defaultDriveId = oneDriveDetails["id"].str;
+			defaultRootId = oneDriveRootDetails["id"].str;
+			remainingFreeSpace = oneDriveDetails["quota"]["remaining"].integer;
+			
+			// Make sure that defaultDriveId is in our driveIDs array to use when checking if item is in database
+			driveIDsArray ~= defaultDriveId;
+			
+			// In some cases OneDrive Business configurations 'restrict' quota details thus is empty / blank / negative value / zero
+			if (remainingFreeSpace <= 0) {
+				// quota details not available
+				log.error("ERROR: OneDrive quota information is being restricted. Please fix by speaking to your OneDrive / Office 365 Administrator.");
+				log.error("ERROR: Flagging to disable upload space checks - this MAY have undesirable results if a file cannot be uploaded due to out of space.");
+				quotaAvailable = false;
+			}
+			
+			// Display accountType, defaultDriveId, defaultRootId & remainingFreeSpace for verbose logging purposes
+			log.vlog("Account Type: ", accountType);
+			log.vlog("Default Drive ID: ", defaultDriveId);
+			log.vlog("Default Root ID: ", defaultRootId);
+			log.vlog("Remaining Free Space: ", remainingFreeSpace);
+		
+			// If account type is documentLibrary - then most likely this is a SharePoint repository
+			// and files 'may' be modified after upload. See: https://github.com/abraunegg/onedrive/issues/205
+			if(accountType == "documentLibrary") {
+				setDisableUploadValidation();
+			}
+		
+			// Check the local database to ensure the OneDrive Root details are in the database
+			checkDatabaseForOneDriveRoot();
+		
+			// Check if there is an interrupted upload session
+			if (session.restore()) {
+				log.log("Continuing the upload session ...");
+				auto item = session.upload();
+				saveItem(item);
+			}		
+			initDone = true;
+		} else {
+			// init failure
+			initDone = false;
+			// log why
+			log.error("ERROR: Unable to query OneDrive to initialize application");
+			// Must exit here
+			exit(-1);
 		}
-    
-		// Check the local database to ensure the OneDrive Root details are in the database
-		checkDatabaseForOneDriveRoot();
-	
-		// Check if there is an interrupted upload session
-		if (session.restore()) {
-			log.log("Continuing the upload session ...");
-			auto item = session.upload();
-			saveItem(item);
-		}		
-		initDone = true;
 	}
 
 	// Configure noRemoteDelete if function is called


### PR DESCRIPTION
If OneDrive / MS Graph has issues and generates internal errors, better handle the responses if MS is having an issue - for example:
```
(dmd-2.085.0)[alex@centos7full onedrive-pr473]$ ./onedrive --confdir '~/.config/onedrive-preining' --synchronize --verbose 
Using Config Dir: /home/alex/.config/onedrive-preining
Initializing the OneDrive API ...
Opening the item database ...
All operations will be performed in: /home/alex/OneDrivePreining
Initializing the Synchronization Engine ...
OneDrive returned a 'HTTP 400 - Bad Request' - gracefully handling error
OneDrive returned a 'HTTP 400 - Bad Request' - gracefully handling error
std.json.JSONException@std/json.d(540): Key not found: driveType
----------------
/home/alex/dlang/dmd-2.085.0/linux/bin64/../../src/phobos/std/exception.d:515 pure @safe void std.exception.bailOut!(std.json.JSONException).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x5dba93]
??:? pure @safe inout(std.json.JSONValue)* std.exception.enforce!(std.json.JSONException).enforce!(inout(std.json.JSONValue)*).enforce(inout(std.json.JSONValue)*, lazy const(char)[], immutable(char)[], ulong) [0x678802]
??:? inout pure ref @safe inout(std.json.JSONValue) std.json.JSONValue.opIndex(immutable(char)[]) [0x631181]
src/sync.d:282 void sync.SyncEngine.init() [0x5ff6d0]
src/main.d:586 bool main.initSyncEngine(sync.SyncEngine) [0x5ef664]
src/main.d:334 _Dmain [0x5ee3ff]
(dmd-2.085.0)[alex@centos7full onedrive-pr473]$ 
```
```
(dmd-2.085.0)[alex@centos7full onedrive-pr473]$ ./onedrive --confdir '~/.config/onedrive-preining' --synchronize --verbose 
Using Config Dir: /home/alex/.config/onedrive-preining
Initializing the OneDrive API ...
Opening the item database ...
All operations will be performed in: /home/alex/OneDrivePreining
Initializing the Synchronization Engine ...
OneDrive returned a 'HTTP 504 Gateway Timeout Error' - gracefully handling error
std.json.JSONException@std/json.d(540): Key not found: driveType
----------------
/home/alex/dlang/dmd-2.085.0/linux/bin64/../../src/phobos/std/exception.d:515 pure @safe void std.exception.bailOut!(std.json.JSONException).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x5dba93]
??:? pure @safe inout(std.json.JSONValue)* std.exception.enforce!(std.json.JSONException).enforce!(inout(std.json.JSONValue)*).enforce(inout(std.json.JSONValue)*, lazy const(char)[], immutable(char)[], ulong) [0x678802]
??:? inout pure ref @safe inout(std.json.JSONValue) std.json.JSONValue.opIndex(immutable(char)[]) [0x631181]
src/sync.d:282 void sync.SyncEngine.init() [0x5ff6d0]
src/main.d:586 bool main.initSyncEngine(sync.SyncEngine) [0x5ef664]
src/main.d:334 _Dmain [0x5ee3ff]
```
```
(dmd-2.085.0)[alex@centos7full onedrive-pr473]$ ./onedrive --confdir '~/.config/onedrive-preining' --synchronize --verbose 
Using Config Dir: /home/alex/.config/onedrive-preining
Initializing the OneDrive API ...
Opening the item database ...
All operations will be performed in: /home/alex/OneDrivePreining
Initializing the Synchronization Engine ...
Account Type: business
Default Drive ID: b!eRoTwf855UO30XBlm3Yz-NYBVmMu24pHvgrM4OUip-8F1LO13vWcT5o0bEQr4zit
Default Root ID: 01WOGXO2N6Y2GOVW7725BZO354PWSELRRZ
Remaining Free Space: 1099309802196
Fetching details for OneDrive Root
OneDrive returned a 'HTTP 504 Gateway Timeout Error' - gracefully handling error
std.json.JSONException@std/json.d(540): Key not found: id
----------------
/home/alex/dlang/dmd-2.085.0/linux/bin64/../../src/phobos/std/exception.d:515 pure @safe void std.exception.bailOut!(std.json.JSONException).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x5dba93]
??:? pure @safe inout(std.json.JSONValue)* std.exception.enforce!(std.json.JSONException).enforce!(inout(std.json.JSONValue)*).enforce(inout(std.json.JSONValue)*, lazy const(char)[], immutable(char)[], ulong) [0x678802]
??:? inout pure ref @safe inout(std.json.JSONValue) std.json.JSONValue.opIndex(immutable(char)[]) [0x631181]
src/sync.d:100 itemdb.Item sync.makeItem(ref const(std.json.JSONValue)) [0x5fe970]
src/sync.d:552 void sync.SyncEngine.checkDatabaseForOneDriveRoot() [0x601174]
src/sync.d:311 void sync.SyncEngine.init() [0x5ff982]
src/main.d:586 bool main.initSyncEngine(sync.SyncEngine) [0x5ef664]
src/main.d:334 _Dmain [0x5ee3ff]
```