### PR TITLE
Reduce change scan impact of fix for #658 (Issue #690)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -843,6 +843,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 					} else {
 						// sync from OneDrive first before uploading files to OneDrive
 						if (logLevel < MONITOR_LOG_SILENT) log.log("Syncing changes from OneDrive ...");
+						// if sync_list is configured, syncListConfigured = true, thus a FULL walk of all OneDrive objects will be performed
 						sync.applyDifferences(syncListConfigured);
 						// Is a full scan of the entire sync_dir required?
 						if (fullScanRequired) {


### PR DESCRIPTION
If there are delta changes (meaning something changed on OneDrive) process the changes that have been presented.

What this PR does:
* always get the 'delta' change list
* if there are OneDrive delta changes (something was changed on OneDrive) & our 'changes' query (delta or full) are > 0 we have some change to process

What this fixes is always having to do a full scan every sync when using 'sync_list' and there is no change on OneDrive ... no need to process all existing files if nothing changed.
