### PR TITLE
Fix 'key not found: name' when checking if deleted item was synced (Issue #644)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -871,13 +871,15 @@ final class SyncEngine
 			// Is this item id in the database?
 			if (itemdb.idInLocalDatabase(item.driveId, item.id)){
 				// item exists in database, most likely moved out of scope for current client configuration
-				log.vdebug("This item was previously synced / seen by the client");
-				if (selectiveSync.isPathExcluded(driveItem["parentReference"]["name"].str)) {
-					// Previously synced item is now out of scope as it has been moved out of what is included in sync_list
-					log.vdebug("This previously synced item is now excluded from being synced due to sync_list exclusion");
-					// flag to delete local file as it now is no longer in sync with OneDrive
-					log.vdebug("Flagging to delete item locally");
-					idsToDelete ~= [item.driveId, item.id];
+				log.vdebug("This item was previously synced / seen by the client");				
+				if (("name" in driveItem["parentReference"]) != null) {
+					if (selectiveSync.isPathExcluded(driveItem["parentReference"]["name"].str)) {
+						// Previously synced item is now out of scope as it has been moved out of what is included in sync_list
+						log.vdebug("This previously synced item is now excluded from being synced due to sync_list exclusion");
+						// flag to delete local file as it now is no longer in sync with OneDrive
+						log.vdebug("Flagging to delete item locally");
+						idsToDelete ~= [item.driveId, item.id];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* Fix searching for 'name' when deleting a synced item, if the OneDrive API does not return the expected details in the API call