### PR TITLE
Change monitor interval default to 300 seconds

### DIFF
--- a/config
+++ b/config
@@ -7,7 +7,7 @@
 #
 # sync_dir = "~/OneDrive"
 # skip_file = "~*|.~*|*.tmp"
-# monitor_interval = "45"
+# monitor_interval = "300"
 # skip_dir = ""
 # log_dir = "/var/log/onedrive/"
 # drive_id = ""

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -74,7 +74,7 @@ Config option 'skip_dir'               =
 Config option 'skip_file'              = ~*|.~*|*.tmp
 Config option 'skip_dotfiles'          = false
 Config option 'skip_symlinks'          = false
-Config option 'monitor_interval'       = 45
+Config option 'monitor_interval'       = 300
 Config option 'min_notify_changes'     = 5
 Config option 'log_dir'                = /var/log/onedrive/
 Config option 'classify_as_big_delete' = 1000
@@ -259,7 +259,7 @@ The default configuration file is listed below:
 #
 # sync_dir = "~/OneDrive"
 # skip_file = "~*|.~*|*.tmp"
-# monitor_interval = "45"
+# monitor_interval = "300"
 # skip_dir = ""
 # log_dir = "/var/log/onedrive/"
 # drive_id = ""
@@ -288,6 +288,7 @@ The default configuration file is listed below:
 # skip_dir_strict_match = "false"
 # application_id = ""
 # resync = "false"
+# bypass_data_preservation = "false"
 ```
 
 
@@ -302,7 +303,7 @@ Example:
 #
 sync_dir="~/MyDirToSync"
 # skip_file = "~*|.~*|*.tmp"
-# monitor_interval = "45"
+# monitor_interval = "300"
 # skip_dir = ""
 # log_dir = "/var/log/onedrive/"
 ```
@@ -321,7 +322,7 @@ Example:
 #
 # sync_dir = "~/OneDrive"
 # skip_file = "~*|.~*|*.tmp"
-# monitor_interval = "45"
+# monitor_interval = "300"
 skip_dir = "Desktop|Documents/IISExpress|Documents/SQL Server Management Studio|Documents/Visual Studio*|Documents/WindowsPowerShell"
 # log_dir = "/var/log/onedrive/"
 ```
@@ -339,7 +340,7 @@ Example:
 #
 # sync_dir = "~/OneDrive"
 skip_file = "~*|Documents/OneNote*|Documents/config.xlaunch|myfile.ext"
-# monitor_interval = "45"
+# monitor_interval = "300"
 # skip_dir = ""
 # log_dir = "/var/log/onedrive/"
 ```
@@ -366,7 +367,7 @@ Example:
 # debug_https = "false"
 skip_dotfiles = "true"
 # dry_run = "false"
-# monitor_interval = "45"
+# monitor_interval = "300"
 ```
 Setting this to `"true"` will skip all .files and .folders while syncing.
 
@@ -386,17 +387,17 @@ Example:
 ```text
 # skip_dotfiles = "false"
 # dry_run = "false"
-monitor_interval = "300"
+monitor_interval = "600"
 # min_notify_changes = "5"
 # monitor_log_frequency = "5"
 ```
-The monitor interval is defined as the wait time 'between' sync's when running in monitor mode. By default without configuration, the monitor_interval is set to 45 seconds. Setting this value to 300 will run the sync process every 5 minutes.
+The monitor interval is defined as the wait time 'between' sync's when running in monitor mode. By default without configuration, the monitor_interval is set to 300 seconds. Setting this value to 600 will run the sync process every 10 minutes.
 
 #### min_notify_changes
 Example:
 ```text
 # dry_run = "false"
-# monitor_interval = "45"
+# monitor_interval = "300"
 min_notify_changes = "50"
 # monitor_log_frequency = "5"
 # monitor_fullscan_frequency = "10"

--- a/src/config.d
+++ b/src/config.d
@@ -60,7 +60,8 @@ final class Config
 		boolValues["dry_run"] = false;
 		boolValues["sync_root_files"] = false;
 		longValues["verbose"] = log.verbose; // might be initialized by the first getopt call!
-		longValues["monitor_interval"] = 45;
+		// The amount of time (seconds) between monitor sync loops
+		longValues["monitor_interval"] = 300;
 		longValues["skip_size"] = 0;
 		longValues["min_notify_changes"] = 5;
 		longValues["monitor_log_frequency"] = 5;


### PR DESCRIPTION
* Having a 45 second default between monitor sync loops is too short. If there are a large number of files on the system (30K+) local file integrity checks take longer than 1 minute to complete, thus, it will seem like the system is 'forever' processing. Changing this to 300 seconds between sync loops is a more sane default.