### PR TITLE
Handle curl exceptions and timeouts better with backoff/retry logic (Issue #693)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -657,13 +657,18 @@ final class OneDriveApi
 					try {
 						http.perform();
 						// no error from http.perform() on re-try
-						log.log("Connectivity to Microsoft OneDrive service has returned");
+						log.log("Internet connectivity to Microsoft OneDrive service has been restored");
 						retrySucess = true;
 					} catch (CurlException e) {
 						if (canFind(e.msg, "Couldn't connect to server on handle")) {
 							log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
 							// Increment & loop around
 							retryAttempts++;
+						}
+						if (retryAttempts == retryCount) {
+							// we have attempted to re-connect X number of times
+							// false set this to true to break out of while loop
+							retrySucess = true;
 						}
 					}
 				}

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -5,6 +5,7 @@ import std.stdio, std.string, std.uni, std.uri, std.file;
 import std.array: split;
 import core.stdc.stdlib;
 import core.thread, std.conv, std.math;
+import std.algorithm.searching;
 import progress;
 import config;
 static import log;
@@ -629,8 +630,48 @@ final class OneDriveApi
 		try {
 			http.perform();
 		} catch (CurlException e) {
-			// Potentially Timeout was reached on handle error
-			log.error("ERROR: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
+			// Parse and display error message received from OneDrive
+			log.error("ERROR: OneDrive returned an error with the following message:");
+			auto errorArray = splitLines(e.msg);
+			string errorMessage = errorArray[0];
+			
+			if (canFind(errorMessage, "Couldn't connect to server on handle")) {
+				// This is a curl timeout
+				log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
+                // or 408 request timeout
+                // https://github.com/abraunegg/onedrive/issues/694
+                // Back off & retry with incremental delay
+                int retryCount = 10000;
+                int retryAttempts = 1;
+                int backoffInterval = 2;
+                int maxBackoffInterval = 3600;
+                while (retryAttempts < retryCount){
+                    int thisBackOff = retryAttempts*backoffInterval;
+                    if (thisBackOff <= maxBackoffInterval) {
+                        Thread.sleep(dur!"seconds"(retryAttempts*backoffInterval));
+                    } else {
+                        Thread.sleep(dur!"seconds"(maxBackoffInterval));
+                    }
+                    try {
+                        http.perform();
+                        retryAttempts = retryCount;
+                    } catch (CurlException e) {
+                        if (canFind(e.msg, "Couldn't connect to server on handle")) {
+				            log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
+                            // Increment & loop around
+                            retryAttempts++;
+                        }
+                    }
+                }
+                if (retryAttempts >= retryCount) {
+                    log.error("  Error Message: Was unable to reconnect to the Microsoft OneDrive service after 10000 attempts lasting over 1.2 years.");
+                    throw new OneDriveException(408, "Request Timeout - HTTP 408 or internet down?");
+                }
+			} else {
+				// Some other error was returned
+				log.error("  Error Message: ", errorMessage);
+			}
+			// return an empty JSON for handling
 			return json;
 		}
 		
@@ -666,6 +707,7 @@ final class OneDriveApi
 			405				Method Not Allowed					The HTTP method in the request is not allowed on the resource.
 			406				Not Acceptable						This service doesn’t support the format requested in the Accept header.
 			409				Conflict							The current state conflicts with what the request expects. For example, the specified parent folder might not exist.
+            408             Request Time out                    Not expected from OneDrive, but can be used to handle internet connection failures the same (fallback and try again)
 			410				Gone								The requested resource is no longer available at the server.
 			411				Length Required						A Content-Length header is required on the request.
 			412				Precondition Failed					A precondition provided in the request (such as an if-match header) does not match the resource's current state.
@@ -728,6 +770,11 @@ final class OneDriveApi
 				break;
 			
 			//	409 - Conflict
+            case 408:
+                // Request Timeout
+                log.vlog("Request Timeout - gracefully handling error");
+				throw new OneDriveException(408, "Request Timeout - HTTP 408 or internet down?"); 
+
 			case 409:
 				// Conflict handling .. how should we act? This only really gets triggered if we are using --local-first & we remove items.db as the DB thinks the file is not uploaded but it is
 				log.vlog("OneDrive returned a 'HTTP 409 - Conflict' - gracefully handling error");

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -645,7 +645,9 @@ final class OneDriveApi
 				int retryAttempts = 1;
 				int backoffInterval = 2;
 				int maxBackoffInterval = 3600;
-				while (retryAttempts < retryCount){
+				bool retrySucess = false;
+				while (!retrySucess){
+					log.vdebug("  Retry Attempt: ", retryAttempts);
 					int thisBackOff = retryAttempts*backoffInterval;
 					if (thisBackOff <= maxBackoffInterval) {
 						Thread.sleep(dur!"seconds"(retryAttempts*backoffInterval));
@@ -654,7 +656,9 @@ final class OneDriveApi
 					}
 					try {
 						http.perform();
-						retryAttempts = retryCount;
+						// no error from http.perform() on re-try
+						log.log("Connectivity to Microsoft OneDrive service has returned");
+						retrySucess = true;
 					} catch (CurlException e) {
 						if (canFind(e.msg, "Couldn't connect to server on handle")) {
 							log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
@@ -706,8 +710,8 @@ final class OneDriveApi
 			404				Not Found							The requested resource doesn’t exist.
 			405				Method Not Allowed					The HTTP method in the request is not allowed on the resource.
 			406				Not Acceptable						This service doesn’t support the format requested in the Accept header.
+			408				Request Time out					Not expected from OneDrive, but can be used to handle Internet connection failures the same (fallback and try again)
 			409				Conflict							The current state conflicts with what the request expects. For example, the specified parent folder might not exist.
-			408             Request Time out                    Not expected from OneDrive, but can be used to handle Internet connection failures the same (fallback and try again)
 			410				Gone								The requested resource is no longer available at the server.
 			411				Length Required						A Content-Length header is required on the request.
 			412				Precondition Failed					A precondition provided in the request (such as an if-match header) does not match the resource's current state.

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -643,14 +643,15 @@ final class OneDriveApi
 				// Back off & retry with incremental delay
 				int retryCount = 10000;
 				int retryAttempts = 1;
-				int backoffInterval = 2;
+				int backoffInterval = 1;
 				int maxBackoffInterval = 3600;
 				bool retrySucess = false;
 				while (!retrySucess){
+					backoffInterval++;
 					log.vdebug("  Retry Attempt: ", retryAttempts);
-					int thisBackOff = retryAttempts*backoffInterval;
-					if (thisBackOff <= maxBackoffInterval) {
-						Thread.sleep(dur!"seconds"(retryAttempts*backoffInterval));
+					int thisBackOffInterval = retryAttempts*backoffInterval;
+					if (thisBackOffInterval <= maxBackoffInterval) {
+						Thread.sleep(dur!"seconds"(thisBackOffInterval));
 					} else {
 						Thread.sleep(dur!"seconds"(maxBackoffInterval));
 					}

--- a/src/sync.d
+++ b/src/sync.d
@@ -1454,7 +1454,7 @@ final class SyncEngine
 				if ((e.httpStatusCode == 429) || (e.httpStatusCode == 408)) {
 					// HTTP request returned status code 429 (Too Many Requests)
 					// https://github.com/abraunegg/onedrive/issues/133
-                    // or 408 request timeout
+					// or 408 request timeout
 					// https://github.com/abraunegg/onedrive/issues/694
 					// Back off & retry with incremental delay
 					int retryCount = 10; 

--- a/src/sync.d
+++ b/src/sync.d
@@ -1451,9 +1451,11 @@ final class SyncEngine
 			try {
 				onedrive.downloadById(item.driveId, item.id, path, fileSize);
 			} catch (OneDriveException e) {
-				if (e.httpStatusCode == 429) {
+				if ((e.httpStatusCode == 429) || (e.httpStatusCode == 408)) {
 					// HTTP request returned status code 429 (Too Many Requests)
 					// https://github.com/abraunegg/onedrive/issues/133
+                    // or 408 request timeout
+					// https://github.com/abraunegg/onedrive/issues/694
 					// Back off & retry with incremental delay
 					int retryCount = 10; 
 					int retryAttempts = 1;
@@ -1465,7 +1467,7 @@ final class SyncEngine
 							// successful download
 							retryAttempts = retryCount;
 						} catch (OneDriveException e) {
-							if (e.httpStatusCode == 429) {
+							if ((e.httpStatusCode == 429) || (e.httpStatusCode == 408)) {
 								// Increment & loop around
 								retryAttempts++;
 							}


### PR DESCRIPTION
I can't find pr694 to issue the merge against, but I'm not awesome at git  I think this handles the case of backoff better, based on how you're doing it for 429 (too many requests) problems, but without the infinite loop case (I set it to make a 10,000 loops, or 1.2 years, with a slowest backoff time of 1 hour.