### PR TITLE
Dockerfile config for arm64

### DIFF
--- a/contrib/docker/Dockerfile-rpi
+++ b/contrib/docker/Dockerfile-rpi
@@ -1,12 +1,13 @@
 # -*-Dockerfile-*-
 FROM debian:stretch
+ARG ARCH armhf # or aarch64
 RUN apt update && \
     apt install -y build-essential curl libcurl4-openssl-dev libsqlite3-dev pkg-config wget git
-RUN wget https://github.com/ldc-developers/ldc/releases/download/v1.16.0/ldc2-1.16.0-linux-armhf.tar.xz && \
-    tar -xvf ldc2-1.16.0-linux-armhf.tar.xz
+RUN wget https://github.com/ldc-developers/ldc/releases/download/v1.16.0/ldc2-1.16.0-linux-${ARCH}.tar.xz && \
+    tar -xvf ldc2-1.16.0-linux-${ARCH}.tar.xz
 COPY . /usr/src/onedrive
 RUN cd /usr/src/onedrive/ && \
-    ./configure DC=/ldc2-1.16.0-linux-armhf/bin/ldmd2 && \
+    ./configure DC=/ldc2-1.16.0-linux-${ARCH}/bin/ldmd2 && \
     make clean && \
     make && \
     make install


### PR DESCRIPTION
This allows using the same Dockerfile for both armhf and arm64.

@abraunegg I would like to also add automated builds, but couldnt find how its done for amd64. Can you point me in the right direction?