### PR TITLE
main.d - log but do not notify sync engine init

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -314,7 +314,7 @@ int main(string[] args)
 	selectiveSync.setFileMask(cfg.getValueString("skip_file"));
 		
 	// Initialize the sync engine
-	log.logAndNotify("Initializing the Synchronization Engine ...");
+	log.log("Initializing the Synchronization Engine ...");
 	auto sync = new SyncEngine(cfg, oneDrive, itemDb, selectiveSync);
 	
 	try {


### PR DESCRIPTION
Don't spit out "Initializing the Synchronization Engine ..." to standard output.
This just makes it harder to combine output with other programs.

This was mentioned in https://github.com/abraunegg/onedrive/issues/611
when I suggested supporting

    xdg-open $(onedrive --get-file-link /redacted/Document.docx)

which works better with this change.