### PR TITLE
Handle OneDrive error response on creating upload session

### DIFF
--- a/src/upload.d
+++ b/src/upload.d
@@ -48,7 +48,9 @@ struct UploadSession
 		} catch (OneDriveException e) {
 			// there was an error
 			log.vlog("Create file upload session failed ... skipping file upload");
-			return;
+			// return upload() will return a JSONValue response, create an empty JSONValue response to return
+			JSONValue response;
+			return response;
 		}
 	}
 

--- a/src/upload.d
+++ b/src/upload.d
@@ -39,10 +39,17 @@ struct UploadSession
 				])
 			];
 		
-		session = onedrive.createUploadSession(parentDriveId, parentId, filename, eTag, fileSystemInfo);
-		session["localPath"] = localPath;
-		save();
-		return upload();
+		try {
+			// Try to create the upload session for this file
+			session = onedrive.createUploadSession(parentDriveId, parentId, filename, eTag, fileSystemInfo);
+			session["localPath"] = localPath;
+			save();
+			return upload();
+		} catch (OneDriveException e) {
+			// there was an error
+			log.vlog("Create file upload session failed ... skipping file upload");
+			return;
+		}
 	}
 
 	/* Restore the previous upload session.


### PR DESCRIPTION
* Add a try block when attempting to create the upload session and handle if there is an error response from OneDrive