### PR TITLE
Handle OneDrive API response when cTag key is missing (Issue #512)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ A clear and concise description of what the bug is.
 
 **Note:** If curl version is >= 7.62.0 please generate a full debug log as per [https://github.com/abraunegg/onedrive/wiki/Generate-debug-log-for-support](https://github.com/abraunegg/onedrive/wiki/Generate-debug-log-for-support) and email to support@mynas.com.au
 
-Once the full degug log has been generated & emailed, please retry your sync by adding `--force-http-1.1`. If this is successful, please advise in issue ticket that `--force-http-1.1` was sucessful in resolving your issue.
+Once the full debug log has been generated & emailed, please retry your sync by adding `--force-http-1.1`. If this is successful, please advise in issue ticket that `--force-http-1.1` was successful in resolving your issue.
 
 **To Reproduce**
 Steps to reproduce the behavior if not causing an application crash:

--- a/src/sync.d
+++ b/src/sync.d
@@ -1531,8 +1531,13 @@ final class SyncEngine
 								writeln("done.");
 							}
 							log.fileOnly("Uploading modified file ", path, " ... done.");
-							// use the cTag instead of the eTag because OneDrive may update the metadata of files AFTER they have been uploaded via simple upload
-							eTag = response["cTag"].str;
+							if ("cTag" in response) {
+								// use the cTag instead of the eTag because OneDrive may update the metadata of files AFTER they have been uploaded via simple upload
+								eTag = response["cTag"].str;
+							} else {
+								// cTag missing in response, use the original item.etag
+								eTag = item.eTag;
+							}
 						} else {
 							// we are --dry-run - simulate the file upload
 							writeln("done.");


### PR DESCRIPTION
* Handle response from OneDrive when cTag JSON elements are missing when uploading a locally modified file