### PR TITLE
Fixing typo in USAGE.md

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,7 +9,7 @@ Additionally, if you are using a 'config' file within your configuration directo
 
 **Invalid configuration:**
 ```text
-skip_file = "= .*|~*"
+skip_file = ".*|~*"
 ```
 **Minimum valid configuration:**
 ```text


### PR DESCRIPTION
There is a typo in the settings for an invalid config. The original file from the *skilion* project looks like this:
`skip_file = ".*|~*"`. Makes it easier to understand what to change in case of an upgrade in my opinion.
Even if it's an example of a bad config.