### PR TITLE
Added env variable to enable download-only mode in Docker

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -54,7 +54,7 @@ fi
 
 # Tell client to sync in download-only mode based on environment variable
 if [ "${ONEDRIVE_DOWNLOADONLY:=0}" == "1" ]; then
-   echo "# We are performing a --download-only"
+   echo "# We are synchronizing in download-only mode"
    ARGS=(--download-only ${ARGS[@]})
 fi
 

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -52,6 +52,12 @@ if [ "${ONEDRIVE_RESYNC:=0}" == "1" ]; then
    ARGS=(--resync ${ARGS[@]})
 fi
 
+# Tell client to sync in download-only mode based on environment variable
+if [ "${ONEDRIVE_DOWNLOADONLY:=0}" == "1" ]; then
+   echo "# We are performing a --download-only"
+   ARGS=(--download-only ${ARGS[@]})
+fi
+
 if [ ${#} -gt 0 ]; then
   ARGS=("${@}")
 fi

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -154,6 +154,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_DEBUG</B> | Controls "--verbose --verbose" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_DEBUG_HTTPS</B> | Controls "--debug-https" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_RESYNC</B> | Controls "--resync" switch on onedrive sync. Default is 0 | 1 |
+| <B>ONEDRIVE_DOWNLOADONLY</B> | Controls "--download-only" switch on onedrive sync. Default is 0 | 1 |
 
 ### Usage Examples
 **Verbose Output:**


### PR DESCRIPTION
Just started using Docker to deploy onedrive and after a ransomware attack decided that having at least one download-only mirror would be a good idea. First pull request ever, so still learning/open to feedback. Thanks for the great onedrive project, I use it all the time now! -- Rich