### PR TITLE
Search all distinct drive id's rather than just default drive id for --get-file-link (Issue #1227)

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -484,4 +484,18 @@ final class ItemDatabase
 		auto stmt = db.prepare("VACUUM;");
 		stmt.exec();
 	}
+	
+	// Select distinct driveId items from database
+	string[] selectDistinctDriveIds()
+	{
+		string[] driveIdArray;
+		auto stmt = db.prepare("SELECT DISTINCT driveId FROM item;");
+		auto res = stmt.exec();
+		if (res.empty) return driveIdArray;
+		while (!res.empty) {
+			driveIdArray ~= res.front[0].dup;
+			res.step();
+		}
+		return driveIdArray;
+	}
 }

--- a/src/sync.d
+++ b/src/sync.d
@@ -5528,25 +5528,31 @@ final class SyncEngine
 		if (exists(localFilePath)) {
 			// File exists locally, does it exist in the database
 			// Path needs to be relative to sync_dir path
-			string relativePath = relativePath(localFilePath, syncDir);
 			Item item;
-			if (itemdb.selectByPath(relativePath, defaultDriveId, item)) {
-				// File is in the local database cache
-				JSONValue fileDetails;
-		
-				try {
-					fileDetails = onedrive.getFileDetails(item.driveId, item.id);
-				} catch (OneDriveException e) {
-					// display what the error is
-					displayOneDriveErrorMessage(e.msg, getFunctionName!({}));
-					return;
-				}
+			string[] distinctDriveIds = itemdb.selectDistinctDriveIds();
+			string relativePath = relativePath(localFilePath, syncDir);
+			bool fileInDB = false;
+			foreach (searchDriveId; distinctDriveIds) {
+				if (itemdb.selectByPath(relativePath, searchDriveId, item)) {
+					// File is in the local database cache
+					fileInDB = true;
+					JSONValue fileDetails;
+					try {
+						fileDetails = onedrive.getFileDetails(item.driveId, item.id);
+					} catch (OneDriveException e) {
+						// display what the error is
+						displayOneDriveErrorMessage(e.msg, getFunctionName!({}));
+						return;
+					}
 
-				if ((fileDetails.type() == JSONType.object) && ("webUrl" in fileDetails)) {
-					// Valid JSON object
-					writeln(fileDetails["webUrl"].str);
+					if ((fileDetails.type() == JSONType.object) && ("webUrl" in fileDetails)) {
+						// Valid JSON object
+						writeln(fileDetails["webUrl"].str);
+					}
 				}
-			} else {
+			}
+			// was file found?
+			if (!fileInDB) {
 				// File has not been synced with OneDrive
 				log.error("File has not been synced with OneDrive: ", localFilePath);
 			}


### PR DESCRIPTION
* Add new DB query to return distinct driveId's from database
* Use all distinct drive ID's to query if path is in-sync with OneDrive before attempting to retrieve the item file link from OneDrive