### PR TITLE
Remove 'Icon' check as no longer valid

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -195,7 +195,6 @@ bool isValidName(string path)
 	matched = m.empty;
 	
 	// Additional explicit validation checks
-	if (itemName == "Icon") {matched = false;}
 	if (itemName == ".lock") {matched = false;}
 	if (itemName == "desktop.ini") {matched = false;}
 	// _vti_ cannot appear anywhere in a file or folder name


### PR DESCRIPTION
* Remove 'Icon' check as no longer listed as a invalid file or folder names in OneDrive API documentation