### PR TITLE
Add download size & hash check (Issue #558)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -320,7 +320,7 @@ final class OneDriveApi
 		const(char)[] url;
 		//		string driveByIdUrl = "https://graph.microsoft.com/v1.0/drives/";
 		url = driveByIdUrl ~ driveId ~ "/items/" ~ id;
-		url ~= "?select=size,malware";
+		url ~= "?select=size,malware,file";
 		return get(url);
 	}
 	

--- a/src/sync.d
+++ b/src/sync.d
@@ -1186,7 +1186,7 @@ final class SyncEngine
 				// does the file hash OneDrive reports match what we have locally?
 				string quickXorHash = computeQuickXorHash(path);
 				if ((getSize(path) == fileSize) || (OneDriveFileHash == quickXorHash)) {
-					// downloaded fileSize = reported file size
+					// downloaded matches either size or hash
 					setTimes(path, item.mtime, item.mtime);
 				} else {
 					// size error?

--- a/src/sync.d
+++ b/src/sync.d
@@ -79,6 +79,11 @@ private bool hasId(const ref JSONValue item)
 	return ("id" in item) != null;
 }
 
+private bool hasQuickXorHash(const ref JSONValue item)
+{
+	return ("quickXorHash" in item["file"]["hashes"]) != null;
+}
+
 private bool isDotFile(string path)
 {
 	// always allow the root
@@ -1133,9 +1138,11 @@ final class SyncEngine
 		if (!dryRun) {
 			ulong fileSize = 0;
 			string OneDriveFileHash;
-			if ( (hasFileSize(fileDetails)) && (fileDetails.object()) ) {
+			if ( (hasFileSize(fileDetails)) && (hasQuickXorHash(fileDetails)) && (fileDetails.object()) ) {
+				// fileDetails is a valid JSON object with the elements we need
 				// Set the file size from the returned data
 				fileSize = fileDetails["size"].integer;
+				OneDriveFileHash = fileDetails["file"]["hashes"]["quickXorHash"].str;
 			} else {
 				// Issue #540 handling
 				log.vdebug("ERROR: onedrive.getFileDetails call returned a OneDriveException error");
@@ -1143,10 +1150,6 @@ final class SyncEngine
 				return;
 			}
 			
-			if ("quickXorHash" in fileDetails["file"]["hashes"]) {
-				OneDriveFileHash = fileDetails["file"]["hashes"]["quickXorHash"].str;
-			}
-		
 			try {
 				onedrive.downloadById(item.driveId, item.id, path, fileSize);
 			} catch (OneDriveException e) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -1174,7 +1174,18 @@ final class SyncEngine
 			}
 			// file has to have downloaded in order to set the times / data for the file
 			if (exists(path)) {
-				setTimes(path, item.mtime, item.mtime);
+				// A 'file' was downloaded - does what we downloaded = reported filesize?
+				if (getSize(path) == fileSize) {
+					// downloaded fileSize = reported file size
+					setTimes(path, item.mtime, item.mtime);
+				} else {
+					// downloaded file size does not match
+					log.error("ERROR: File download size mis-match. Increase logging verbosity to determine why.");
+					// we do not want this local file to remain on the local file system
+					safeRemove(path);	
+					downloadFailed = true;
+					return;
+				}
 			} else {
 				log.error("ERROR: File failed to download. Increase logging verbosity to determine why.");
 				downloadFailed = true;

--- a/src/sync.d
+++ b/src/sync.d
@@ -1196,7 +1196,7 @@ final class SyncEngine
 					}
 					// hash error?
 					if (OneDriveFileHash != quickXorHash) {
-						// downloaded file size does not match
+						// downloaded file hash does not match
 						log.error("ERROR: File download hash mis-match. Increase logging verbosity to determine why.");
 					}	
 					// we do not want this local file to remain on the local file system


### PR DESCRIPTION
* Check if the file that was downloaded to local disk equals the reported size of the file on OneDrive. If size or hash do not match, report an error and remove the local file as it is most likely corrupt.