### PR TITLE
Improve --single-directory sync performance

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1591,52 +1591,55 @@ final class SyncEngine
 							} else {
 								// No item ID match or folder sync match
 								log.vdebug("Change does not match any criteria to apply");
+								
 								// Before discarding change - does this ID still exist on OneDrive - as in IS this 
 								// potentially a --single-directory sync and the user 'moved' the file out of the 'sync-dir' to another OneDrive folder
 								// This is a corner edge case - https://github.com/skilion/onedrive/issues/341
-								JSONValue oneDriveMovedNotDeleted;
-								try {
-									oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item["id"].str);
-								} catch (OneDriveException e) {
-									log.vdebug("oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item['id'].str); generated a OneDriveException");
-									if (e.httpStatusCode == 404) {
-										// No .. that ID is GONE
-										log.vlog("Remote change discarded - item cannot be found");
-										return;
-									}
-									
-									if (e.httpStatusCode == 429) {
-										// HTTP request returned status code 429 (Too Many Requests). We need to leverage the response Retry-After HTTP header to ensure minimum delay until the throttle is removed.
-										handleOneDriveThrottleRequest();
-										// Retry request after delay
-										log.vdebug("Retrying original request that generated the OneDrive HTTP 429 Response Code (Too Many Requests) - calling oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item['id'].str);");
-										try {
-											oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item["id"].str);
-										} catch (OneDriveException e) {
-											// A further error was generated
-											// Rather than retry original function, retry the actual call and replicate error handling
-											if (e.httpStatusCode == 404) {
-												// No .. that ID is GONE
-												log.vlog("Remote change discarded - item cannot be found");
-												return;
-											} else {
-												// not a 404
-												displayOneDriveErrorMessage(e.msg);
-												return;
-											}
-										}
-									} else {
-										// not a 404 or a 429
-										displayOneDriveErrorMessage(e.msg);
-										return;
-									}
-								}
-								// Yes .. ID is still on OneDrive but elsewhere .... #341 edge case handling
+
 								// What is the original local path for this ID in the database? Does it match 'syncFolderChildPath'
 								if (itemdb.idInLocalDatabase(driveId, item["id"].str)){
 									// item is in the database
 									string originalLocalPath = itemdb.computePath(driveId, item["id"].str);
 									if (canFind(originalLocalPath, syncFolderChildPath)){
+										JSONValue oneDriveMovedNotDeleted;
+										try {
+											oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item["id"].str);
+										} catch (OneDriveException e) {
+											log.vdebug("oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item['id'].str); generated a OneDriveException");
+											if (e.httpStatusCode == 404) {
+												// No .. that ID is GONE
+												log.vlog("Remote change discarded - item cannot be found");
+												return;
+											}
+											
+											if (e.httpStatusCode == 429) {
+												// HTTP request returned status code 429 (Too Many Requests). We need to leverage the response Retry-After HTTP header to ensure minimum delay until the throttle is removed.
+												handleOneDriveThrottleRequest();
+												// Retry request after delay
+												log.vdebug("Retrying original request that generated the OneDrive HTTP 429 Response Code (Too Many Requests) - calling oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item['id'].str);");
+												try {
+													oneDriveMovedNotDeleted = onedrive.getPathDetailsById(driveId, item["id"].str);
+												} catch (OneDriveException e) {
+													// A further error was generated
+													// Rather than retry original function, retry the actual call and replicate error handling
+													if (e.httpStatusCode == 404) {
+														// No .. that ID is GONE
+														log.vlog("Remote change discarded - item cannot be found");
+														return;
+													} else {
+														// not a 404
+														displayOneDriveErrorMessage(e.msg);
+														return;
+													}
+												}
+											} else {
+												// not a 404 or a 429
+												displayOneDriveErrorMessage(e.msg);
+												return;
+											}
+										}
+
+										// Yes .. ID is still on OneDrive but elsewhere .... #341 edge case handling
 										// This 'change' relates to an item that WAS in 'syncFolderChildPath' but is now 
 										// stored elsewhere on OneDrive - outside the path we are syncing from
 										// Remove this item locally as it's local path is now obsolete
@@ -1644,7 +1647,7 @@ final class SyncEngine
 									} else {
 										// out of scope for some other reason
 										if (singleDirectoryScope){
-											log.vlog("Remote change discarded - not in --single-directory sync scope");
+											log.vlog("Remote change discarded - not in --single-directory sync scope (in DB)");
 										} else {
 											log.vlog("Remote change discarded - not in sync scope");
 										}
@@ -1654,7 +1657,7 @@ final class SyncEngine
 									// item is not in the database
 									if (singleDirectoryScope){
 										// We are syncing a single directory, so this is the reason why it is out of scope
-										log.vlog("Remote change discarded - not in --single-directory sync scope");
+										log.vlog("Remote change discarded - not in --single-directory sync scope (not in DB)");
 										log.vdebug("Remote change discarded: ", item);
 									} else {
 										// Not a single directory sync

--- a/src/sync.d
+++ b/src/sync.d
@@ -1609,9 +1609,7 @@ final class SyncEngine
 											if (e.httpStatusCode == 404) {
 												// No .. that ID is GONE
 												log.vlog("Remote change discarded - item cannot be found");
-												return;
 											}
-											
 											if (e.httpStatusCode == 429) {
 												// HTTP request returned status code 429 (Too Many Requests). We need to leverage the response Retry-After HTTP header to ensure minimum delay until the throttle is removed.
 												handleOneDriveThrottleRequest();
@@ -1625,17 +1623,14 @@ final class SyncEngine
 													if (e.httpStatusCode == 404) {
 														// No .. that ID is GONE
 														log.vlog("Remote change discarded - item cannot be found");
-														return;
 													} else {
 														// not a 404
 														displayOneDriveErrorMessage(e.msg);
-														return;
 													}
 												}
 											} else {
 												// not a 404 or a 429
 												displayOneDriveErrorMessage(e.msg);
-												return;
 											}
 										}
 


