### PR TITLE
Fix crash when resume_upload file is not a valid JSON

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -517,20 +517,20 @@ int main(string[] args)
 	selectiveSync.setFileMask(cfg.getValueString("skip_file"));
 		
 	// Initialize the sync engine
-	if (cfg.getValueString("get_file_link") == "") {
-		// Print out that we are initializing the engine only if we are not grabbing the file link
-		log.logAndNotify("Initializing the Synchronization Engine ...");
-	}
 	auto sync = new SyncEngine(cfg, oneDrive, itemDb, selectiveSync);
-	
 	try {
 		if (!initSyncEngine(sync)) {
 			oneDrive.http.shutdown();
 			return EXIT_FAILURE;
+		} else {
+			if (cfg.getValueString("get_file_link") == "") {
+				// Print out that we are initializing the engine only if we are not grabbing the file link
+				log.logAndNotify("Initializing the Synchronization Engine ...");
+			}
 		}
 	} catch (CurlException e) {
 		if (!cfg.getValueBool("monitor")) {
-			log.log("\nNo internet connection.");
+			log.log("\nNo Internet connection.");
 			oneDrive.http.shutdown();
 			return EXIT_FAILURE;
 		}

--- a/src/sync.d
+++ b/src/sync.d
@@ -1344,7 +1344,12 @@ final class SyncEngine
 			
 			// handle changed time
 			if (newItem.type == ItemType.file && oldItem.mtime != newItem.mtime) {
-				setTimes(newPath, newItem.mtime, newItem.mtime);
+				try {
+					setTimes(newPath, newItem.mtime, newItem.mtime);
+				} catch (FileException e) {
+					// display the error message
+					displayFileSystemErrorMessage(e.msg);
+				}
 			}
 		} 
 	}
@@ -1459,7 +1464,12 @@ final class SyncEngine
 				if ((getSize(path) == fileSize) || (OneDriveFileHash == quickXorHash) || (OneDriveFileHash == sha1Hash)) {
 					// downloaded matches either size or hash
 					log.vdebug("Downloaded file matches reported size and or reported file hash");
-					setTimes(path, item.mtime, item.mtime);
+					try {
+						setTimes(path, item.mtime, item.mtime);
+					} catch (FileException e) {
+						// display the error message
+						displayFileSystemErrorMessage(e.msg);
+					}
 				} else {
 					// size error?
 					if (getSize(path) != fileSize) {

--- a/src/upload.d
+++ b/src/upload.d
@@ -62,7 +62,16 @@ struct UploadSession
 	{
 		if (exists(sessionFilePath)) {
 			log.vlog("Trying to restore the upload session ...");
-			session = readText(sessionFilePath).parseJSON();
+			// We cant use JSONType.object check, as this is currently a string
+			// We cant use a try & catch block, as it does not catch std.json.JSONException
+			auto sessionFileText = readText(sessionFilePath);
+			if(canFind(sessionFileText,"@odata.context")) {
+				session = readText(sessionFilePath).parseJSON();
+			} else {
+				log.vlog("Upload session resume data is invalid");
+				remove(sessionFilePath);
+				return false;
+			}
 			
 			// Check the session resume file for expirationDateTime
 			if ("expirationDateTime" in session){


### PR DESCRIPTION
* Validate that there is JSON data in the string before the string is read via parseJSON()