### PR TITLE
Fix application crash when SharePoint displayName is being withheld

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -5696,8 +5696,21 @@ final class SyncEngine
 					// Add to siteSearchResults so we can display what we did find
 					string siteSearchResultsEntry;
 					foreach (searchResult; siteQuery["value"].array) {
-						siteSearchResultsEntry = " * " ~ searchResult["displayName"].str;
-						siteSearchResults ~= siteSearchResultsEntry;
+						// We can only add the displayName if it is available
+						if ("displayName" in searchResult) {
+							// Use the displayName
+							siteSearchResultsEntry = " * " ~ searchResult["displayName"].str;
+							siteSearchResults ~= siteSearchResultsEntry;
+						} else {
+							// Add, but indicate displayName unavailable, use id
+							if ("id" in searchResult) {
+								siteSearchResultsEntry = " * " ~ "Unknown displayName (Data not provided by API), Site ID: " ~ searchResult["id"].str;
+								siteSearchResults ~= siteSearchResultsEntry;
+							} else {
+								// displayName and id unavailable, display in debug log the entry
+								log.vdebug("Bad SharePoint Data for site: ", searchResult);
+							}
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
* Handle bad ShaprePoint data when the API does not return the expected data points when using those references to display what SharePoint sites are avaialble