### PR TITLE
Adding support for authentication w/ single tenant custom applications

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -474,6 +474,16 @@ The following are supported for pattern matching and exclusion rules:
 
 **Note:** after changing the sync_list, you must perform a full re-synchronization by adding `--resync` to your existing command line - for example: `onedrive --synchronize --resync`
 
+### Configuring the client for 'single tenant application' use
+In some instances when using OneDrive Business Accounts, depending on the Azure organisational configuration, it will be necessary to configure the client as a 'single tenant application'. 
+To configure this, update the 'config' file with your tenant name (not the GUID), then this will be used for the authentication process.
+```text
+# bypass_data_preservation = "false"
+# azure_ad_endpoint = ""
+azure_tenant_id = "your.azure.tenant.id.name"
+# sync_business_shared_folders = "false"
+```
+
 ### How to 'skip' directories from syncing?
 There are several mechanisms available to 'skip' a directory from the sync process:
 *   Utilise 'skip_dir'

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -476,11 +476,14 @@ The following are supported for pattern matching and exclusion rules:
 
 ### Configuring the client for 'single tenant application' use
 In some instances when using OneDrive Business Accounts, depending on the Azure organisational configuration, it will be necessary to configure the client as a 'single tenant application'. 
-To configure this, update the 'config' file with your tenant name (not the GUID), then this will be used for the authentication process.
+To configure this, after creating the application on your Azure tenant, update the 'config' file with the tenant name (not the GUID) and the newly created Application ID, then this will be used for the authentication process.
 ```text
+# skip_dir_strict_match = "false"
+application_id = "your.application.id.guid"
+# resync = "false"
 # bypass_data_preservation = "false"
-# azure_ad_endpoint = ""
-azure_tenant_id = "your.azure.tenant.id.name"
+# azure_ad_endpoint = "xxxxxx"
+azure_tenant_id = "your.azure.tenant.name"
 # sync_business_shared_folders = "false"
 ```
 

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -151,6 +151,10 @@ final class OneDriveApi
 		switch(azureConfigValue) {
 			case "":
 				log.log("Configuring Global Azure AD Endpoints");
+				// Authentication
+				authUrl = globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/authorize";
+				redirectUrl = globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/nativeclient";
+				tokenUrl = globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/token";
 				break;
 			case "USL4":
 				log.log("Configuring Azure AD for US Government Endpoints");

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -150,7 +150,11 @@ final class OneDriveApi
 		string azureConfigValue = cfg.getValueString("azure_ad_endpoint");
 		switch(azureConfigValue) {
 			case "":
-				log.log("Configuring Global Azure AD Endpoints");
+				if (tenantId == "common") {
+					log.log("Configuring Global Azure AD Endpoints");
+				} else {
+					log.log("Configuring Global Azure AD Endpoints - Single Tenant Application");
+				}
 				// Authentication
 				authUrl = globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/authorize";
 				redirectUrl = globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/nativeclient";


### PR DESCRIPTION
Adding support for authentication w/ single tenant custom applications in OneDrive Business/Enterprise accounts.

When using a custom single tenant application the /common/ part on the authentication URLs needs to be replaced
by the tenant name. This can be configured on the azure_tenant_id setting, but this entry was being ignored unless
a custom azure_ad_endpoint was also set.