### PR TITLE
Update Docker.md - add "-it" parameter in the command line when "--logout' is needed

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -205,7 +205,7 @@ docker container run -e ONEDRIVE_RESYNC=1 -e ONEDRIVE_VERBOSE=1 -v onedrive_conf
 
 **Perform a --logout and re-authenticate:**
 ```bash
-docker container run -e ONEDRIVE_LOGOUT=1 -v onedrive_conf:/onedrive/conf -v "${ONEDRIVE_DATA_DIR}:/onedrive/data" driveone/onedrive:latest
+docker container run -it -e ONEDRIVE_LOGOUT=1 -v onedrive_conf:/onedrive/conf -v "${ONEDRIVE_DATA_DIR}:/onedrive/data" driveone/onedrive:latest
 ```
 
 ## Build instructions


### PR DESCRIPTION
"-it" must be added to the command line in order to be able to paste the link to the response uri. Without adding "-it' in the command line parameters, docker just exists.