### PR TITLE
Fix alpine docker build

### DIFF
--- a/contrib/docker/Dockerfile-alpine
+++ b/contrib/docker/Dockerfile-alpine
@@ -1,7 +1,6 @@
 # -*-Dockerfile-*-
 FROM golang:alpine
-RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
-     -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
+RUN apk add \
     alpine-sdk gnupg xz curl-dev sqlite-dev binutils-gold \
     autoconf automake ldc
 RUN go get github.com/tianon/gosu
@@ -15,8 +14,7 @@ RUN cd /usr/src/onedrive/ && \
 
 FROM alpine
 ENTRYPOINT ["/entrypoint.sh"]
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
-     -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
+RUN apk add --no-cache \
     bash libcurl libgcc shadow sqlite-libs ldc-runtime && \
     mkdir -p /onedrive/conf /onedrive/data
 COPY contrib/docker/entrypoint.sh /


### PR DESCRIPTION
Current build is not working and stating missing symbols, this seem
to be due to using the edge version of ldc and ldc-runtime.