### PR TITLE
Correctly handle files which contain '%'

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -205,7 +205,7 @@ bool isValidName(string path)
 			// Leading whitespace and trailing whitespace/dot
 			`^\s.*|^.*[\s\.]$|` ~
 			// Invalid characters
-			`.*[<>:"\|\?*/\\].*|` ~
+			`.*[<>:"\|\?*/\\%].*|` ~
 			// Reserved device name and trailing .~
 			`(?:^CON|^PRN|^AUX|^NUL|^COM[0-9]|^LPT[0-9])(?:[.].+)?$`
 		);


### PR DESCRIPTION
* Fix checking filenames which contain '%' which should be classified as invalid based on the MS OneDrive API Invalid characters designation