### PR TITLE
Fix download failure and crash due to incorrect local filesystem permissions when using mounted external devices

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -501,7 +501,13 @@ final class OneDriveApi
 		// Configure the applicable permissions for the folder
 		newPath.setAttributes(cfg.returnRequiredDirectoryPermisions());
 		const(char)[] url = driveByIdUrl ~ driveId ~ "/items/" ~ id ~ "/content?AVOverride=1";
+		// Download file
 		download(url, saveToPath, fileSize);
+		// Does path exist?
+		if (exists(saveToPath)) {
+			// File was downloaded sucessfully - configure the applicable permissions for the file
+			saveToPath.setAttributes(cfg.returnRequiredFilePermisions());
+		}
 	}
 
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content
@@ -797,8 +803,14 @@ final class OneDriveApi
 	{
 		// Threshold for displaying download bar
 		long thresholdFileSize = 4 * 2^^20; // 4 MiB
-		// open file as write in binary mode
-		auto file = File(filename, "wb");
+		
+		try {
+			// open file as write in binary mode
+			auto file = File(filename, "wb");
+		} catch (FileException e) {
+			// display the error message
+			displayFileSystemErrorMessage(e.msg);
+		}
 		
 		// function scopes
 		scope(exit) {
@@ -818,8 +830,6 @@ final class OneDriveApi
 				// close open file
 				file.close();
 			}
-			// Configure the applicable permissions for the file
-			filename.setAttributes(cfg.returnRequiredFilePermisions());
 		}
 		
 		http.method = HTTP.Method.get;

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -493,8 +493,17 @@ final class OneDriveApi
 	{
 		checkAccessTokenExpired();
 		scope(failure) {
-			if (exists(saveToPath)) remove(saveToPath);
+			if (exists(saveToPath)) {
+				// try and remove the file, catch error
+				try {
+					remove(saveToPath);
+				} catch (FileException e) {
+					// display the error message
+					displayFileSystemErrorMessage(e.msg);
+				} 
+			}	
 		}
+		
 		// Create the directory
 		string newPath = dirName(saveToPath);
 		mkdirRecurse(newPath);
@@ -803,6 +812,7 @@ final class OneDriveApi
 	{
 		// Threshold for displaying download bar
 		long thresholdFileSize = 4 * 2^^20; // 4 MiB
+		// open file as write in binary mode
 		auto file = File(filename, "wb");
 		
 		// function scopes

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -803,14 +803,7 @@ final class OneDriveApi
 	{
 		// Threshold for displaying download bar
 		long thresholdFileSize = 4 * 2^^20; // 4 MiB
-		
-		try {
-			// open file as write in binary mode
-			auto file = File(filename, "wb");
-		} catch (FileException e) {
-			// display the error message
-			displayFileSystemErrorMessage(e.msg);
-		}
+		auto file = File(filename, "wb");
 		
 		// function scopes
 		scope(exit) {

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -506,7 +506,13 @@ final class OneDriveApi
 		
 		// Create the directory
 		string newPath = dirName(saveToPath);
-		mkdirRecurse(newPath);
+		try {
+			mkdirRecurse(newPath);
+		} catch (FileException e) {
+			// display the error message
+			displayFileSystemErrorMessage(e.msg);
+		}
+		
 		// Configure the applicable permissions for the folder
 		newPath.setAttributes(cfg.returnRequiredDirectoryPermisions());
 		const(char)[] url = driveByIdUrl ~ driveId ~ "/items/" ~ id ~ "/content?AVOverride=1";

--- a/src/sync.d
+++ b/src/sync.d
@@ -2025,7 +2025,7 @@ final class SyncEngine
 				} else {
 					// parent id is not in the database
 					unwanted = true;
-					log.vlog("Skipping item - parent not present in local database");
+					log.vlog("Skipping file - parent path not present in local database");
 				}
 			}
 		}

--- a/src/sync.d
+++ b/src/sync.d
@@ -2423,10 +2423,15 @@ final class SyncEngine
 			}
 			
 			if (!dryRun) {
-				// Create the new directory
-				mkdirRecurse(path);
-				// Configure the applicable permissions for the folder
-				path.setAttributes(cfg.returnRequiredDirectoryPermisions());
+				try {
+					// Create the new directory
+					mkdirRecurse(path);
+					// Configure the applicable permissions for the folder
+					path.setAttributes(cfg.returnRequiredDirectoryPermisions());
+				} catch (FileException e) {
+					// display the error message
+					displayFileSystemErrorMessage(e.msg);
+				}
 			} else {
 				// we dont create the directory, but we need to track that we 'faked it'
 				idsFaked ~= [item.driveId, item.id];

--- a/src/sync.d
+++ b/src/sync.d
@@ -2431,6 +2431,9 @@ final class SyncEngine
 				} catch (FileException e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);
