### PR TITLE
Update enforce statement for parent id database query (Issue #912)

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2990,11 +2990,9 @@ final class SyncEngine
 						// Perform the database lookup - is the parent in the database?
 						if (!itemdb.selectByPath(dirName(path), parent.driveId, parent)) {
 							// parent is not in the database
-							log.vdebug("Parent path is not in the database - need to add it");
+							log.vdebug("Parent path is not in the database - need to add it: ", dirName(path));
 							uploadCreateDir(dirName(path));
 						}
-						// still enforce check of parent path. if the above was triggered, the below will generate a sync retry and will now be sucessful
-						enforce(itemdb.selectByPath(dirName(path), parent.driveId, parent), "The parent item id is not in the database");
 						
 						JSONValue driveItem = [
 								"name": JSONValue(baseName(path)),

--- a/src/sync.d
+++ b/src/sync.d
@@ -2994,6 +2994,14 @@ final class SyncEngine
 							uploadCreateDir(dirName(path));
 						}
 						
+						// Is the parent a 'folder' from another user? ie - is this a 'shared folder' that has been shared with us?
+						if (defaultDriveId == parent.driveId){
+							// enforce check of parent path. if the above was triggered, the below will generate a sync retry and will now be sucessful
+							enforce(itemdb.selectByPath(dirName(path), parent.driveId, parent), "The parent item id is not in the database");
+						} else {
+							log.vdebug("Parent drive ID is not our drive ID - parent most likely a shared folder");
+						}
+						
 						JSONValue driveItem = [
 								"name": JSONValue(baseName(path)),
 								"folder": parseJSON("{}")


### PR DESCRIPTION
* Remove redundant enforce check as if the parent is not in the database, the previous statement ensures the parent is in the database. If the parent is a shared folder, the parent ID will never be in the database as we are never provided it.