### PR TITLE
Revert the config & logpath change and check correct input entry

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -453,8 +453,6 @@ int main(string[] args)
 	
 	// vdebug syncDir as set and calculated
 	log.vdebug("syncDir: ", syncDir);
-	// As we use the cfg value of sync_dir elsewhere, and if it includes a ~ it is now correctly expanded, update the configuration with new expanded value
-	cfg.setValueString("sync_dir", syncDir);
 	
 	// Configure the logging directory if different from application default
 	// log_dir environment handling to handle ~ expansion properly

--- a/src/sync.d
+++ b/src/sync.d
@@ -2973,7 +2973,7 @@ final class SyncEngine
 		}
 		
 		// scan for changes in the path provided
-		if (isDir(logPath)) {
+		if (isDir(path)) {
 			// if this path is a directory, output this message.
 			// if a file, potentially leads to confusion as to what the client is actually doing
 			log.vlog("Uploading differences of ", logPath);
@@ -3095,7 +3095,7 @@ final class SyncEngine
 		}
 		
 		// scan for changes in the path provided
-		if (isDir(logPath)) {
+		if (isDir(path)) {
 			// if this path is a directory, output this message.
 			// if a file, potentially leads to confusion as to what the client is actually doing
 			log.vlog("Uploading new items of ", logPath);


### PR DESCRIPTION
* Revert the config & logpath change introduced via #1267 as the logging path should not be the value checked, the input path is what should be checked