### PR TITLE
Update entrypoint.sh

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -16,7 +16,7 @@ fi
 # Create new user using target UID
 if ! oduser="$(getent passwd $ONEDRIVE_UID)"; then
   oduser='onedrive'
-  useradd "${oduser}" -u $ONEDRIVE_UID -g $ONEDRIVE_GID
+  useradd -m "${oduser}" -u $ONEDRIVE_UID -g $ONEDRIVE_GID
 else
   oduser="${oduser%%:*}"
   usermod -g "${odgroup}" "${oduser}"


### PR DESCRIPTION
Included the flag "-m" to create the home directory when creating the user.

Required when passing parameters to the docker container:
docker run -it --rm -v /.OneDrive:/onedrive onedrive -h
++ stat /onedrive/data -c %u
+ ONEDRIVE_UID=1000
++ stat /onedrive/data -c %g
+ ONEDRIVE_GID=1000
++ getent group 1000
+ odgroup=
+ odgroup=onedrive
+ groupadd onedrive -g 1000
++ getent passwd 1000
+ oduser=
+ oduser=onedrive
+ useradd onedrive -u 1000 -g 1000
Creating mailbox file: No such file or directory
+ chown onedrive:onedrive /onedrive/ /onedrive/conf
+ ARGS=(--monitor --verbose --confdir /onedrive/conf --syncdir /onedrive/data)
+ '[' 1 -gt 0 ']'
+ ARGS=("${@}")
+ exec gosu onedrive /usr/local/bin/onedrive -h
std.file.FileException@std/file.d(3011): /home/onedrive: Permission denied