### PR TITLE
Fix alpine build so it uses the same alpine version

### DIFF
--- a/contrib/docker/Dockerfile-alpine
+++ b/contrib/docker/Dockerfile-alpine
@@ -1,8 +1,8 @@
 # -*-Dockerfile-*-
-FROM golang:alpine
+FROM alpine
 RUN apk add \
     alpine-sdk gnupg xz curl-dev sqlite-dev binutils-gold \
-    autoconf automake ldc
+    autoconf automake ldc go
 RUN go get github.com/tianon/gosu
 COPY . /usr/src/onedrive
 RUN cd /usr/src/onedrive/ && \
@@ -18,4 +18,4 @@ RUN apk add --no-cache \
     bash libcurl libgcc shadow sqlite-libs ldc-runtime && \
     mkdir -p /onedrive/conf /onedrive/data
 COPY contrib/docker/entrypoint.sh /
-COPY --from=0 /go/bin/gosu /usr/local/bin/onedrive /usr/local/bin/
+COPY --from=0 /root/go/bin/gosu /usr/local/bin/onedrive /usr/local/bin/


### PR DESCRIPTION
The current docker file uses golang:alpine which can fall out of
step with alpine:latest. If there build does fall out of step the
ldc compiler will have different version the runtime will have
different lib dependences and hence will not work stating missing/
mismatched runtime libraries. This can be address by directly
pulling the alpine docker and installing go using the alpine
version, and hence the mismatch will not accrue.