### PR TITLE
Fix module std.digest.digest is deprecated (Issue #915)

### DIFF
--- a/src/qxor.d
+++ b/src/qxor.d
@@ -1,5 +1,5 @@
 import std.algorithm;
-import std.digest.digest;
+import std.digest;
 
 // implementation of the QuickXorHash algorithm in D
 // https://github.com/OneDrive/onedrive-api-docs/blob/live/docs/code-snippets/quickxorhash.md


### PR DESCRIPTION
* Fix module std.digest.digest is deprecated when using DMD 2.092 and above