### PR TITLE
Enhance error message for curl CA SSL issue (Issue #507)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -202,7 +202,8 @@ int main(string[] args)
 		online = testNetwork();
 	} catch (CurlException e) {
 		// No network connection to OneDrive Service
-		log.error("No network connection to Microsoft OneDrive Service");
+		log.error("Cannot connect to Microsoft OneDrive Service");
+		log.error("Reason: ", e.msg);
 		if (!cfg.getValueBool("monitor")) {
 			return EXIT_FAILURE;
 		}


### PR DESCRIPTION
* Enhance error message when unable to connect to Microsoft OneDrive service when the CA SSL certificate has issues