### PR TITLE
Remove depreciated config option 'force_http_11'

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,6 @@
 # disable_notifications = "false"
 # disable_upload_validation = "false"
 # enable_logging = "false"
-# force_http_11 = "false"
 # force_http_2 = "false"
 # local_first = "false"
 # no_remote_delete = "false"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -326,7 +326,6 @@ See the [config](https://raw.githubusercontent.com/abraunegg/onedrive/master/con
 # disable_notifications = "false"
 # disable_upload_validation = "false"
 # enable_logging = "false"
-# force_http_11 = "false"
 # force_http_2 = "false"
 # local_first = "false"
 # no_remote_delete = "false"

--- a/onedrive.1.in
+++ b/onedrive.1.in
@@ -89,11 +89,6 @@ Configuration file key: \fBenable_logging\fP (default: \fBfalse\fP)
 \fB\-\-force\fP
 Force the deletion of data when a 'big delete' is detected
 .TP
-\fB\-\-force\-http\-1.1\fP
-Force the use of HTTP 1.1 for all operations (DEPRECIATED)
-.br
-Configuration file key: \fBforce_http_11\fP (default: \fBfalse\fP)
-.TP
 \fB\-\-force\-http\-2\fP
 Force the use of HTTP/2 for all operations where applicable
 .br

--- a/src/config.d
+++ b/src/config.d
@@ -61,7 +61,6 @@ final class Config
 		boolValues["disable_notifications"] = false;
 		boolValues["disable_upload_validation"] = false;
 		boolValues["enable_logging"] = false;
-		boolValues["force_http_11"] = false;
 		boolValues["force_http_2"] = false;
 		boolValues["local_first"] = false;
 		boolValues["no_remote_delete"] = false;
@@ -343,9 +342,6 @@ final class Config
 				"enable-logging",
 					"Enable client activity to a separate log file",
 					&boolValues["enable_logging"],
-				"force-http-1.1",
-					"Force the use of HTTP/1.1 for all operations (DEPRECIATED)",
-					&boolValues["force_http_11"],
 				"force-http-2",
 					"Force the use of HTTP/2 for all operations where applicable",
 					&boolValues["force_http_2"],

--- a/src/main.d
+++ b/src/main.d
@@ -580,11 +580,6 @@ int main(string[] args)
 		return EXIT_SUCCESS;
 	}
 	
-	// If the user is still using --force-http-1.1 advise its no longer required
-	if (cfg.getValueBool("force_http_11")) {
-		log.log("NOTE: The use of --force-http-1.1 is depreciated");
-	}
-	
 	// Test if OneDrive service can be reached, exit if it cant be reached
 	log.vdebug("Testing network to ensure network connectivity to Microsoft OneDrive Service");
 	online = testNetwork();


### PR DESCRIPTION
* Remove depreciated config option 'force_http_11' which was flagged as depreciated by PR #549 in v2.3.6 (June 2019).