### PR TITLE
Add function to check client version vs latest GitHub release

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -636,7 +636,7 @@ int main(string[] args)
 	log.vdebug("Testing network to ensure network connectivity to Microsoft OneDrive Service");
 	online = testNetwork();
 	if (!online) {
-	// Cant initialise the API as we are not online
+		// Cant initialise the API as we are not online
 		if (!cfg.getValueBool("monitor")) {
 			// Running as --synchronize
 			log.error("Unable to reach Microsoft OneDrive API service, unable to initialize application\n");
@@ -689,10 +689,12 @@ int main(string[] args)
 				return EXIT_FAILURE;
 			}
 		}
-	}
-
-	// Initialize OneDrive, check for authorization
-	if (online) {
+	} else {
+		// Check application version and Initialize OneDrive API, check for authorization
+		// Check Application Version
+		log.vlog("Checking Application Version ...");
+		checkApplicationVersion();
+	
 		// we can only initialise if we are online
 		log.vlog("Initializing the OneDrive API ...");
 		oneDrive = new OneDriveApi(cfg);

--- a/src/util.d
+++ b/src/util.d
@@ -362,10 +362,8 @@ string getLatestReleaseVersion() {
 	
 	if ("tag_name" in json) {
 		// use the provided tag
-		// "tag_name": "vA.B.CC",
-		latestTag = json["tag_name"].str;
-		// strip 'v'
-		latestTag = strip(latestTag, "v");
+		// "tag_name": "vA.B.CC" and strip 'v'
+		latestTag = strip(json["tag_name"].str, "v");
 	} else {
 		// set to zeros
 		latestTag = "0.0.0";

--- a/src/util.d
+++ b/src/util.d
@@ -351,6 +351,50 @@ string getFunctionName(alias func)() {
     return __traits(identifier, __traits(parent, func)) ~ "()\n";
 }
 
+// Get the latest release version from GitHub
+string getLatestReleaseVersion() {
+	// Import curl just for this function
+	import std.net.curl;
+	auto content = get("https://api.github.com/repos/abraunegg/onedrive/releases/latest");
+	JSONValue json;
+	string latestTag;
+	json = content.parseJSON();
+	
+	if ("tag_name" in json) {
+		// use the provided tag
+		// "tag_name": "vA.B.CC",
+		latestTag = json["tag_name"].str;
+		// strip 'v'
+		latestTag = strip(latestTag, "v");
+	} else {
+		// set to zeros
+		latestTag = "0.0.0";
+	}
+	// return the latest github version
+	return latestTag;
+}
+
+// Check the application version versus GitHub latestTag
+void checkApplicationVersion() {
+	// calculate if the client is current version or not
+	string latestVersion = strip(getLatestReleaseVersion());
+	auto currentVersionArray = strip(strip(import("version"), "v")).split("-");
+	string applicationVersion = currentVersionArray[0];
+	
+	// display warning if not current
+	if (applicationVersion != latestVersion) {
+		// application version is not the latest version that is available ..
+		if (applicationVersion > latestVersion) {
+			// application version is newer than available release ...
+		}
+		// application version is older than available on GitHub
+		if (applicationVersion < latestVersion) {
+			// application version is obsolete and unsupported
+			log.log("\nWARNING: Your onedrive client is obsolete and unsupported. Please upgrade your client version.\n");
+		}
+	}
+}
+
 // Unit Tests
 unittest
 {


### PR DESCRIPTION
* Add application version check, to check GitHub latest release tag and compare to the application version being run. If the application version is older, display a warning message that the client is obsolete and unsupported and that the user needs to upgrade their client version.