### PR TITLE
Update application output when using --dry-run and --resync and database is corrupt (Issue#844)

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -279,9 +279,15 @@ int main(string[] args)
 	if (cfg.getValueBool("dry_run")) {
 		// Make a copy of the original items.sqlite3 for use as the dry run copy if it exists
 		if (exists(cfg.databaseFilePath)) {
-			// copy the file
-			log.vdebug("Copying items.sqlite3 to items-dryrun.sqlite3 to use for dry run operations");
-			copy(cfg.databaseFilePath,cfg.databaseFilePathDryRun);
+			// in a --dry-run --resync scenario, we should not copy the existing database file
+			if (!cfg.getValueBool("resync")) {
+				// copy the existing DB file to the dry-run copy
+				log.vdebug("Copying items.sqlite3 to items-dryrun.sqlite3 to use for dry run operations");
+				copy(cfg.databaseFilePath,cfg.databaseFilePathDryRun);
+			} else {
+				// no database copy due to --resync
+				log.vdebug("No database copy created for --dry-run due to --resync also being used");
+			}
 		}
 	}
 	

--- a/src/main.d
+++ b/src/main.d
@@ -277,6 +277,13 @@ int main(string[] args)
 	
 	// dry-run database setup
 	if (cfg.getValueBool("dry_run")) {
+		// If the dry run database exists, clean this up
+		if (exists(cfg.databaseFilePathDryRun)) {
+			// remove the existing file
+			log.vdebug("Removing items-dryrun.sqlite3 as it still exists for some reason");
+			safeRemove(cfg.databaseFilePathDryRun);	
+		}
+		
 		// Make a copy of the original items.sqlite3 for use as the dry run copy if it exists
 		if (exists(cfg.databaseFilePath)) {
 			// in a --dry-run --resync scenario, we should not copy the existing database file

--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -87,6 +87,7 @@ struct Database
 		int rc = sqlite3_exec(pDb, toStringz(sql), null, null, null);
 		if (rc != SQLITE_OK) {
 			log.error("\nA database execution error occurred: "~ getErrorMessage() ~ "\n");
+			log.error("Please retry your command with --resync to fix any local database corruption issues.\n");
 			close();
 			exit(-1);
 		}
@@ -184,6 +185,7 @@ struct Statement
 			} else {
 				string errorMessage = ifromStringz(sqlite3_errmsg(sqlite3_db_handle(pStmt)));
 				log.error("\nA database statement execution error occurred: "~ errorMessage ~ "\n");
+				log.error("Please retry your command with --resync to fix any local database corruption issues.\n");
 				exit(-1);
 			}
 		}


### PR DESCRIPTION
* Update application output when database is corrupt and how to resolve
* Handle --dry-run and --resync correctly - do not copy the database, it may be corrupt