### PR TITLE
Update USAGE.md

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -558,11 +558,11 @@ onedrive --monitor --verbose --confdir="~/.config/onedriveWork" &
 
 ### Automatic syncing of both OneDrive accounts
 
-In order to automatically start syncing your OneDrive accounts, you will need to create a service file for each account. From the `~/onedrive` folder:
+In order to automatically start syncing your OneDrive accounts, you will need to create a service file for each account. From the `/usr/lib/systemd/user` folder:
 ```text
 cp onedrive.service onedrive-work.service
 ```
-And edit the line beginning with `ExecStart` so that the command mirrors the one you used above:
+And edit the line beginning with `ExecStart` so that the confdir mirrors the one you used above:
 ```text
 ExecStart=/usr/local/bin/onedrive --monitor --confdir="/path/to/config/dir"
 ```


### PR DESCRIPTION
Clarifying path for setting up multiple daemons: The "onedrive.service" file was not located in ~/onedrive but in /usr/lib/systemd/user in my case. This seems to be the place where systemctl looks for unit files.