### PR TITLE
Fix error when moving folder outside the sync directory

### DIFF
--- a/src/monitor.d
+++ b/src/monitor.d
@@ -231,8 +231,6 @@ final class Monitor
 			while (i < length) {
 				inotify_event *event = cast(inotify_event*) &buffer[i];
 				string path;
-				path = getPath(event);
-				
 				// inotify event debug
 				log.vdebug("inotify event wd: ", event.wd);
 				log.vdebug("inotify event mask: ", event.mask);
@@ -272,6 +270,9 @@ final class Monitor
 					throw new MonitorException("Inotify overflow, events missing");
 				}
 
+				// if the event is not to be ignored, obtain path
+				path = getPath(event);
+				
 				// skip events that should be excluded based on application configuration
 				if (selectiveSync.isDirNameExcluded(path.strip('.').strip('/'))) {
 					goto skip;


### PR DESCRIPTION
This was the error referenced in https://github.com/abraunegg/onedrive/pull/955. The occurrence is as follows:

1. A folder is moved outside the synchronization root.
2. The inotify read operation returns the `IN_MOVED_FROM` event from the parent folder and the `IN_IGNORED` event from the removed folder in different calls.
3. The first time the while loop is entered, the only operation available in the buffer is the `IN_MOVED_FROM`, resulting in an addition of the moved folder path into `cookieToPath`.
4. After exiting the while loop, the program enters the following foreach loop, removing the string corresponding to the removed folder path from `wdToDirName`.
5. The second time the while loop is entered, the only operation available now is the `IN_IGNORED` from the removed folder. When `getPath` is called, the program ends with a segmentation fault since the corresponding index was already removed from `wdToDirName`.

The simplest solution to fix this problem is to check if the event is to be ignored before calling `getPath`.