### PR TITLE
Fix issue 567

### DIFF
--- a/contrib/systemd/onedrive.service.in
+++ b/contrib/systemd/onedrive.service.in
@@ -8,6 +8,7 @@ Wants=network-online.target
 ExecStart=@prefix@/bin/onedrive --monitor
 Restart=on-failure
 RestartSec=3
+RestartPreventExitStatus=3
 
 [Install]
 WantedBy=default.target

--- a/contrib/systemd/onedrive@.service.in
+++ b/contrib/systemd/onedrive@.service.in
@@ -10,6 +10,7 @@ User=%i
 Group=users
 Restart=on-failure
 RestartSec=3
+RestartPreventExitStatus=3
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main.d
+++ b/src/main.d
@@ -10,6 +10,8 @@ static import log;
 OneDriveApi oneDrive;
 ItemDatabase itemDb;
 
+const int EXIT_UNAUTHORIZED = 3;
+
 enum MONITOR_LOG_SILENT = 2;
 enum MONITOR_LOG_QUIET  = 1;
 enum LOG_NORMAL = 0;
@@ -220,7 +222,7 @@ int main(string[] args)
 		log.error("Could not initialize the OneDrive API");
 		// workaround for segfault in std.net.curl.Curl.shutdown() on exit
 		oneDrive.http.shutdown();
-		return EXIT_FAILURE;
+		return EXIT_UNAUTHORIZED;
 	}
 	
 	// if --synchronize or --monitor not passed in, exit & display help


### PR DESCRIPTION
This pull would change the exit code for onedrive when the api for onedrive was not authenticated from the generic 1 to 3 to allow the exit code to be leveraged by init systems, and then also implements leveraging this exit code in the systemd services to prevent the service from looping endlessly if the user running it hasn't authenticated onedrive first.

This is created in response to discussion about the `Restart=on-failure` discussion in issue #567 

Has been tested on F30 
```
uname -a
Linux grapefruit-lacroix-local 5.1.15-300.fc30.x86_64 #1 SMP Tue Jun 25 14:07:22 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```

```
$ onedrive --version
onedrive v2.3.7-2-g80675aa
```

Service output trying to run service as unauthorized root user:
```
$ systemctl status onedrive.service 
● onedrive.service - OneDrive Free Client
   Loaded: loaded (/usr/lib/systemd/system/onedrive.service; disabled; vendor preset: disabled)
   Active: activating (auto-restart) (Result: exit-code) since Fri 2019-07-05 16:00:55 CDT; 804ms ago
     Docs: https://github.com/abraunegg/onedrive
  Process: 10411 ExecStart=/usr/local/bin/onedrive --monitor (code=exited, status=3)
 Main PID: 10411 (code=exited, status=3)
```

```
$ journalctl --unit=onedrive | tail
systemd[1]: Started OneDrive Free Client.
onedrive[16299]: Authorize this app visiting:
onedrive[16299]: https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=22c49a0d-d21c-4792-aed1-8f163c982546&scope=files.readwrite%20files.readwrite.all%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient
onedrive[16299]: Enter the response uri: Invalid uri
onedrive[16299]: Could not initialize the OneDrive API
systemd[1]: onedrive.service: Main process exited, code=exited, status=3/NOTIMPLEMENTED
systemd[1]: onedrive.service: Failed with result 'exit-code'.
```

Service output running service as user that has authenticated:
```
$ systemctl status --user onedrive.service 
● onedrive.service - OneDrive Free Client
   Loaded: loaded (/usr/lib/systemd/user/onedrive.service; enabled; vendor preset: enabled)
   Active: active (running) since Fri 2019-07-05 16:00:10 CDT; 7min ago
     Docs: https://github.com/abraunegg/onedrive
 Main PID: 10262 (onedrive)
   CGroup: /user.slice/user-1000.slice/user@1000.service/onedrive.service
           └─10262 /usr/local/bin/onedrive --monitor

Jul 05 16:00:10 grapefruit-lacroix-local systemd[1888]: Started OneDrive Free Client.
Jul 05 16:00:10 grapefruit-lacroix-local onedrive[10262]: Initializing the Synchronization Engine ...
Jul 05 16:00:11 grapefruit-lacroix-local onedrive[10262]: Initializing monitor ...
Jul 05 16:00:11 grapefruit-lacroix-local onedrive[10262]: OneDrive monitor interval (seconds): 45
Jul 05 16:04:01 grapefruit-lacroix-local onedrive[10262]: Syncing changes from OneDrive ...
```
