### PR TITLE
Fix Docker Alpine build failing due to filesystem permissions issue

### DIFF
--- a/contrib/docker/Dockerfile-alpine
+++ b/contrib/docker/Dockerfile-alpine
@@ -1,5 +1,5 @@
 # -*-Dockerfile-*-
-FROM alpine
+FROM alpine:3.13
 RUN apk add \
     alpine-sdk gnupg xz curl-dev sqlite-dev binutils-gold \
     autoconf automake ldc go


### PR DESCRIPTION
* Fix Docker Alpine build failing due to filesystem permissions issue due to Alpine 3.14 - refer to https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2