### PR TITLE
./configure creates incorrect Makefile for RHEL/CentOS 7 platform (Issue #495)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,10 +52,18 @@ endif
 DCFLAGS += $(NOTIF_VERSIONS)
 endif
 
-system_unit_files = systemd.units/onedrive@.service
-user_unit_files = systemd.units/onedrive.service
+system_unit_files = systemd.units/onedrive.service
+user_unit_files = systemd.units/onedrive@.service
 
 DOCFILES = README.md README.Office365.md config LICENSE CHANGELOG.md
+
+ifneq ("$(wildcard /etc/redhat-release)","")
+RHEL = $(shell cat /etc/redhat-release | grep -E "(Red Hat Enterprise Linux Server|CentOS)" | wc -l)
+RHEL_VERSION = $(shell rpm --eval "%{centos_ver}")
+else
+RHEL = 0
+RHEL_VERSION = 0
+endif
 
 SOURCES = \
 	src/config.d \
@@ -99,8 +107,13 @@ install: all
 	for i in $(DOCFILES) ; do $(INSTALL) -D -m 644 $$i $(DESTDIR)$(docdir)/$$i ; done
 ifeq ($(HAVE_SYSTEMD),yes)
 	$(INSTALL) -d -o root -g root -m 0755 $(DESTDIR)$(systemduserunitdir) $(DESTDIR)$(systemdsystemunitdir)
+ifeq ($(RHEL),1)
+	$(INSTALL) -m 0644 $(system_unit_files) $(DESTDIR)$(systemdsystemunitdir)
+	$(INSTALL) -m 0644 $(user_unit_files) $(DESTDIR)$(systemdsystemunitdir)
+else
 	$(INSTALL) -m 0644 $(system_unit_files) $(DESTDIR)$(systemdsystemunitdir)
 	$(INSTALL) -m 0644 $(user_unit_files) $(DESTDIR)$(systemduserunitdir)
+endif	
 endif
 ifeq ($(COMPLETIONS),yes)
 	$(INSTALL) -D -m 644 completions/complete.zsh $(DESTDIR)$(ZSH_COMPLETION_DIR)/_onedrive

--- a/Makefile.in
+++ b/Makefile.in
@@ -127,11 +127,10 @@ uninstall:
 	rm -f $(DESTDIR)$(sysconfdir)/logrotate.d/onedrive
 ifeq ($(HAVE_SYSTEMD),yes)
 ifeq ($(RHEL),1)
-	for i in $(system_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
-	for i in $(user_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
+	rm -f $(DESTDIR)$(systemdsystemunitdir)/onedrive*.service
 else
-	for i in $(system_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
-	for i in $(user_unit_files) ; do rm -f $(DESTDIR)$(systemduserunitdir)/$$i ; done
+	rm -f $(DESTDIR)$(systemdsystemunitdir)/onedrive*.service
+	rm -f $(DESTDIR)$(systemduserunitdir)/onedrive*.service
 endif
 endif
 	for i in $(DOCFILES) ; do rm -f $(DESTDIR)$(DOCDIR)/$$i ; done

--- a/Makefile.in
+++ b/Makefile.in
@@ -52,8 +52,8 @@ endif
 DCFLAGS += $(NOTIF_VERSIONS)
 endif
 
-system_unit_files = systemd.units/onedrive.service
-user_unit_files = systemd.units/onedrive@.service
+system_unit_files = systemd.units/onedrive@.service
+user_unit_files = systemd.units/onedrive.service
 
 DOCFILES = README.md README.Office365.md config LICENSE CHANGELOG.md
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -126,8 +126,13 @@ uninstall:
 	rm -f $(DESTDIR)$(mandir)/man1/onedrive.1
 	rm -f $(DESTDIR)$(sysconfdir)/logrotate.d/onedrive
 ifeq ($(HAVE_SYSTEMD),yes)
+ifeq ($(RHEL),1)
+	for i in $(system_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
+	for i in $(user_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
+else
 	for i in $(system_unit_files) ; do rm -f $(DESTDIR)$(systemdsystemunitdir)/$$i ; done
 	for i in $(user_unit_files) ; do rm -f $(DESTDIR)$(systemduserunitdir)/$$i ; done
+endif
 endif
 	for i in $(DOCFILES) ; do rm -f $(DESTDIR)$(DOCDIR)/$$i ; done
 ifeq ($(COMPLETIONS),yes)


### PR DESCRIPTION
* Fix incorrect systemd unit file allocation
* Add check for RHEL/CentOS system as there is no user unit dir on those platforms