### PR TITLE
Fixed to work with "sudo docker run"

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set +H -xeuo pipefail
 
-ONEDRIVE_UID=$(stat /onedrive/data -c '%u')
-ONEDRIVE_GID=$(stat /onedrive/data -c '%g')
+: ${ONEDRIVE_UID:=$(stat /onedrive/data -c '%u')}
+: ${ONEDRIVE_GID:=$(stat /onedrive/data -c '%g')}
 
 # Create new group using target GID
 if ! odgroup="$(getent group $ONEDRIVE_GID)"; then


### PR DESCRIPTION
Can set env from outside.

usage:
$ sudo docker run -it --restart unless-stopped --name onedrive -v onedrive_conf:/onedrive/conf -v "${onedriveDir}:/onedrive/data" -e ONEDRIVE_UID=1000 -e ONEDRIVE_GID=1000 driveone/onedrive
