### PR TITLE
Escape parentheses from path or file names

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -107,12 +107,12 @@ Regex!char wild2regex(const(char)[] pattern)
 		case '/':
 			str ~= "\\/";
 			break;
-        case '(':
-            str ~= "\\(";
-            break;
-        case ')':
-            str ~= "\\)";
-            break;
+		case '(':
+			str ~= "\\(";
+			break;
+		case ')':
+			str ~= "\\)";
+			break;
 		default:
 			str ~= c;
 			break;

--- a/src/util.d
+++ b/src/util.d
@@ -107,6 +107,12 @@ Regex!char wild2regex(const(char)[] pattern)
 		case '/':
 			str ~= "\\/";
 			break;
+        case '(':
+            str ~= "\\(";
+            break;
+        case ')':
+            str ~= "\\)";
+            break;
 		default:
 			str ~= c;
 			break;


### PR DESCRIPTION
Escape parentheses from path or file names, when doing comparison with regex