### PR TITLE
Fix changing permissions on pre-existing local directories

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -658,6 +658,7 @@ int main(string[] args)
 			// Attempt to create the sync dir we have been configured with
 			mkdirRecurse(syncDir);
 			// Configure the applicable permissions for the folder
+			log.vdebug("Setting directory permissions for: ", syncDir);
 			syncDir.setAttributes(cfg.returnRequiredDirectoryPermisions());
 		} catch (std.file.FileException e) {
 			// Creating the sync directory failed
@@ -913,6 +914,7 @@ int main(string[] args)
 						string singleDirectoryPath = cfg.getValueString("single_directory");
 						mkdirRecurse(singleDirectoryPath);
 						// Configure the applicable permissions for the folder
+						log.vdebug("Setting directory permissions for: ", singleDirectoryPath);
 						singleDirectoryPath.setAttributes(cfg.returnRequiredDirectoryPermisions());
 					}
 				}

--- a/src/sync.d
+++ b/src/sync.d
@@ -2438,10 +2438,15 @@ final class SyncEngine
 			
 			if (!dryRun) {
 				try {
-					// Create the new directory
-					mkdirRecurse(path);
-					// Configure the applicable permissions for the folder
-					path.setAttributes(cfg.returnRequiredDirectoryPermisions());
+					// Does the path exist locally?
+					if (!exists(path)) {
+						// Create the new directory
+						log.vdebug("Requested path does not exist, creating directory structure: ", path);
+						mkdirRecurse(path);
+						// Configure the applicable permissions for the folder
+						log.vdebug("Setting directory permissions for: ", path);
+						path.setAttributes(cfg.returnRequiredDirectoryPermisions());
+					}
 				} catch (FileException e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);


### PR DESCRIPTION
* When attempting to create local directories, test to determine if they exist locally first before creating & setting file system permissions