### PR TITLE
Handle zero-byte modified files for OneDrive Business (Issue #849)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2225,10 +2225,26 @@ final class SyncEngine
 								// OneDrive Business Account
 								// We need to always use a session to upload, but handle the changed file correctly
 								if (accountType == "business"){
-									// For logging consistency
-									writeln("");
+									
 									try {
-										response = session.upload(path, item.driveId, item.parentId, baseName(path), item.eTag);
+										// is this a zero-byte file?
+										if (getSize(path) == 0) {
+											// the file we are trying to upload as a session is a zero byte file - we cant use a session to upload or replace the file 
+											// as OneDrive technically does not support zero byte files
+											writeln("skipped.");
+											log.fileOnly("Uploading modified file ", path, " ... skipped.");
+											log.vlog("Skip Reason: Microsoft OneDrive does not support 'zero-byte' files as a modified upload. Will upload as new file.");
+											// delete file on OneDrive
+											onedrive.deleteById(item.driveId, item.id, item.eTag);
+											// delete file from local database
+											itemdb.deleteById(item.driveId, item.id);
+											return;
+										} else {
+											// For logging consistency
+											writeln("");
+											// normal session upload
+											response = session.upload(path, item.driveId, item.parentId, baseName(path), item.eTag);
+										}
 									} catch (OneDriveException e) {
 										if (e.httpStatusCode == 401) {
 											// OneDrive returned a 'HTTP/1.1 401 Unauthorized Error' - file failed to be uploaded
@@ -2263,66 +2279,81 @@ final class SyncEngine
 									}
 									// upload done without error
 									writeln("done.");
+									
 									// As the session.upload includes the last modified time, save the response
 									// Is the response a valid JSON object - validation checking done in saveItem
 									saveItem(response);
 								}
 								// OneDrive documentLibrary
 								if (accountType == "documentLibrary"){
-									// Handle certain file types differently
-									if ((extension(path) == ".txt") || (extension(path) == ".csv")) {
-										// .txt and .csv are unaffected by https://github.com/OneDrive/onedrive-api-docs/issues/935 
-										// For logging consistency
-										writeln("");
-										try {
-											response = session.upload(path, item.driveId, item.parentId, baseName(path), item.eTag);
-										} catch (OneDriveException e) {
-											if (e.httpStatusCode == 401) {
-												// OneDrive returned a 'HTTP/1.1 401 Unauthorized Error' - file failed to be uploaded
+									// is this a zero-byte file?
+									if (getSize(path) == 0) {
+										// the file we are trying to upload as a session is a zero byte file - we cant use a session to upload or replace the file 
+										// as OneDrive technically does not support zero byte files
+										writeln("skipped.");
+										log.fileOnly("Uploading modified file ", path, " ... skipped.");
+										log.vlog("Skip Reason: Microsoft OneDrive does not support 'zero-byte' files as a modified upload. Will upload as new file.");
+										// delete file on OneDrive
+										onedrive.deleteById(item.driveId, item.id, item.eTag);
+										// delete file from local database
+										itemdb.deleteById(item.driveId, item.id);
+										return;
+									} else {
+										// Handle certain file types differently
+										if ((extension(path) == ".txt") || (extension(path) == ".csv")) {
+											// .txt and .csv are unaffected by https://github.com/OneDrive/onedrive-api-docs/issues/935 
+											// For logging consistency
+											writeln("");
+											try {
+												response = session.upload(path, item.driveId, item.parentId, baseName(path), item.eTag);
+											} catch (OneDriveException e) {
+												if (e.httpStatusCode == 401) {
+													// OneDrive returned a 'HTTP/1.1 401 Unauthorized Error' - file failed to be uploaded
+													writeln("skipped.");
+													log.vlog("OneDrive returned a 'HTTP 401 - Unauthorized' - gracefully handling error");
+													uploadFailed = true;
+													return;
+												}										
+												// Resolve https://github.com/abraunegg/onedrive/issues/36
+												if ((e.httpStatusCode == 409) || (e.httpStatusCode == 423)) {
+													// The file is currently checked out or locked for editing by another user
+													// We cant upload this file at this time
+													writeln("skipped.");
+													log.fileOnly("Uploading modified file ", path, " ... skipped.");
+													writeln("", path, " is currently checked out or locked for editing by another user.");
+													log.fileOnly(path, " is currently checked out or locked for editing by another user.");
+													uploadFailed = true;
+													return;
+												} else {
+													// display what the error is
+													writeln("skipped.");
+													displayOneDriveErrorMessage(e.msg);
+													uploadFailed = true;
+													return;
+												}
+											} catch (FileException e) {
+												// display the error message
 												writeln("skipped.");
-												log.vlog("OneDrive returned a 'HTTP 401 - Unauthorized' - gracefully handling error");
-												uploadFailed = true;
-												return;
-											}										
-											// Resolve https://github.com/abraunegg/onedrive/issues/36
-											if ((e.httpStatusCode == 409) || (e.httpStatusCode == 423)) {
-												// The file is currently checked out or locked for editing by another user
-												// We cant upload this file at this time
-												writeln("skipped.");
-												log.fileOnly("Uploading modified file ", path, " ... skipped.");
-												writeln("", path, " is currently checked out or locked for editing by another user.");
-												log.fileOnly(path, " is currently checked out or locked for editing by another user.");
-												uploadFailed = true;
-												return;
-											} else {
-												// display what the error is
-												writeln("skipped.");
-												displayOneDriveErrorMessage(e.msg);
+												displayFileSystemErrorMessage(e.msg);
 												uploadFailed = true;
 												return;
 											}
-										} catch (FileException e) {
-											// display the error message
+											// upload done without error
+											writeln("done.");
+											// As the session.upload includes the last modified time, save the response
+											// Is the response a valid JSON object - validation checking done in saveItem
+											saveItem(response);
+										} else {									
+											// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
+											// This means, as a session upload, on 'completion' the file is 'moved' and generates a 404 ......
 											writeln("skipped.");
-											displayFileSystemErrorMessage(e.msg);
-											uploadFailed = true;
+											log.fileOnly("Uploading modified file ", path, " ... skipped.");
+											log.vlog("Skip Reason: Microsoft Sharepoint 'enrichment' after upload issue");
+											log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
+											// Delete record from the local database - file will be uploaded as a new file
+											itemdb.deleteById(item.driveId, item.id);
 											return;
 										}
-										// upload done without error
-										writeln("done.");
-										// As the session.upload includes the last modified time, save the response
-										// Is the response a valid JSON object - validation checking done in saveItem
-										saveItem(response);
-									} else {									
-										// Due to https://github.com/OneDrive/onedrive-api-docs/issues/935 Microsoft modifies all PDF, MS Office & HTML files with added XML content. It is a 'feature' of SharePoint.
-										// This means, as a session upload, on 'completion' the file is 'moved' and generates a 404 ......
-										writeln("skipped.");
-										log.fileOnly("Uploading modified file ", path, " ... skipped.");
-										log.vlog("Skip Reason: Microsoft Sharepoint 'enrichment' after upload issue");
-										log.vlog("See: https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details");
-										// Delete record from the local database - file will be uploaded as a new file
-										itemdb.deleteById(item.driveId, item.id);
-										return;
 									}
 								}
 							}


### PR DESCRIPTION
* OneDrive does not support the uploading of zero-byte files when uploading via the OneDrive Web UI, however it is possible to upload then via the API as a 'new file'. If the zero-byte file is modified, upload this as a 'new file' rather than attempt to upload as a normal modified file.