### PR TITLE
Update itemdb.d - root directory not found anymore

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -214,7 +214,7 @@ final class ItemDatabase
 		Item currItem = { driveId: rootDriveId };
 		
 		// Issue https://github.com/abraunegg/onedrive/issues/578
-		if (startsWith(path, "./")) {
+		if (startsWith(path, "./") || path == ".") {
 			// Need to remove the . from the path prefix
 			path = "root/" ~ path.chompPrefix(".");
 		} else {
@@ -249,7 +249,7 @@ final class ItemDatabase
 		Item currItem = { driveId: rootDriveId };
 		
 		// Issue https://github.com/abraunegg/onedrive/issues/578
-		if (startsWith(path, "./")) {
+		if (startsWith(path, "./") || path == ".") {
 			// Need to remove the . from the path prefix
 			path = "root/" ~ path.chompPrefix(".");
 		} else {


### PR DESCRIPTION
The root path is not found anymore after inserting the if statement, when you create a new path in the root folder.

Monitor directory: ./test16
[M] Directory created: ./test16
Uploading differences of ./test16
Uploading new items of ./test16
OneDrive Client requested to create remote path: ./test16
The requested directory to create was not found on OneDrive - creating remote directory: ./test16
Cannot create remote directory: The parent item id is not in the database