### PR TITLE
Revert #1343 as OneDrive API is now fixed in relation to handling '%' within filenames

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -205,7 +205,7 @@ bool isValidName(string path)
 			// Leading whitespace and trailing whitespace/dot
 			`^\s.*|^.*[\s\.]$|` ~
 			// Invalid characters
-			`.*[<>:"\|\?*/\\%].*|` ~
+			`.*[<>:"\|\?*/\\].*|` ~
 			// Reserved device name and trailing .~
 			`(?:^CON|^PRN|^AUX|^NUL|^COM[0-9]|^LPT[0-9])(?:[.].+)?$`
 		);


### PR DESCRIPTION
* Revert #1343 as OneDrive API is now fixed in relation to handling '%' within filenames