### PR TITLE
Implement recursive deletion when Retention Policy is enabled

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -3949,7 +3949,7 @@ final class SyncEngine
 		
 		// query the database - how many objects will this remove?
 		auto children = getChildren(item.driveId, item.id);
-		long itemsToDelete = 1 + count(children);
+		long itemsToDelete = count(children);
 		
 		// Are we running in monitor mode? A local delete of a file will issue a inotify event, which will trigger the local & remote data immediately
 		if (!cfg.getValueBool("monitor")) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -3996,6 +3996,8 @@ final class SyncEngine
 							try {
 								foreach_reverse (Item child; children) {
 									onedrive.deleteById(child.driveId, child.id, child.eTag);
+									// delete the child reference in the local database
+									itemdb.deleteById(child.driveId, child.id);
 								}
 								onedrive.deleteById(item.driveId, item.id, item.eTag);
 							} catch (OneDriveException e) {


### PR DESCRIPTION
Hi. First time contributing to this project. I didn't find any instructions for contributors so I tried my best to preserve the same coding style as the rest of the file.
These changes should fix the warnings when removing a folder with content on drives with Retention Policy enabled (#338), as it is my case with my university. Although the code works fine, the last changes on monitor.d introduced an error where removing any empty folder may or may not result in a segmentation fault. I did rebase the changes onto the 2.4.2 tag and everything works fine there.
Cheers,
Christian