### PR TITLE
Correctly set config directory permissions at first start

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -664,11 +664,20 @@ final class Config
 	
 	int returnRequiredDirectoryPermisions() {
 		// read the configuredDirectoryPermissionMode and return
+		if (configuredDirectoryPermissionMode == 0) {
+			// the configured value is zero, this means that directories would get
+			// values of d---------
+			configureRequiredDirectoryPermisions();
+		}
 		return configuredDirectoryPermissionMode;
 	}
 	
 	int returnRequiredFilePermisions() {
 		// read the configuredFilePermissionMode and return
+		if (configuredFilePermissionMode == 0) {
+			// the configured value is zero
+			configureRequiredFilePermisions();
+		}
 		return configuredFilePermissionMode;
 	}
 }

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -725,7 +725,13 @@ final class OneDriveApi
 				refreshToken = response["refresh_token"].str();
 				accessTokenExpiration = Clock.currTime() + dur!"seconds"(response["expires_in"].integer());
 				if (!.dryRun) {
-					std.file.write(cfg.refreshTokenFilePath, refreshToken);
+					try {
+						// try and update the refresh_token file
+						std.file.write(cfg.refreshTokenFilePath, refreshToken);
+					} catch (FileException e) {
+						// display the error message
+						displayFileSystemErrorMessage(e.msg);
+					}
 				}
 				if (printAccessToken) writeln("New access token: ", accessToken);
 			} else {
@@ -1309,6 +1315,14 @@ final class OneDriveApi
 		if (errorMessage.type() == JSONType.object) {
 			log.error("  Error Reason:  ", errorMessage["error_description"].str);
 		}
+	}
+	
+	// Parse and display error message received from the local file system
+	private void displayFileSystemErrorMessage(string message) 
+	{
+		log.error("ERROR: The local file system returned an error with the following message:");
+		auto errorArray = splitLines(message);
+		log.error("  Error Message: ", errorArray[0]);
 	}
 }
 

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -728,6 +728,7 @@ final class OneDriveApi
 					try {
 						// try and update the refresh_token file
 						std.file.write(cfg.refreshTokenFilePath, refreshToken);
+						cfg.refreshTokenFilePath.setAttributes(cfg.returnRequiredFilePermisions());
 					} catch (FileException e) {
 						// display the error message
 						displayFileSystemErrorMessage(e.msg);


### PR DESCRIPTION
* When ~/.config/onedrive/ gets created for the first time, directory permissions are not set, thus, effective permissions of 'd---------' get applied. This then causes issues attempting to update the 'refresh_token' as permission is denied.
* When permission is denied, the file exception error is not correctly handled