### PR TITLE
Fix unable to upload to OneDrive Business Shared Folders due to API restricting quota information

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -425,9 +425,11 @@ final class SyncEngine
 					// json response was missing a 'remaining' value
 					if (accountType == "personal"){
 						log.error("ERROR: OneDrive quota information is missing. Potentially your OneDrive account currently has zero space available. Please free up some space online.");
+						quotaAvailable = false;
 					} else {
 						// quota details not available
 						log.error("ERROR: OneDrive quota information is being restricted. Please fix by speaking to your OneDrive / Office 365 Administrator.");
+						quotaRestricted = true;
 					}				
 				}
 			}


### PR DESCRIPTION
* In fixing #1712  which was due to a OneDrive API change, the flagging that quota is being restricted was missed, thus, if this is truly being restricted may cause files to OneDrive Business Shared Folders be unable to be uploaded despite space being available.