### PR TITLE
Update 'Skipping shared folder due to existing name conflict' check for Business Shared Folders

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -639,9 +639,12 @@ final class SyncEngine
 							// for each driveid in the existing driveIDsArray 
 							foreach (searchDriveId; driveIDsArray) {
 								log.vdebug("searching database for: ", searchDriveId, " ", sharedFolderName);
-								if (itemdb.selectByPath(sharedFolderName, searchDriveId, databaseItem)) {
+								if (itemdb.idInLocalDatabase(searchDriveId, searchResult["remoteItem"]["id"].str)){
+									// Shared folder is present
 									log.vdebug("Found shared folder name in database");
 									itemInDatabase = true;
+									// Query the DB for the details of this item
+									itemdb.selectByPath(sharedFolderName, searchDriveId, databaseItem);
 									log.vdebug("databaseItem: ", databaseItem);
 									// Does the databaseItem.driveId == defaultDriveId?
 									if (databaseItem.driveId == defaultDriveId) {


### PR DESCRIPTION
* In looking on how to investigate #1345, it appears that for some reason the logic behind syncing shared folders was not working (although it previously was). Update the logic to specifically check the DB for the required driveId & itemId before attempting to get that DB item.