### PR TITLE
Check to ensure that file downloaded and is present locally before setting times (Issue #496)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1093,11 +1093,20 @@ final class SyncEngine
 				downloadFailed = true;
 				return;
 			}
-			setTimes(path, item.mtime, item.mtime);
+			// file has to have downloaded in order to set the times / data for the file
+			if (exists(path)) {
+				setTimes(path, item.mtime, item.mtime);
+			} else {
+				log.error("ERROR: File failed to download. Increase logging verbosity to determine why.");
+				downloadFailed = true;
+				return;
+			}
 		}
 		
-		writeln("done.");
-		log.fileOnly("Downloading file ", path, " ... done.");
+		if (!downloadFailed) {
+			writeln("done.");
+			log.fileOnly("Downloading file ", path, " ... done.");
+		}
 	}
 
 	// returns true if the given item corresponds to the local one


### PR DESCRIPTION
* Check to see if the file was actually downloaded before attempting to set the times on the file.
* If file is not local, download failed