### PR TITLE
Fix Alpine Docker lock to 3.13

### DIFF
--- a/contrib/docker/Dockerfile-alpine
+++ b/contrib/docker/Dockerfile-alpine
@@ -12,7 +12,7 @@ RUN cd /usr/src/onedrive/ && \
     make && \
     make install
 
-FROM alpine
+FROM alpine:3.13
 ENTRYPOINT ["/entrypoint.sh"]
 RUN apk add --no-cache \
     bash libcurl libgcc shadow sqlite-libs ldc-runtime && \


### PR DESCRIPTION
This issue relates to a build issue on the official docker build
system where Alpine Linux 3.14 will not currently build so fix
the Alpine version to 3.13.

Make sure build and runtime image used in building the docker
container are the same Alpine version to remove runtime issues.