### PR DESCRIPTION
Hello @abraunegg,
I've prepared a PR that immensely improves performance of --single-directory and sync_list synchronizations, especially those that require iterating through full OneDrive tree.

# Disclaimer

Please note that this is simply a change proposal that may or may not be acceptable yet, but I'm willing to cooperate to make it better.

# What does this change include?

This PR moves `oneDriveMovedNotDeleted` check part from `sync.d:1597` from the beginning of the code block just before `idsToDelete` modification in `sync.d:1643`. What it does is that `onedrive.getPathDetailsById` invocation is only made if it can really make an impact whether a change item is to be discarded or deleted in synced directory.

# Why is the change made?

Such change is important, because `onedrive.getPathDetailsById` invocation there is responsible for almost 90% of the time spent inside that function if there are a lot of discarded change items (I've done some profiling with valgrind). Example: on my 200 GB OneDrive: syncing --single-directory of a folder with one file took almost 12 hours before I stopped it out of pity (and it didn't finish!) (all the time was spent discarding changes).

# How&why does this change works?

Basically said code block makes three mostly independent checks:

1. Whether the changed item still exists on OneDrive
2. Whether the changed item is already in local database
3. Whether the changed item's local path matches the synced path.

Item is only deleted from synced folder if all of those checks are true. In every other case the change is discarded. So no matter the result of check 1., change will be discarded if check 2. and check 3. are false. The solution made is to make check 1. (which is extremely expensive) execute only after checks 2. and 3. pass.

That way changes that would be discarded because of check 2. or 3. are processed much faster. 10x faster.

# What is the benefit?

- faster synchronization code, especially for big drives, small sync_lists and resyncs,
- less network traffic.

# Is the change tested?

Well... Didn't find any automated tests around, so just made several smoke tests, like checking if the code works and it works the same for basic --single-directory operations like move, delete, out-of-folder delete. It does work and it does work the same. But I didn't manage to trigger `oneDriveMovedNotDeleted` check code path in any case.

# Notes

I've just made a PR, instead of first reporting a ticket, because I needed to have this made change now for my private project needs.

I would also like to discuss with you several findings around the code I've modified:

- I'm not sure how `return`s in `oneDriveMovedNotDeleted` finally blocks affect the code (for example `sync.d:1605`). If such `return` statement is executed, then `applyDifferences` function is interrupted and changes are not further processed. Are those returns there for any particular purpose?
- I have some doubts about `canFind(originalLocalPath, syncFolderChildPath)` call in `sync.d:1639`. `originalLocalPath` evaluates to the file path that is **not** prefixed by `/drive/root`, as `syncFolderChildPath` variable is, so that `canFind` call always seem to return `false`. Unless I'm missing something?

I would really appreciate getting in touch with you to try making that change. I feel like it has a potential to make your tool's experience even greater.