### PR TITLE
Fix Docker alpine by adding ldc-runtime to output build step

### DIFF
--- a/contrib/docker/Dockerfile-alpine
+++ b/contrib/docker/Dockerfile-alpine
@@ -1,10 +1,8 @@
 # -*-Dockerfile-*-
 FROM golang:alpine
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >>/etc/apk/repositories
-RUN apk add alpine-sdk bash llvm5 gnupg xz jq curl-dev sqlite-dev binutils-gold autoconf automake ldc ldc-runtime
-RUN cd /usr/lib &&\
-    ln -s libdruntime-ldc-shared.so libdruntime-ldc.so &&\
-    ln -s libphobos2-ldc-shared.so libphobos2-ldc.so
+RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    alpine-sdk llvm5 gnupg xz curl-dev sqlite-dev binutils-gold \
+    autoconf automake ldc
 RUN go get github.com/tianon/gosu
 COPY . /usr/src/onedrive
 RUN cd /usr/src/onedrive/ && \
@@ -16,7 +14,8 @@ RUN cd /usr/src/onedrive/ && \
 
 FROM alpine
 ENTRYPOINT ["/entrypoint.sh"]
-RUN apk add --no-cache bash libcurl libgcc shadow sqlite-libs && \
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    bash libcurl libgcc shadow sqlite-libs ldc-runtime && \
     mkdir -p /onedrive/conf /onedrive/data
 COPY contrib/docker/entrypoint.sh /
 COPY --from=0 /go/bin/gosu /usr/local/bin/onedrive /usr/local/bin/


### PR DESCRIPTION
The runtime dc symbols are missing for the docker output build
image and are applied in the docker build step only. This change
move the lrc-runtime to the output build image it also remove the
need for symlinking the runtime in the docker build step.