### PR TITLE
Handle moving files into a skipped .folder when skip_dotfiles = true

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -706,7 +706,7 @@ int main(string[] args)
 				} catch (CurlException e) {
 					log.vlog("Offline, cannot move item!");
 				} catch(Exception e) {
-					log.logAndNotify("Cannot move item:, ", e.msg);
+					log.logAndNotify("Cannot move item: ", e.msg);
 				}
 			};
 			signal(SIGINT, &exitHandler);

--- a/src/sync.d
+++ b/src/sync.d
@@ -3359,6 +3359,7 @@ final class SyncEngine
 					// target location is a .folder
 					log.vdebug("Target location is excluded from sync due to skip_dotfiles = true");
 					// item will have been moved locally, but as this is now to a location that is not synced, needs to be removed from OneDrive
+					log.log("Item has been moved to a location that is excluded from sync operations. Removing item from OneDrive");
 					uploadDeleteItem(fromItem, from);
 					return;
 				}

--- a/src/sync.d
+++ b/src/sync.d
@@ -3351,6 +3351,20 @@ final class SyncEngine
 			uploadDeleteItem(toItem, to);
 		}
 		if (!itemdb.selectByPath(dirName(to), defaultDriveId, parentItem)) {
+			// the parent item is not in the database
+			
+			// is the destination a .folder that is being skipped?
+			if (cfg.getValueBool("skip_dotfiles")) {
+				if (isDotFile(dirName(to))) {
+					// target location is a .folder
+					log.vdebug("Target location is excluded from sync due to skip_dotfiles = true");
+					// item will have been moved locally, but as this is now to a location that is not synced, needs to be removed from OneDrive
+					uploadDeleteItem(fromItem, from);
+					return;
+				}
+			}
+			
+			// some other error
 			throw new SyncException("Can't move an item to an unsynced directory");
 		}
 		if (fromItem.driveId != parentItem.driveId) {


### PR DESCRIPTION
* If skip_dotfiles = true, moving files into a skipped .folder should not throw an error and should be removed from their previous location on OneDrive