### PR TITLE
fix broken autoconf code for --enable-XXX options

### DIFF
--- a/configure
+++ b/configure
@@ -631,6 +631,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -714,6 +715,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -966,6 +968,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1103,7 +1114,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1256,6 +1267,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2312,7 +2324,12 @@ HAVE_SYSTEMD=$havesystemd
 
 # Check whether --enable-notifications was given.
 if test "${enable_notifications+set}" = set; then :
-  enableval=$enable_notifications; enable_notifications=yes
+  enableval=$enable_notifications;
+fi
+
+
+if test "x$enable_notifications" = "xyes"; then :
+  enable_notifications=yes
 else
   enable_notifications=no
 fi
@@ -2398,7 +2415,12 @@ NOTIFICATIONS=$enable_notifications
 
 # Check whether --enable-completions was given.
 if test "${enable_completions+set}" = set; then :
-  enableval=$enable_completions; enable_completions=yes
+  enableval=$enable_completions;
+fi
+
+
+if test "x$enable_completions" = "xyes"; then :
+  enable_completions=yes
 else
   enable_completions=no
 fi
@@ -2466,16 +2488,18 @@ fi
 
 fi
 
-
 # Check whether --enable-debug was given.
 if test "${enable_debug+set}" = set; then :
-  enableval=$enable_debug; DEBUG=yes
+  enableval=$enable_debug;
+fi
+
+if test "x$enable_debug" = "xyes"; then :
+  DEBUG=yes
 
 else
   DEBUG=no
 
 fi
-
 
 ac_config_files="$ac_config_files Makefile contrib/pacman/PKGBUILD contrib/spec/onedrive.spec onedrive.1 contrib/systemd/onedrive.service contrib/systemd/onedrive@.service"
 

--- a/configure.ac
+++ b/configure.ac
@@ -117,10 +117,10 @@ dnl
 dnl Notification support
 dnl only check for libnotify if --enable-notifications is given
 AC_ARG_ENABLE(notifications,
-       [AS_HELP_STRING([--enable-notifications],
-          [Enable desktop notifications via libnotify])],
-       enable_notifications=yes,
-       enable_notifications=no)
+  AS_HELP_STRING([--enable-notifications], [Enable desktop notifications via libnotify]))
+
+AS_IF([test "x$enable_notifications" = "xyes"], [enable_notifications=yes], [enable_notifications=no])
+
 dnl if --enable-notifications was given, check for libnotify, and disable if not found
 dnl otherwise substitute the notifu
 AS_IF([test "x$enable_notifications" = "xyes"],
@@ -131,11 +131,11 @@ AC_SUBST([NOTIFICATIONS],$enable_notifications)
 dnl
 dnl Completion support
 dnl First determine whether completions are requested, pass that to Makefile
-AC_ARG_ENABLE(completions,
-       [AS_HELP_STRING([--enable-completions],
-          [Install shell completions for bash and zsh])],
-       enable_completions=yes,
-       enable_completions=no)
+AC_ARG_ENABLE([completions],
+  AS_HELP_STRING([--enable-completions], [Install shell completions for bash and zsh]))
+
+AS_IF([test "x$enable_completions" = "xyes"], [enable_completions=yes], [enable_completions=no])
+
 AC_SUBST([COMPLETIONS],$enable_completions)
 
 
@@ -164,14 +164,11 @@ AS_IF([test "x$enable_completions" = "xyes"],[
   AC_SUBST([ZSH_COMPLETION_DIR], $with_zsh_completion_dir)
   ])
 
-
 dnl
 dnl Debug support
 AC_ARG_ENABLE(debug,
-       [AS_HELP_STRING([--enable-debug],
-          [Pass debug option to the compiler])],
-       AC_SUBST([DEBUG],yes),
-       AC_SUBST([DEBUG],no))
+  AS_HELP_STRING([--enable-debug], [Pass debug option to the compiler]))
+AS_IF([test "x$enable_debug" = "xyes"], AC_SUBST([DEBUG],yes), AC_SUBST([DEBUG],no))
 
 dnl generate necessary files
 AC_CONFIG_FILES([


### PR DESCRIPTION
Currently, using --disable-XXX is not working, because the
arguments of AC_ARG_ENABLE are only for presence versus absence,
not for positive versus negative. Fix this by properly using
AS_IF on the value set.