### PR TITLE
Remove double scan of OneDrive when using --monitor --resync at application startup

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -787,7 +787,7 @@ int main(string[] args)
 				auto currTime = MonoTime.currTime();
 				if (currTime - lastCheckTime > checkInterval) {
 					// monitor sync loop
-					log.log("################################################## NEW LOOP ##################################################");
+					log.vdebug("################################################## NEW LOOP ##################################################");
 					// log monitor output suppression
 					logMonitorCounter += 1;
 					if (logMonitorCounter > logInterval) {
@@ -925,7 +925,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 	
 	do {
 		try {
-			log.log("################################################## NEW SYNC ##################################################");
+			log.vdebug("################################################## NEW SYNC ##################################################");
 			if (singleDirectory != ""){
 				// we were requested to sync a single directory
 				log.vlog("Syncing changes from this selected path: ", singleDirectory);
@@ -978,7 +978,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 						if (logLevel < MONITOR_LOG_SILENT) log.log("Syncing changes from OneDrive ...");
 						
 						// For the initial sync, always use the delta link so that we capture all the right delta changes including adds, moves & deletes
-						log.log("Calling sync.applyDifferences(false);");
+						log.vdebug("Calling sync.applyDifferences(false);");
 						sync.applyDifferences(false);
 						
 						// is this a download only request?						
@@ -986,7 +986,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 							// process local changes walking the entire path checking for changes
 							// in monitor mode all local changes are captured via inotify
 							// thus scanning every 'monitor_interval' (default 45 seconds) for local changes is excessive and not required
-							log.log("Calling sync.scanForDifferences(localPath);");
+							log.vdebug("Calling sync.scanForDifferences(localPath);");
 							sync.scanForDifferences(localPath);
 							
 							// At this point, all OneDrive changes / local changes should be uploaded and in sync
@@ -1004,32 +1004,32 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 							
 							// Do not perform a full walk of the OneDrive objects
 							if ((!fullScanRequired) && (!syncListConfiguredFullScanOverride)){
-								log.log("Final True-Up: Do not perform a full walk of the OneDrive objects - not required");
-								log.log("Calling sync.applyDifferences(false);");
+								log.vdebug("Final True-Up: Do not perform a full walk of the OneDrive objects - not required");
+								log.vdebug("Calling sync.applyDifferences(false);");
 								sync.applyDifferences(false);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop
 							if ((!fullScanRequired) && (syncListConfiguredFullScanOverride)){
-								log.log("Final True-Up: Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop");
-								log.log("Calling sync.applyDifferences(true);");
+								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop");
+								log.vdebug("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because a full scan was required
 							if ((fullScanRequired) && (!syncListConfiguredFullScanOverride)){
-								log.log("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required");
-								log.log("Calling sync.applyDifferences(true);");
+								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required");
+								log.vdebug("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop
 							if ((fullScanRequired) && (syncListConfiguredFullScanOverride)){
-								log.log("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop");
-								log.log("Calling sync.applyDifferences(true);");
+								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop");
+								log.vdebug("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}

--- a/src/main.d
+++ b/src/main.d
@@ -811,7 +811,7 @@ int main(string[] args)
 					}
 					
 					// Monitor Loop Counter
-					log.log("fullScanCounter =                    ", fullScanCounter);
+					log.vdebug("fullScanCounter =                    ", fullScanCounter);
 					// sync option handling per sync loop
 					log.vdebug("syncListConfigured =                 ", syncListConfigured);
 					log.vdebug("fullScanRequired =                   ", fullScanRequired);

--- a/src/main.d
+++ b/src/main.d
@@ -918,6 +918,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 	
 	do {
 		try {
+			log.log("################################################## NEW SYNC ##################################################");
 			if (singleDirectory != ""){
 				// we were requested to sync a single directory
 				log.vlog("Syncing changes from this selected path: ", singleDirectory);
@@ -970,7 +971,7 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 						if (logLevel < MONITOR_LOG_SILENT) log.log("Syncing changes from OneDrive ...");
 						
 						// For the initial sync, always use the delta link so that we capture all the right delta changes including adds, moves & deletes
-						log.vdebug("Calling sync.applyDifferences(false);");
+						log.log("Calling sync.applyDifferences(false);");
 						sync.applyDifferences(false);
 						
 						// is this a download only request?						
@@ -996,32 +997,32 @@ void performSync(SyncEngine sync, string singleDirectory, bool downloadOnly, boo
 							
 							// Do not perform a full walk of the OneDrive objects
 							if ((!fullScanRequired) && (!syncListConfiguredFullScanOverride)){
-								log.vdebug("Final True-Up: Do not perform a full walk of the OneDrive objects - not required");
-								log.vdebug("Calling sync.applyDifferences(false);");
+								log.log("Final True-Up: Do not perform a full walk of the OneDrive objects - not required");
+								log.log("Calling sync.applyDifferences(false);");
 								sync.applyDifferences(false);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop
 							if ((!fullScanRequired) && (syncListConfiguredFullScanOverride)){
-								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop");
-								log.vdebug("Calling sync.applyDifferences(true);");
+								log.log("Final True-Up: Perform a full walk of OneDrive objects because sync_list is in use / or trigger was set in --monitor loop");
+								log.log("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because a full scan was required
 							if ((fullScanRequired) && (!syncListConfiguredFullScanOverride)){
-								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required");
-								log.vdebug("Calling sync.applyDifferences(true);");
+								log.log("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required");
+								log.log("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}
 							
 							// Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop
 							if ((fullScanRequired) && (syncListConfiguredFullScanOverride)){
-								log.vdebug("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop");
-								log.vdebug("Calling sync.applyDifferences(true);");
+								log.log("Final True-Up: Perform a full walk of OneDrive objects because a full scan was required and sync_list is in use and trigger was set in --monitor loop");
+								log.log("Calling sync.applyDifferences(true);");
 								sync.applyDifferences(true);
 								return;
 							}

--- a/src/sync.d
+++ b/src/sync.d
@@ -865,11 +865,11 @@ final class SyncEngine
 		string deltaLink = "";
 		string deltaLinkAvailable = itemdb.getDeltaLink(driveId, id);
 		// if sync_list is not configured, syncListConfigured should be false
-		log.vdebug("syncListConfigured = ", syncListConfigured);
+		log.log("syncListConfigured = ", syncListConfigured);
 		// oneDriveFullScanTrigger should be false unless set by actions on OneDrive and only if sync_list or skip_dir is used
-		log.vdebug("oneDriveFullScanTrigger = ", oneDriveFullScanTrigger);
+		log.log("oneDriveFullScanTrigger = ", oneDriveFullScanTrigger);
 		// should only be set if 10th scan in monitor mode or as final true up sync in stand alone mode
-		log.vdebug("performFullItemScan = ", performFullItemScan);
+		log.log("performFullItemScan = ", performFullItemScan);
 				
 		// do we override performFullItemScan if it is currently false and oneDriveFullScanTrigger is true?
 		if ((!performFullItemScan) && (oneDriveFullScanTrigger)) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -865,11 +865,11 @@ final class SyncEngine
 		string deltaLink = "";
 		string deltaLinkAvailable = itemdb.getDeltaLink(driveId, id);
 		// if sync_list is not configured, syncListConfigured should be false
-		log.log("syncListConfigured = ", syncListConfigured);
+		log.vdebug("syncListConfigured = ", syncListConfigured);
 		// oneDriveFullScanTrigger should be false unless set by actions on OneDrive and only if sync_list or skip_dir is used
-		log.log("oneDriveFullScanTrigger = ", oneDriveFullScanTrigger);
+		log.vdebug("oneDriveFullScanTrigger = ", oneDriveFullScanTrigger);
 		// should only be set if 10th scan in monitor mode or as final true up sync in stand alone mode
-		log.log("performFullItemScan = ", performFullItemScan);
+		log.vdebug("performFullItemScan = ", performFullItemScan);
 				
 		// do we override performFullItemScan if it is currently false and oneDriveFullScanTrigger is true?
 		if ((!performFullItemScan) && (oneDriveFullScanTrigger)) {


### PR DESCRIPTION
The PR does the following:
* In '--monitor --resync', the prior actual process performed the '--synchronize' section first, before dropping into the '--monitor' loop. This fixes this as '--resync' has zero bearing on what mode operation is used.
* Restores '--monitor' full sync scan at start of application as per prior https://github.com/abraunegg/onedrive/commit/bc9f2cf893c97e0e564a4f2ab4cedb744c3a54fc  - then every subsequent loop, delta will be used. 'sync_list' full scan is still handed every 10th sync post this as per normal