### PR TITLE
Fix application crash in --monitor mode due to 'Failed to stat file' when setgid is used on a directory

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2512,9 +2512,6 @@ final class SyncEngine
 				} catch (FileException e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);
-				} catch (Exception e) {
-					// display the error message
-					displayFileSystemErrorMessage(e.msg);
 				}
 			}
 		} 
@@ -2694,9 +2691,6 @@ final class SyncEngine
 						log.vdebug("Calling setTimes() for this file: ", path);
 						setTimes(path, item.mtime, item.mtime);
 					} catch (FileException e) {
-						// display the error message
-						displayFileSystemErrorMessage(e.msg);
-					} catch (Exception e) {
 						// display the error message
 						displayFileSystemErrorMessage(e.msg);
 					}

--- a/src/sync.d
+++ b/src/sync.d
@@ -2507,8 +2507,12 @@ final class SyncEngine
 			// handle changed time
 			if (newItem.type == ItemType.file && oldItem.mtime != newItem.mtime) {
 				try {
+					log.vdebug("Calling setTimes() for this file: ", newPath);
 					setTimes(newPath, newItem.mtime, newItem.mtime);
 				} catch (FileException e) {
+					// display the error message
+					displayFileSystemErrorMessage(e.msg);
+				} catch (Exception e) {
 					// display the error message
 					displayFileSystemErrorMessage(e.msg);
 				}
@@ -2687,8 +2691,12 @@ final class SyncEngine
 					// downloaded matches either size or hash
 					log.vdebug("Downloaded file matches reported size and or reported file hash");
 					try {
+						log.vdebug("Calling setTimes() for this file: ", path);
 						setTimes(path, item.mtime, item.mtime);
 					} catch (FileException e) {
+						// display the error message
+						displayFileSystemErrorMessage(e.msg);
+					} catch (Exception e) {
 						// display the error message
 						displayFileSystemErrorMessage(e.msg);
 					}


### PR DESCRIPTION
* Add debugging output when adding paths and items to an inotify watch
* Only if a path is a directory, perform a path walk
* Catch Exception as error