### PR TITLE
Fix docker build error on stretch

### DIFF
--- a/contrib/docker/Dockerfile-stretch
+++ b/contrib/docker/Dockerfile-stretch
@@ -1,7 +1,7 @@
 # -*-Dockerfile-*-
 FROM debian:stretch
 RUN apt update && \
-    apt install -y build-essential curl libcurl4-openssl-dev libsqlite3-dev pkg-config
+    apt install -y build-essential curl libcurl4-openssl-dev libsqlite3-dev pkg-config git
 RUN curl -fsS -o install.sh https://dlang.org/install.sh && \
     bash install.sh dmd
 COPY . /usr/src/onedrive


### PR DESCRIPTION
I was told there was no git.

/bin/sh: 2: git: not found
make: *** [version] Error 127
Makefile:143: recipe for target 'version' failed
The command '/bin/sh -c . "$(bash install.sh -a)" &&     cd /usr/src/onedrive/ &&     ./configure &&     make clean &&     make &&     make install' returned a non-zero code: 2
