### PR TITLE
Fix application crash due to a conversion overflow when calculating file offset for session uploads

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -769,6 +769,7 @@ final class OneDriveApi
 		auto file = File(filepath, "rb");
 		file.seek(offset);
 		string contentRange = "bytes " ~ to!string(offset) ~ "-" ~ to!string(offset + offsetSize - 1) ~ "/" ~ to!string(fileSize);
+		log.vdebugNewLine("contentRange: ", contentRange);
 		
 		// function scopes
 		scope(exit) {
@@ -789,7 +790,8 @@ final class OneDriveApi
 		http.url = uploadUrl;
 		http.addRequestHeader("Content-Range", contentRange);
 		http.onSend = data => file.rawRead(data).length;
-		http.contentLength = offsetSize;
+		// convert offsetSize to ulong
+		http.contentLength = to!ulong(offsetSize);
 		auto response = perform();
 		// TODO: retry on 5xx errors
 		checkHttpCode(response);

--- a/src/upload.d
+++ b/src/upload.d
@@ -182,7 +182,7 @@ struct UploadSession
 				fragmentCount++;
 				log.vdebugNewLine("Fragment: ", fragmentCount, " of ", iteration);
 				p.next();
-				log.vdebugNewLine("fragmentSize: ", fragmentSize, "offset: ", offset, " fragSize: ", fragSize, " fileSize: ", fileSize );
+				log.vdebugNewLine("fragmentSize: ", fragmentSize, "offset: ", offset, " fileSize: ", fileSize );
 				fragSize = fragmentSize < fileSize - offset ? fragmentSize : fileSize - offset;
 				log.vdebugNewLine("Using fragSize: ", fragSize);
 				

--- a/src/upload.d
+++ b/src/upload.d
@@ -173,6 +173,7 @@ struct UploadSession
 			Progress p = new Progress(iteration);
 			p.title = "Uploading";
 			long fragmentCount = 0;
+			long fragSize = 0;
 			
 			// Initialise the download bar at 0%
 			p.next();
@@ -181,7 +182,23 @@ struct UploadSession
 				fragmentCount++;
 				log.vdebugNewLine("Fragment: ", fragmentCount, " of ", iteration);
 				p.next();
-				long fragSize = fragmentSize < fileSize - offset ? fragmentSize : fileSize - offset;
+				log.vdebugNewLine("fragmentSize: ", fragmentSize, "offset: ", offset, " fragSize: ", fragSize, " fileSize: ", fileSize );
+				fragSize = fragmentSize < fileSize - offset ? fragmentSize : fileSize - offset;
+				log.vdebugNewLine("Using fragSize: ", fragSize);
+				
+				// fragSize must not be a negative value
+				if (fragSize < 0) {
+					// Session upload will fail
+					// not a JSON object - fragment upload failed
+					log.vlog("File upload session failed - invalid calculation of fragment size");
+					if (exists(sessionFilePath)) {
+						remove(sessionFilePath);
+					}
+					// set response to null as error
+					response = null;
+					return response;
+				}
+				
 				// If the resume upload fails, we need to check for a return code here
 				try {
 					response = onedrive.uploadFragment(


### PR DESCRIPTION
* Fix an unhandled application crash when calculating the required offset for a file fragment size when resuming a session upload