### PR TITLE
Fix handling of skip_dir, skip_file & sync_list config option handling

### DIFF
--- a/src/monitor.d
+++ b/src/monitor.d
@@ -83,7 +83,7 @@ final class Monitor
 			if (selectiveSync.isFileNameExcluded(baseName(dirname))) {
 				return;
 			}
-			if (selectiveSync.isPathExcluded(buildNormalizedPath(dirname))) {
+			if (selectiveSync.isPathExcludedViaSyncList(buildNormalizedPath(dirname))) {
 				return;
 			}
 		}
@@ -210,7 +210,7 @@ final class Monitor
 				if (selectiveSync.isFileNameExcluded(strip(path,"./"))) {
 					goto skip;
 				}
-				if (selectiveSync.isPathExcluded(path)) {
+				if (selectiveSync.isPathExcludedViaSyncList(path)) {
 					goto skip;
 				}
 

--- a/src/selective.d
+++ b/src/selective.d
@@ -75,8 +75,14 @@ final class SelectiveSync
 		return false;
 	}
 	
-	// config sync_list file handling
-	bool isPathExcluded(string path)
+	// Match against sync_list only
+	bool isPathExcludedViaSyncList(string path)
+	{
+		return .isPathExcluded(path, paths);
+	}
+	
+	// Match against skip_dir, skip_file & sync_list entries
+	bool isPathExcludedMatchAll(string path)
 	{
 		return .isPathExcluded(path, paths) || .isPathMatched(path, mask) || .isPathMatched(path, dirmask);
 	}

--- a/src/sync.d
+++ b/src/sync.d
@@ -1120,7 +1120,7 @@ final class SyncEngine
 					} else {
 						// path is unwanted
 						unwanted = true;
-						log.vdebug("OneDrive change path is to be excluded by user configuration: ", path);
+						log.vlog("Skipping item - path excluded by user config: ",  path);
 					}
 				}
 			} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -1054,7 +1054,7 @@ final class SyncEngine
 				// item exists in database, most likely moved out of scope for current client configuration
 				log.vdebug("This item was previously synced / seen by the client");				
 				if (("name" in driveItem["parentReference"]) != null) {
-					if (selectiveSync.isPathExcluded(driveItem["parentReference"]["name"].str)) {
+					if (selectiveSync.isPathExcludedViaSyncList(driveItem["parentReference"]["name"].str)) {
 						// Previously synced item is now out of scope as it has been moved out of what is included in sync_list
 						log.vdebug("This previously synced item is now excluded from being synced due to sync_list exclusion");
 						// flag to delete local file as it now is no longer in sync with OneDrive
@@ -1110,7 +1110,7 @@ final class SyncEngine
 				// compute the item path to see if the path is excluded
 				path = itemdb.computePath(item.driveId, item.parentId) ~ "/" ~ item.name;
 				path = buildNormalizedPath(path);
-				if (selectiveSync.isPathExcluded(path)) {
+				if (selectiveSync.isPathExcludedViaSyncList(path)) {
 					// selective sync advised to skip, however is this a file and are we configured to upload / download files in the root?
 					if ((isItemFile(driveItem)) && (cfg.getValueBool("sync_root_files")) && (rootName(path) == "") ) {
 						// This is a file
@@ -1648,7 +1648,7 @@ final class SyncEngine
 		// If path or filename does not exclude, is this excluded due to use of selective sync?
 		if (!unwanted) {
 			path = itemdb.computePath(item.driveId, item.id);
-			unwanted = selectiveSync.isPathExcluded(path);
+			unwanted = selectiveSync.isPathExcludedViaSyncList(path);
 		}
 
 		// skip unwanted items
@@ -2186,14 +2186,14 @@ final class SyncEngine
 						return;
 					}
 				}
-				if (selectiveSync.isPathExcluded(path)) {
+				if (selectiveSync.isPathExcludedViaSyncList(path)) {
 					if ((isFile(path)) && (cfg.getValueBool("sync_root_files")) && (rootName(strip(path,"./")) == "")) {
 						log.vdebug("Not skipping path due to sync_root_files inclusion: ", path);
 					} else {
 						string userSyncList = cfg.configDirName ~ "/sync_list";
 						if (exists(userSyncList)){
 							// skipped most likely due to inclusion in sync_list
-							log.vlog("Skipping item - path excluded by sync_list: ", path);
+							log.vlog("Skipping item - excluded by skip_list config: ", path);
 							return;
 						} else {
 							// skipped for some other reason

--- a/src/sync.d
+++ b/src/sync.d
@@ -1065,18 +1065,25 @@ final class SyncEngine
 			}
 		}
 		
-		// Check if this is a directory to skip
+		// Check if this is excluded by config option: skip_dir
 		if (!unwanted) {
 			// Only check path if config is != ""
 			if (cfg.getValueString("skip_dir") != "") {
-				unwanted = selectiveSync.isDirNameExcluded(item.name);
-				if (unwanted) log.vlog("Skipping item - excluded by skip_dir config: ", item.name);
+				// Is the item a folder?
+				if (isItemFolder(driveItem)) {
+					unwanted = selectiveSync.isDirNameExcluded(item.name);
+					if (unwanted) log.vlog("Skipping item - excluded by skip_dir config: ", item.name);
+				}
 			}
 		}
-		// Check if this is a file to skip
+		
+		// Check if this is excluded by config option: skip_file
 		if (!unwanted) {
-			unwanted = selectiveSync.isFileNameExcluded(item.name);
-			if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+			// Is the item a file?
+			if (isItemFile(driveItem)) {
+				unwanted = selectiveSync.isFileNameExcluded(item.name);
+				if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+			}
 		}
 
 		// check the item type
@@ -2183,8 +2190,16 @@ final class SyncEngine
 					if ((isFile(path)) && (cfg.getValueBool("sync_root_files")) && (rootName(strip(path,"./")) == "")) {
 						log.vdebug("Not skipping path due to sync_root_files inclusion: ", path);
 					} else {
-						log.vlog("Skipping item - path excluded by sync_list: ", path);
-						return;
+						string userSyncList = cfg.configDirName ~ "/sync_list";
+						if (exists(userSyncList)){
+							// skipped most likely due to inclusion in sync_list
+							log.vlog("Skipping item - path excluded by sync_list: ", path);
+							return;
+						} else {
+							// skipped for some other reason
+							log.vlog("Skipping item - path excluded by user config: ", path);
+							return;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
* config option skip_dir should only be applied to directories
* config option skip_file should only be applied to files
* If 'directory' is in 'skip_file' then upload skip reason erroneously lists sync_list as reason for skipping