### PR TITLE
Add file check when adding item to database if using --upload-only --remove-source-files

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -5351,7 +5351,8 @@ final class SyncEngine
 			if (hasId(jsonItem)) {
 				// Are we in a --upload-only & --remove-source-files scenario?
 				// We do not want to add the item to the database in this situation as there is no local reference to the file post file deletion
-				if ((uploadOnly) && (localDeleteAfterUpload)) {
+				// If the item is a directory, we need to add this to the DB, if this is a file, we dont add this, the parent path is not in DB, thus any new files in this directory are not added
+				if ((uploadOnly) && (localDeleteAfterUpload) && (isItemFile(jsonItem))) {
 					// Log that we skipping adding item to the local DB and the reason why
 					log.vdebug("Skipping adding to database as --upload-only & --remove-source-files configured");
 				} else {


### PR DESCRIPTION
* Add a file check when using --upload-only --remove-source-files so that parental paths are added to the database, to allow child objects to be uploaded in this scenario