### PR TITLE
fix building without git available

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -141,7 +141,7 @@ endif
 
 version:
 	if [ -f .git/HEAD ] ; then \
-		echo $(shell git describe --tags) > version ; \
+		git describe --tags > version ; \
 	else \
 		echo $(version) > version ; \
 	fi


### PR DESCRIPTION
The current code requires git even if there is not .git directory.
Switch to piping the output of git directly to the version file,
which makes sure that it is not called during if evaluation.

Report and patch thanks to Sebastian Graf (sgraf812)