### PR TITLE
fix typo in the Ubuntu installation docs

### DIFF
--- a/docs/ubuntu-package-install.md
+++ b/docs/ubuntu-package-install.md
@@ -16,7 +16,7 @@ Whilst there are [onedrive](https://packages.ubuntu.com/search?keywords=onedrive
 Ubuntu and its clones are based on various different releases, thus, you must use the correct instructions below, otherwise you may run into package dependancy issues and will be unable to install the client.
 
 ### Step 1: Ensure your systen is up-to-date
-Use a script, simalar to the following to ensure your system is updated correctly:
+Use a script, similar to the following to ensure your system is updated correctly:
 ```text
 #!/bin/bash
 rm -rf /var/lib/dpkg/lock-frontend


### PR DESCRIPTION
I fixed a small typo in the Ubuntu installation docs. 'simalar' should be 'similar'.