### PR TITLE
also go into retry loop on DNS failure

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -635,7 +635,8 @@ final class OneDriveApi
 			auto errorArray = splitLines(e.msg);
 			string errorMessage = errorArray[0];
 			
-			if (canFind(errorMessage, "Couldn't connect to server on handle")) {
+			if (canFind(errorMessage, "Couldn't connect to server on handle") ||
+			    canFind(errorMessage, "Couldn't resolve host name on handle")) {
 				// This is a curl timeout
 				log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
 				// or 408 request timeout
@@ -661,7 +662,8 @@ final class OneDriveApi
 						log.log("Internet connectivity to Microsoft OneDrive service has been restored");
 						retrySuccess = true;
 					} catch (CurlException e) {
-						if (canFind(e.msg, "Couldn't connect to server on handle")) {
+						if (canFind(e.msg, "Couldn't connect to server on handle") ||
+			                            canFind(e.msg, "Couldn't resolve host name on handle")) {
 							log.error("  Error Message: There was a timeout in accessing the Microsoft OneDrive service - Internet connectivity issue?");
 							// Increment & loop around
 							retryAttempts++;


### PR DESCRIPTION
With current master branch on a disconnected connection, we get
```
ERROR: OneDrive returned an error with the following message:
  Error Message: Couldn't resolve host name on handle 55EB5A5A94A0
[DEBUG] Invalid JSON response from OneDrive unable to initialize application
ERROR: OneDrive returned an error with the following message:
  Error Message: Couldn't resolve host name on handle 55EB5A5A94A0
ERROR: OneDrive returned an error with the following message:
  Error Message: Couldn't resolve host name on handle 55EB5A5A94A0
[DEBUG] Invalid JSON response from OneDrive unable to initialize application
ERROR: OneDrive returned an error with the following message:
  Error Message: Couldn't resolve host name on handle 55EB5A5A94A0
ERROR: Unable to query OneDrive to initialize application
Segmentation fault
```
Catch the DNS error the same way we catch the timeout error