### PR TITLE
Fix 'Item cannot be deleted from OneDrive because not found in the local database'

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1043,7 +1043,7 @@ int main(string[] args)
 					log.vlog("Offline, cannot delete item!");
 				} catch(SyncException e) {
 					if (e.msg == "The item to delete is not in the local database") {
-						log.vlog("Item cannot be deleted from OneDrive because not found in the local database");
+						log.vlog("Item cannot be deleted from OneDrive because it was not found in the local database");
 					} else {
 						log.logAndNotify("Cannot delete remote item: ", e.msg);
 					}

--- a/src/sync.d
+++ b/src/sync.d
@@ -5331,9 +5331,19 @@ final class SyncEngine
 	void deleteByPath(const(string) path)
 	{
 		Item item;
-		if (!itemdb.selectByPath(path, defaultDriveId, item)) {
+		// Need to check all driveid's we know about, not just the defaultDriveId
+		bool itemInDB = false;
+		foreach (searchDriveId; driveIDsArray) {
+			if (itemdb.selectByPath(path, searchDriveId, item)) {
+				// item was found in the DB
+				itemInDB = true;
+				break;
+			}
+		}
+		if (!itemInDB) {
 			throw new SyncException("The item to delete is not in the local database");
 		}
+		
 		if (item.parentId == null) {
 			// the item is a remote folder, need to do the operation on the parent
 			enforce(itemdb.selectByPathWithoutRemote(path, defaultDriveId, item));

--- a/src/sync.d
+++ b/src/sync.d
@@ -933,7 +933,6 @@ final class SyncEngine
 		}
 		
 		Item item;
-		
 		// Need to check all driveid's we know about, not just the defaultDriveId
 		bool itemInDB = false;
 		foreach (searchDriveId; driveIDsArray) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -933,7 +933,18 @@ final class SyncEngine
 		}
 		
 		Item item;
-		if (!itemdb.selectByPath(path, defaultDriveId, item)) {
+		
+		// Need to check all driveid's we know about, not just the defaultDriveId
+		bool itemInDB = false;
+		foreach (searchDriveId; driveIDsArray) {
+			if (itemdb.selectByPath(path, searchDriveId, item)) {
+				// item was found in the DB
+				itemInDB = true;
+				break;
+			}
+		}
+		// Was the item found in the DB
+		if (!itemInDB) {
 			// this is odd .. this directory is not in the local database - just go delete it
 			log.vlog("The requested directory to delete was not found in the local database - pushing delete request direct to OneDrive");
 			uploadDeleteItem(item, path);


### PR DESCRIPTION
* When in --monitor mode, and there are multiple driveId being used (shared folders), when a deletion event occurs, search the DB using all the known driveids rather than just the default one. When using just the default driveid, if the file to be deleted resides on another drive, the following error message is printed: 'Item cannot be deleted from OneDrive because not found in the local database' - which is not entirely accurate as the item is in the database, it is just not being searched for correctly.