### PR TITLE
Resolve file / folder upload issues (Issue #598)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -780,7 +780,8 @@ final class OneDriveApi
 			//	412 - Precondition Failed
 			case 412:
 				log.vlog("OneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error");
-				break;
+				// Throw this as a specific exception so this is caught when performing uploadLastModifiedTime
+				throw new OneDriveException(http.statusLine.code, http.statusLine.reason, response);
 				
 			// Server side (OneDrive) Errors
 			//  500 - Internal Server Error

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -627,9 +627,8 @@ final class OneDriveApi
 		try {
 			json = content.parseJSON();
 		} catch (JSONException e) {
-			e.msg ~= "\n";
-			e.msg ~= content;
-			throw e;
+			// Log that a JSON Exception was caught, dont output the HTML response from OneDrive
+			log.vdebug("JSON Exception caught when performing HTTP operations - use --debug-https to diagnose further");
 		}
 		return json;
 	}


### PR DESCRIPTION
* Without this throw, `uploadLastModifiedTime` fails to catch that the 412 error was returned, thus, the retry with a null cTag / eTag is not performed which leads to 'OneDrive response missing required 'id' element' being generated.
* Fix 'Unexpected character '<'. (Line 1:1)' when OneDrive has an exception error and does not return a valid JSON