### PR TITLE
Check for the presence of .nosync when processing DB entries

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2816,7 +2816,7 @@ final class SyncEngine
 		}
 		
 		// scan for changes in the path provided
-		log.log("Uploading differences of ", logPath);
+		log.vlog("Uploading differences of ", logPath);
 		Item item;
 		// For each unique OneDrive driveID we know about
 		foreach (driveId; driveIDsArray) {
@@ -2946,9 +2946,18 @@ final class SyncEngine
 		// Is this item excluded by user configuration of skip_dir or skip_file?
 		// Is this item a directory or 'remote' type? A 'remote' type is a folder DB tie so should be compared as directory for exclusion
 		if ((item.type == ItemType.dir)||(item.type == ItemType.remote)) {
+			// Do we need to check for .nosync? Only if --check-for-nosync was passed in
+			if (cfg.getValueBool("check_nosync")) {
+				if (exists(path ~ "/.nosync")) {
+					log.vlog("Skipping item - .nosync found & --check-for-nosync enabled: ", path);
+					return;
+				}
+			}
+			
 			// Is the path excluded?
 			unwanted = selectiveSync.isDirNameExcluded(item.name);
 		}
+		
 		// Is this item a file?
 		if (item.type == ItemType.file) {
 			// Is the filename excluded?

--- a/src/sync.d
+++ b/src/sync.d
@@ -2816,7 +2816,7 @@ final class SyncEngine
 		}
 		
 		// scan for changes in the path provided
-		log.vlog("Uploading differences of ", logPath);
+		log.log("Uploading differences of ", logPath);
 		Item item;
 		// For each unique OneDrive driveID we know about
 		foreach (driveId; driveIDsArray) {


### PR DESCRIPTION
* Add check for .nosync if enabled for directory database objects as these might also be relevant mount points which have 'gone' away