### PR TITLE
Check if symbolic link is relative to location path

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2874,11 +2874,11 @@ final class SyncEngine
 					chdir(currentSyncDir);
 					// results
 					if (relativeLink.startsWith("../") && relativeLinkTest) {
-						log.log("Skipping item - symbolic link is a 'relative link' to target ('", relativeLink, "') which is not supported: ", path);
+						log.vdebug("Not skipping item - symbolic link is a 'relative link' to target ('", relativeLink, "') which can be supported: ", path);
 					} else {
 						log.log("Skipping item - invalid symbolic link: ", path);
+						return;
 					}
-					return;
 				}
 			}
 			

--- a/src/sync.d
+++ b/src/sync.d
@@ -2873,7 +2873,7 @@ final class SyncEngine
 					// reset back to our 'sync_dir'
 					chdir(currentSyncDir);
 					// results
-					if (relativeLink.startsWith("../") && relativeLinkTest) {
+					if (relativeLinkTest) {
 						log.vdebug("Not skipping item - symbolic link is a 'relative link' to target ('", relativeLink, "') which can be supported: ", path);
 					} else {
 						log.log("Skipping item - invalid symbolic link: ", path);


### PR DESCRIPTION
* If a symbolic link is 'relative', it is relative to the path where the symbolic link exists, not the current working directory. Test if the failed symbolic link read is due to the link being relative, and advise accordingly.