### PR TITLE
get rid of forced root necessity during installation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,14 +100,13 @@ onedrive: version $(SOURCES)
 	$(DC) $(DCFLAGS) $(addprefix -L,$(curl_LIBS)) $(addprefix -L,$(sqlite_LIBS)) $(addprefix -L,$(notify_LIBS)) -L-ldl $(SOURCES) -of$@
 
 install: all
-	$(INSTALL) -d -o root -g users -m 0775 $(DESTDIR)/var/log/onedrive
 	$(INSTALL) -D onedrive $(DESTDIR)$(bindir)/onedrive
 	$(INSTALL) -D onedrive.1 $(DESTDIR)$(mandir)/man1/onedrive.1
 	$(INSTALL) -D -m 644 contrib/logrotate/onedrive.logrotate $(DESTDIR)$(sysconfdir)/logrotate.d/onedrive
 	mkdir -p $(DESTDIR)$(docdir)
 	$(INSTALL) -D -m 644 $(DOCFILES) $(DESTDIR)$(docdir)
 ifeq ($(HAVE_SYSTEMD),yes)
-	$(INSTALL) -d -o root -g root -m 0755 $(DESTDIR)$(systemduserunitdir) $(DESTDIR)$(systemdsystemunitdir)
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(systemduserunitdir) $(DESTDIR)$(systemdsystemunitdir)
 ifeq ($(RHEL),1)
 	$(INSTALL) -m 0644 $(system_unit_files) $(DESTDIR)$(systemdsystemunitdir)
 	$(INSTALL) -m 0644 $(user_unit_files) $(DESTDIR)$(systemdsystemunitdir)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,11 +134,18 @@ onedrive --synchronize --verbose
 ### Client Activity Log
 When running onedrive all actions can be logged to a separate log file. This can be enabled by using the `--enable-logging` flag. By default, log files will be written to `/var/log/onedrive/`
 
-**Note:** You will need to ensure your user has the applicable permissions to write to this directory or the following warning will be printed:
+**Note:** You will need to ensure the existence of this directory, and that your user has the applicable permissions to write to this directory or the following warning will be printed:
 ```text
 Unable to access /var/log/onedrive/
 Please manually create '/var/log/onedrive/' and set appropriate permissions to allow write access
 The requested client activity log will instead be located in the users home directory
+```
+
+On many systems this can be achieved by
+```text
+mkdir /var/log/onedrive
+chown root.users /var/log/onedrive
+chmod 0775 /var/log/onedrive
 ```
 
 All logfiles will be in the format of `%username%.onedrive.log`, where `%username%` represents the user who ran the client.


### PR DESCRIPTION
Currently, we require installation to be carried out by root:
- we create /var/log/onedrive with ownership root.users
- we create the systemd unit directories with root.root

Remove the creation of /var/log/onedrive directory. The default is
not to log, and fall back to logging to home directory. It is
the obligation of the system administrator to create these
directory. Furthermore, we don't know whether the group "users"
is actually present.

Remove the owner/group specification from the directory creation.
We install the actual service files without owner/group specs
anyway.

Update USAGE.md to document this.