### PR TITLE
Update application output when just authorising application (Issue #820)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,10 +29,10 @@ The application will attempt to handle instances where you have two files with t
 ### curl compatibility
 If your system utilises curl >= 7.62.0 curl defaults to prefer HTTP/2 over HTTP/1.1 by default. If you wish to use HTTP/2 for some operations you will need to use the `--force-http-2` config option to enable otherwise all operations will use HTTP/1.1.
 
-### First run :zap:
-After installing the application you must run it at least once from the terminal to authorize it.
+### Authorize the application with your OneDrive Account
+After installing the application you must authorize the application with your OneDrive Account. This is done by running the application without any additional command switches.
 
-You will be asked to open a specific link using your web browser where you will have to login into your Microsoft Account and give the application the permission to access your files. After giving the permission, you will be redirected to a blank page. Copy the URI of the blank page into the application.
+You will be asked to open a specific URL by using your web browser where you will have to login into your Microsoft Account and give the application the permission to access your files. After giving permission to the application, you will be redirected to a blank page. Copy the URI of the blank page into the application.
 ```text
 [user@hostname ~]$ onedrive 
 
@@ -42,6 +42,20 @@ https://.....
 
 Enter the response uri: 
 
+```
+
+**Example:**
+```
+[user@hostname ~]$ onedrive 
+Authorize this app visiting:
+
+https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=22c49a0d-d21c-4792-aed1-8f163c982546&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient
+
+Enter the response uri: https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>
+
+Application has been successfully authorised, however no additional command switches were provided.
+
+Please use --help for further assistance in regards to running this application.
 ```
 
 ### Show your configuration

--- a/src/config.d
+++ b/src/config.d
@@ -68,6 +68,8 @@ final class Config
 		boolValues["remove_source_files"] = false;
 		// Strict matching for skip_dir
 		boolValues["skip_dir_strict_match"] = false;
+		// was the application just authorised - paste of response uri
+		boolValues["applicationAuthorizeResponseUri"] = false;
 
 		// Determine the users home directory. 
 		// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts

--- a/src/config.d
+++ b/src/config.d
@@ -20,6 +20,8 @@ final class Config
 	public string configFileSyncDir;
 	public string configFileSkipFile;
 	public string configFileSkipDir;
+	// was the application just authorised - paste of response uri
+	public bool applicationAuthorizeResponseUri = false;
 		
 	private string userConfigFilePath;
 	// hashmap for the values found in the user config file
@@ -31,7 +33,8 @@ final class Config
 
 	this(string confdirOption)
 	{
-		// default configuration
+		// default configuration - entries in config file ~/.config/onedrive/config
+		// an entry here means it can be set via the config file if there is a coresponding read and set in update_from_args()
 		stringValues["sync_dir"]         = defaultSyncDir;
 		stringValues["skip_file"]        = defaultSkipFile;
 		stringValues["skip_dir"]         = defaultSkipDir;
@@ -68,8 +71,6 @@ final class Config
 		boolValues["remove_source_files"] = false;
 		// Strict matching for skip_dir
 		boolValues["skip_dir_strict_match"] = false;
-		// was the application just authorised - paste of response uri
-		boolValues["applicationAuthorizeResponseUri"] = false;
 
 		// Determine the users home directory. 
 		// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts

--- a/src/main.d
+++ b/src/main.d
@@ -453,7 +453,7 @@ int main(string[] args)
 		// was the application just authorised?
 		if (cfg.getValueBool("applicationAuthorizeResponseUri")) {
 			// Application was just authorised
-			log.log("\nApplication has been sucessfully authorised, however no additional command switches were provided.\n");
+			log.log("\nApplication has been successfully authorised, however no additional command switches were provided.\n");
 			log.log("Please use --help for further assistance in regards to running this application.\n");
 			oneDrive.http.shutdown();
 			return EXIT_SUCCESS;

--- a/src/main.d
+++ b/src/main.d
@@ -451,7 +451,7 @@ int main(string[] args)
 	
 	if (!performSyncOK) {
 		// was the application just authorised?
-		if (cfg.getValueBool("applicationAuthorizeResponseUri")) {
+		if (cfg.applicationAuthorizeResponseUri) {
 			// Application was just authorised
 			log.log("\nApplication has been successfully authorised, however no additional command switches were provided.\n");
 			log.log("Please use --help for further assistance in regards to running this application.\n");

--- a/src/main.d
+++ b/src/main.d
@@ -460,7 +460,7 @@ int main(string[] args)
 		} else {
 			// Application was not just authorised
 			log.log("\n--synchronize or --monitor switches missing from your command line input. Please add one (not both) of these switches to your command line or use --help for further assistance.\n");
-			log.log("No OneDrive sync will be performed one of these two arguments being present.\n");
+			log.log("No OneDrive sync will be performed without one of these two arguments being present.\n");
 			oneDrive.http.shutdown();
 			return EXIT_FAILURE;
 		}

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -180,6 +180,7 @@ final class OneDriveApi
 			log.log("Authorize this app visiting:\n");
 			write(url, "\n\n", "Enter the response uri: ");
 			readln(response);
+			cfg.setValueBool("applicationAuthorizeResponseUri", true);
 		} else {
 			string[] authFiles = authFilesString.split(":");
 			string authUrl = authFiles[0];

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -180,7 +180,7 @@ final class OneDriveApi
 			log.log("Authorize this app visiting:\n");
 			write(url, "\n\n", "Enter the response uri: ");
 			readln(response);
-			cfg.setValueBool("applicationAuthorizeResponseUri", true);
+			cfg.applicationAuthorizeResponseUri = true;
 		} else {
 			string[] authFiles = authFilesString.split(":");
 			string authUrl = authFiles[0];


### PR DESCRIPTION
* Update application output to be clearer when just authorising the application and --synchronize or --monitor not passed in