### PR TITLE
Update regex parsing of response URI (Issue #829)

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -225,7 +225,7 @@ final class OneDriveApi
 			}
 		}
 		// match the authorization code
-		auto c = matchFirst(response, r"(?:[\?&]code=)([\w\d-]+)");
+		auto c = matchFirst(response, r"(?:[\?&]code=)([\w\d-.]+)");
 		if (c.empty) {
 			log.log("Invalid uri");
 			return false;


### PR DESCRIPTION
* Update regex that extracts the response code from the response URI to avoid generating a bad request leading to AADSTS9002313: Invalid request. Request is malformed or invalid. With thanks to @zfil for fix.