### PR TITLE
Update link to new microsoft documentation

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -23,7 +23,7 @@ skip_file = "~*|.~*|*.tmp"
 Do not use a skip_file entry of `.*` as this will prevent correct searching of local changes to process.
 
 ### Local File and Folder Naming Conventions
-The files and directories in the synchronization directory must follow the [Windows naming conventions](https://msdn.microsoft.com/en-us/library/aa365247).
+The files and directories in the synchronization directory must follow the [Windows naming conventions](https://docs.microsoft.com/windows/win32/fileio/naming-a-file).
 The application will attempt to handle instances where you have two files with the same names but with different capitalization. Where there is a namespace clash, the file name which clashes will not be synced. This is expected behavior and won't be fixed.
 
 ### curl compatibility


### PR DESCRIPTION
Micro-PR:

The Microsoft documentation seems to have moved to docs.microsoft.com. Former link (https://msdn.microsoft.com/en-us/library/aa365247) was redirected there.