### PR TITLE
Override skip_dir|skip_file through flag to force sync

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,6 +28,7 @@
     + [min_notify_changes](#min_notify_changes)
     + [operation_timeout](#operation_timeout)
   * [Performing a --resync](#performing-a---resync)
+  * [Performing a --force-sync without a --resync or changing your configuration](#performing-a---force-sync-without-a---resync-or-changing-your-configuration)
   * [Handling Symbolic Links](#handling-symbolic-links)
   * [Selective sync via 'sync_list' file](#selective-sync-via-sync_list-file)
   * [Configuring the client for 'single tenant application' use](#configuring-the-client-for-single-tenant-application-use)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,7 +24,7 @@
     + [skip_file](#skip_file)
     + [skip_dotfiles](#skip_dotfiles)
     + [monitor_interval](#monitor_interval)
-	+ [monitor_fullscan_frequency](#monitor_fullscan_frequency)
+    + [monitor_fullscan_frequency](#monitor_fullscan_frequency)
     + [min_notify_changes](#min_notify_changes)
     + [operation_timeout](#operation_timeout)
   * [Performing a --resync](#performing-a---resync)
@@ -595,6 +595,28 @@ To proceed with using `--resync`, you must type 'y' or 'Y' to allow the applicat
 
 **Note:** In some automated environments (and it is 100% assumed you *know* what you are doing because of automation), in order to avoid this 'proceed with acknowledgement' requirement, add `--resync-auth` to automatically acknowledge the prompt.
 
+### Performing a --force-sync without a --resync or changing your configuration
+In some cases and situations, you may have configured the application to skip certain files and folders using 'skip_file' and 'skip_dir' configuration. You then may have a requirement to actually sync one of these items, but do not wish to modify your configuration, nor perform an entire `--resync` twice.
+
+The `--force-sync` option allows you to sync a specific directory, ignoring your 'skip_file' and 'skip_dir' configuration and negating the requirement to perform a `--resync`
+
+In order to use this option, you must run the application manually in the following manner:
+```text
+onedrive --synchronize --single-directory '<directory_to_sync>' --force-sync <add any other options needed or required>
+```
+
+When using `--force-sync`, the following warning and advice will be presented:
+```text
+WARNING: Overriding application configuration to use application defaults for skip_dir and skip_file due to --synchronize --single-directory --force-sync being used
+
+The use of --force-sync will reconfigure the application to use defaults. This may have untold and unknown future impacts.
+By proceeding in using this option you accept any impacts including any data loss that may occur as a result of using --force-sync.
+
+Are you sure you wish to proceed with --force-sync [Y/N] 
+```
+
+To proceed with using `--force-sync`, you must type 'y' or 'Y' to allow the application to continue.
+
 ### Handling Symbolic Links
 Microsoft OneDrive has zero concept or understanding of symbolic links, and attempting to upload a symbolic link to Microsoft OneDrive generates a platform API error. All data (files and folders) that are uploaded to OneDrive must be whole files or actual directories.
 
@@ -1118,6 +1140,8 @@ Options:
       Force the deletion of data when a 'big delete' is detected
   --force-http-2
       Force the use of HTTP/2 for all operations where applicable
+  --force-sync
+      Force a synchronization of a specific folder, only when using --single-directory and ignoring all non-default skip_dir and skip_file rules
   --get-O365-drive-id ARG
       Query and return the Office 365 Drive ID for a given Office 365 SharePoint Shared Library
   --get-file-link ARG

--- a/src/config.d
+++ b/src/config.d
@@ -303,6 +303,7 @@ final class Config
 		boolValues["synchronize"]         = false;
 		boolValues["force"]               = false;
 		boolValues["list_business_shared_folders"] = false;
+		boolValues["force_sync"]          = false;
 
 		// Application Startup option validation
 		try {
@@ -372,6 +373,9 @@ final class Config
 				"force",
 					"Force the deletion of data when a 'big delete' is detected",
 					&boolValues["force"],
+				"force-sync",
+					"Force a synchronization of a specific folder, only when using --single-directory and ignoring all non-default skip_dir and skip_file rules",
+					&boolValues["force_sync"],
 				"get-file-link",
 					"Display the file link of a synced file",
 					&stringValues["get_file_link"],
@@ -712,6 +716,20 @@ final class Config
 			configureRequiredFilePermisions();
 		}
 		return configuredFilePermissionMode;
+	}
+	
+	void resetSkipToDefaults() {
+		// reset skip_file and skip_dir to application defaults
+		// skip_file
+		log.vdebug("original skip_file: ", getValueString("skip_file"));
+		log.vdebug("resetting skip_file");
+		setValueString("skip_file", defaultSkipFile);
+		log.vdebug("reset skip_file: ", getValueString("skip_file"));
+		// skip_dir
+		log.vdebug("original skip_dir: ", getValueString("skip_dir"));
+		log.vdebug("resetting skip_dir");
+		setValueString("skip_dir", defaultSkipDir);
+		log.vdebug("reset skip_dir: ", getValueString("skip_dir"));
 	}
 }
 

--- a/src/config.d
+++ b/src/config.d
@@ -374,7 +374,7 @@ final class Config
 					"Force the deletion of data when a 'big delete' is detected",
 					&boolValues["force"],
 				"force-sync",
-					"Force a synchronization of a specific folder, only when using --single-directory and ignoring all non-default skip_dir and skip_file rules",
+					"Force a synchronization of a specific folder, only when using --synchronize --single-directory and ignore all non-default skip_dir and skip_file rules",
 					&boolValues["force_sync"],
 				"get-file-link",
 					"Display the file link of a synced file",

--- a/src/config.d
+++ b/src/config.d
@@ -736,6 +736,8 @@ final class Config
 void outputLongHelp(Option[] opt)
 {
 	auto argsNeedingOptions = [
+		"--auth-files",
+		"--auth-response",
 		"--confdir",
 		"--create-directory",
 		"--create-share-link",
@@ -750,7 +752,9 @@ void outputLongHelp(Option[] opt)
 		"--monitor-fullscan-frequency",
 		"--remove-directory",
 		"--single-directory",
+		"--skip-dir",
 		"--skip-file",
+		"--skip-size",
 		"--source-directory",
 		"--syncdir",
 		"--user-agent" ];


### PR DESCRIPTION
* Force a synchronization of a specific folder, only when using --synchronize --single-directory and ignoring all non-default skip_dir and skip_file rules