### PR TITLE
add libphobos2-ldc-shared94 to Dockerfile-debian

### DIFF
--- a/contrib/docker/Dockerfile-debian
+++ b/contrib/docker/Dockerfile-debian
@@ -19,7 +19,7 @@ RUN ./configure DC=/usr/bin/ldmd2 \
 FROM debian:${DEBIAN_VERSION}-slim
 
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libcurl4 libsqlite3-0 ca-certificates \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libcurl4 libsqlite3-0 ca-certificates libphobos2-ldc-shared-dev \
  && rm -rf /var/lib/apt/lists/* \
  # Fix bug with ssl on armhf: https://serverfault.com/a/1045189
  && /usr/bin/c_rehash \

--- a/contrib/docker/Dockerfile-debian
+++ b/contrib/docker/Dockerfile-debian
@@ -19,7 +19,7 @@ RUN ./configure DC=/usr/bin/ldmd2 \
 FROM debian:${DEBIAN_VERSION}-slim
 
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libcurl4 libsqlite3-0 ca-certificates libphobos2-ldc-shared-dev \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libcurl4 libsqlite3-0 ca-certificates libphobos2-ldc-shared94 \
  && rm -rf /var/lib/apt/lists/* \
  # Fix bug with ssl on armhf: https://serverfault.com/a/1045189
  && /usr/bin/c_rehash \


### PR DESCRIPTION
I was facing this issue when building the container on my raspi 4. I started the docker container and got back; 
```
Attaching to onedrive_onedrive_1
onedrive_1  | Base Args: --monitor
onedrive_1  | # Launching onedrive
onedrive_1  | /usr/local/bin/onedrive: error while loading shared libraries: libphobos2-ldc-shared.so.94: cannot open shared object file: No such file or directory
```
I fixed it by adding "libphobos2-ldc-shared-dev" to the Dockerfile-debian file.