### PR TITLE
Remove double logging output for a 412 error

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -791,7 +791,6 @@ final class OneDriveApi
 			
 			//	412 - Precondition Failed
 			case 412:
-				log.vlog("OneDrive returned a 'HTTP 412 - Precondition Failed' - gracefully handling error");
 				// Throw this as a specific exception so this is caught when performing sync.uploadLastModifiedTime
 				throw new OneDriveException(http.statusLine.code, http.statusLine.reason, response);
 				


### PR DESCRIPTION
* remove this logging output as it creates a double entry - once here and once in sync.d (sync.uploadLastModifiedTime)