### PR TITLE
[systemd] Sync remote changes before start monitor

### DIFF
--- a/contrib/systemd/onedrive.service.in
+++ b/contrib/systemd/onedrive.service.in
@@ -5,6 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+ExecStartPre=@prefix@/bin/onedrive --synchronize
 ExecStart=@prefix@/bin/onedrive --monitor
 Restart=on-failure
 RestartSec=3

--- a/contrib/systemd/onedrive@.service.in
+++ b/contrib/systemd/onedrive@.service.in
@@ -5,6 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+ExecStartPre=@prefix@/bin/onedrive --synchronize --confdir=/home/%i/.config/onedrive
 ExecStart=@prefix@/bin/onedrive --monitor --confdir=/home/%i/.config/onedrive
 User=%i
 Group=users


### PR DESCRIPTION
When you start monitor, changes in remote did not download to local automatically. So do synchronize before start monitor.