### PR TITLE
Handle deletion events for directories when inotify events are missing

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2978,15 +2978,17 @@ final class SyncEngine
 				if (!cfg.getValueBool("monitor")) {
 					// Not in --monitor mode
 					log.vlog("The directory has been deleted locally");
-					if (noRemoteDelete) {
-						// do not process remote directory delete
-						log.vlog("Skipping remote directory delete as --upload-only & --no-remote-delete configured");
-					} else {
-						uploadDeleteItem(item, path);
-					}	
 				} else {
 					// Appropriate message as we are in --monitor mode
-					log.vlog("The directory appears to have been deleted locally .. but we are running in --monitor mode. This may have been 'moved' rather than 'deleted'");
+					log.vlog("The directory appears to have been deleted locally .. but we are running in --monitor mode. This may have been 'moved' on the local filesystem rather than being 'deleted'");
+					log.vdebug("Most likely cause - 'inotify' event was missing for whatever action was taken locally or action taken when application was stopped");
+				}
+				// A moved file will be uploaded as 'new', delete the old file and reference
+				if (noRemoteDelete) {
+					// do not process remote directory delete
+					log.vlog("Skipping remote directory delete as --upload-only & --no-remote-delete configured");
+				} else {
+					uploadDeleteItem(item, path);
 				}
 			} else {
 				// we are in a --dry-run situation, directory appears to have deleted locally - this directory may never have existed as we never downloaded it ..


### PR DESCRIPTION
* Handle the missing inotify events for deleted items as a deletion event when running in --monitor