+					// flag that this download failed, otherwise the 'item' is added to the database - then, as not present on the local disk, would get deleted from OneDrive
+					downloadFailed = true;
+					return;
 				}
 			} else {
 				// we dont create the directory, but we need to track that we 'faked it'

--- a/src/sync.d
+++ b/src/sync.d
@@ -2431,9 +2431,6 @@ final class SyncEngine
 				} catch (FileException e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);
-					// flag that this download failed, otherwise the 'item' is added to the database - then, as not present on the local disk, would get deleted from OneDrive
-					downloadFailed = true;
-					return;
 				}
 			} else {
 				// we dont create the directory, but we need to track that we 'faked it'

--- a/src/sync.d
+++ b/src/sync.d
@@ -2565,7 +2565,6 @@ final class SyncEngine
 				log.vdebug("onedrive.downloadById(item.driveId, item.id, path, fileSize); generated a OneDriveException");
 				// 408 = Request Time Out 
 				// 429 = Too Many Requests - need to delay
-				
 				if (e.httpStatusCode == 408) {
 					// 408 error handling - request time out
 					// https://github.com/abraunegg/onedrive/issues/694
@@ -2637,6 +2636,12 @@ final class SyncEngine
 						}
 					}
 				}
+			} catch (FileException e) {
+				// There was a file system error
+				// display the error message
+				displayFileSystemErrorMessage(e.msg);							
+				downloadFailed = true;
+				return;
 			} catch (std.exception.ErrnoException e) {
 				// There was a file system error
 				// display the error message

--- a/src/sync.d
+++ b/src/sync.d
@@ -2006,25 +2006,31 @@ final class SyncEngine
 				// - full path + combination of any above two - /path/name*.txt
 				// - full path to file - /path/to/file.txt
 				
-				// need to compute the full path for this file
-				path = itemdb.computePath(item.driveId, item.parentId) ~ "/" ~ item.name;
-				
-				// The path that needs to be checked needs to include the '/'
-				// This due to if the user has specified in skip_file an exclusive path: '/path/file' - that is what must be matched
-				if (!startsWith(path, "/")){
-					// Add '/' to the path
-					path = '/' ~ path;
+				// is the parent id in the database?
+				if (itemdb.idInLocalDatabase(item.driveId, item.parentId)){
+					// need to compute the full path for this file
+					path = itemdb.computePath(item.driveId, item.parentId) ~ "/" ~ item.name;
+					
+					// The path that needs to be checked needs to include the '/'
+					// This due to if the user has specified in skip_file an exclusive path: '/path/file' - that is what must be matched
+					if (!startsWith(path, "/")){
+						// Add '/' to the path
+						path = '/' ~ path;
+					}
+					
+					log.vdebug("skip_file item to check: ", path);
+					unwanted = selectiveSync.isFileNameExcluded(path);
+					log.vdebug("Result: ", unwanted);
+					if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
+				} else {
+					// parent id is not in the database
+					unwanted = true;
+					log.vlog("Skipping item - parent not present in local database");
 				}
-				
-				log.vdebug("skip_file item to check: ", path);
-				unwanted = selectiveSync.isFileNameExcluded(path);
-				log.vdebug("Result: ", unwanted);
-				if (unwanted) log.vlog("Skipping item - excluded by skip_file config: ", item.name);
 			}
 		}
 
 		// check the item type
-		
 		if (!unwanted) {
 			if (isItemFile(driveItem)) {
 				log.vdebug("The item we are syncing is a file");
@@ -2238,6 +2244,14 @@ final class SyncEngine
 			}
 			// What was the item that was saved
 			log.vdebug("item details: ", item);
+		}  else {
+			// flag was tripped, which was it
+			if (downloadFailed) {
+				log.vdebug("Download or creation of local directory failed");
+			}
+			if (malwareDetected) {
+				log.vdebug("OneDrive reported that file contained malware");
+			}
 		}
 	}
 
@@ -2431,6 +2445,9 @@ final class SyncEngine
 				} catch (FileException e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);
+					// flag that this failed
+					downloadFailed = true;
+					return;
 				}
 			} else {
 				// we dont create the directory, but we need to track that we 'faked it'


### PR DESCRIPTION
* Move set file attributes to master function, in-case there is a download failure, exit scope cannot set attributes on a file that is non existent