### PR TITLE
Update file handling when a failed download has occurred due to CTRL-C (Issue #791)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1411,12 +1411,18 @@ final class SyncEngine
 				item.mtime.fracSecs = Duration.zero;
 				
 				if (localModifiedTime > item.mtime) {
-					// local file is newer than item on OneDrive
-					// no local rename
-					// no download needed
-					log.vlog("Local item modified time is newer based on UTC time conversion - keeping local item");
-					log.vdebug("Skipping OneDrive change as this is determined to be unwanted due to local item modified time being newer than OneDrive item");
-					return;
+					// local file is newer than item on OneDrive based on file modified time
+					// Is this item id in the database?
+					if (itemdb.idInLocalDatabase(item.driveId, item.id)){
+						// no local rename
+						// no download needed
+						log.vlog("Local item modified time is newer based on UTC time conversion - keeping local item as this exists in the local database");
+						log.vdebug("Skipping OneDrive change as this is determined to be unwanted due to local item modified time being newer than OneDrive item and present in the sqlite database");
+						return;
+					} else {
+						// file exists locally but is not in the sqlite database - maybe a failed download?
+						log.vlog("Local item does not exist in local database - replacing with file from OneDrive - failed download?");
+					}
 				} else {
 					// remote file is newer than local item
 					log.vlog("Remote item modified time is newer based on UTC time conversion");


### PR DESCRIPTION
* If CTRL-C is used when downloading a file, remnants of this file may still exist when next sync occurs. If the file is not present in the local cache database, redownload the file from OneDrive. Does not impact however if --local-first directive is being used.