### PR TITLE
Fix logging output when handing downloaded files

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -453,7 +453,8 @@ int main(string[] args)
 	
 	// vdebug syncDir as set and calculated
 	log.vdebug("syncDir: ", syncDir);
-	
+	// As we use the cfg value of sync_dir elsewhere, and if it includes a ~ it is now correctly expanded, update the configuration with new expanded value
+	cfg.setValueString("sync_dir", syncDir);
 	
 	// Configure the logging directory if different from application default
 	// log_dir environment handling to handle ~ expansion properly

--- a/src/sync.d
+++ b/src/sync.d
@@ -3099,9 +3099,10 @@ final class SyncEngine
 			// if this path is a directory, output this message.
 			// if a file, potentially leads to confusion as to what the client is actually doing
 			log.vlog("Uploading new items of ", logPath);
-			// Filesystem walk to find new files not uploaded - only valid for directories
-			uploadNewItems(path);
 		}
+		
+		// Filesystem walk to find new files not uploaded
+		uploadNewItems(path);
 	}
 	
 	private void uploadDifferences(const ref Item item)

--- a/src/sync.d
+++ b/src/sync.d
@@ -2973,7 +2973,11 @@ final class SyncEngine
 		}
 		
 		// scan for changes in the path provided
-		log.vlog("Uploading differences of ", logPath);
+		if (isDir(logPath)) {
+			// if this path is a directory, output this message.
+			// if a file, potentially leads to confusion as to what the client is actually doing
+			log.vlog("Uploading differences of ", logPath);
+		}
 		Item item;
 		// For each unique OneDrive driveID we know about
 		foreach (driveId; driveIDsArray) {
@@ -2983,11 +2987,13 @@ final class SyncEngine
 				// There could be multiple shared folders all from this same driveId
 				foreach(dbItem; itemdb.selectByDriveId(driveId)) {
 					// Does it still exist on disk in the location the DB thinks it is
+					log.vdebug("Calling uploadDifferences(dbItem) as item is present in local cache DB");
 					uploadDifferences(dbItem);
 				}
 			} else {
 				if (itemdb.selectByPath(path, driveId, item)) {
 					// Does it still exist on disk in the location the DB thinks it is
+					log.vdebug("Calling uploadDifferences(item) as item is present in local cache DB");
 					uploadDifferences(item);
 				}
 			}
@@ -3088,9 +3094,14 @@ final class SyncEngine
 			logPath = path;
 		}
 		
-		log.vlog("Uploading new items of ", logPath);
-		// Filesystem walk to find new files not uploaded
-		uploadNewItems(path);
+		// scan for changes in the path provided
+		if (isDir(logPath)) {
+			// if this path is a directory, output this message.
+			// if a file, potentially leads to confusion as to what the client is actually doing
+			log.vlog("Uploading new items of ", logPath);
+			// Filesystem walk to find new files not uploaded - only valid for directories
+			uploadNewItems(path);
+		}
 	}
 	
 	private void uploadDifferences(const ref Item item)
@@ -3311,6 +3322,9 @@ final class SyncEngine
 	{
 		// Reset upload failure - OneDrive or filesystem issue (reading data)
 		uploadFailed = false;
+		
+		// uploadFileDifferences is called when processing DB entries to compare against actual files on disk
+		string itemSource = "database";
 	
 		assert(item.type == ItemType.file);
 		if (exists(path)) {
@@ -3325,12 +3339,14 @@ final class SyncEngine
 					localModifiedTime.fracSecs = Duration.zero;
 					
 					if (localModifiedTime != itemModifiedTime) {
-						log.vlog("The file last modified time has changed");					
+						log.vlog("The file last modified time has changed");
+						log.vdebug("The local item has a different modified time ", localModifiedTime, " when compared to ", itemSource, " modified time ", itemModifiedTime);
 						string eTag = item.eTag;
 						
 						// perform file hash tests - has the content of the file changed?
 						if (!testFileHash(path, item)) {
 							log.vlog("The file content has changed");
+							log.vdebug("The local item has a different hash when compared to ", itemSource, " item hash");
 							write("Uploading modified file ", path, " ... ");
 							JSONValue response;
 							


### PR DESCRIPTION
* Fix logging output when processing files to remove potential ambiguity as to what events are actually occurring with individual file events