### PR TITLE
Update when DB is updated by OneDrive API data and update when file hash is required to be generated

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2437,6 +2437,7 @@ final class SyncEngine
 
 		// update the item
 		if (cached) {
+			// the item is in the items.sqlite3 database
 			log.vdebug("OneDrive change is an update to an existing local item");
 			applyChangedItem(oldItem, oldPath, item, path);
 		} else {
@@ -2459,19 +2460,21 @@ final class SyncEngine
 			// if the file was detected as malware and NOT downloaded, we dont want to falsify the DB as downloading it as otherwise the next pass will think it was deleted, thus delete the remote item
 			// Likewise if the download failed, we dont want to falsify the DB as downloading it as otherwise the next pass will think it was deleted, thus delete the remote item 
 			if (cached) {
+				// the item is in the items.sqlite3 database
 				// Do we need to update the database with the details that were provided by the OneDrive API?
-				// Is the local file timestamp same as the API data?
-				SysTime localModifiedTime = timeLastModified(path).toUTC();
+				// Is the last modified timestamp in the DB the same as the API data?
+				SysTime localModifiedTime = oldItem.mtime;
 				localModifiedTime.fracSecs = Duration.zero;
 				SysTime remoteModifiedTime = item.mtime;
 				remoteModifiedTime.fracSecs = Duration.zero;
 				
 				if (localModifiedTime != remoteModifiedTime) {
-					// Database update needed
-					log.vdebug("Updating local database with item details as timestamps of items are different");
+					// Database update needed for this item because our record is out-of-date
+					log.log("DATABASE UPDATE: Updating local database with item details as timestamps of items are different");
 					itemdb.update(item);
 				}
 			} else {
+				// item is not in the items.sqlite3 database
 				log.vdebug("Inserting new item details to local database");
 				itemdb.insert(item);
 			}

--- a/src/sync.d
+++ b/src/sync.d
@@ -2470,7 +2470,7 @@ final class SyncEngine
 				
 				if (localModifiedTime != remoteModifiedTime) {
 					// Database update needed for this item because our record is out-of-date
-					log.log("DATABASE UPDATE: Updating local database with item details as timestamps of items are different");
+					log.vdebug("Updating local database with item details as timestamps of items are different");
 					itemdb.update(item);
 				}
 			} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -2468,11 +2468,11 @@ final class SyncEngine
 				
 				if (localModifiedTime != remoteModifiedTime) {
 					// Database update needed
-					log.vdebug("Updating local database with item details");
+					log.vdebug("Updating local database with item details as timestamps of items are different");
 					itemdb.update(item);
 				}
 			} else {
-				log.vdebug("Inserting item details to local database");
+				log.vdebug("Inserting new item details to local database");
 				itemdb.insert(item);
 			}
 			// What was the item that was saved


### PR DESCRIPTION
* Only update the database if the item modified time is different, otherwise we are needlessly updating the database with data that is the same
* Generating a file hash, during the file integrity check is computationally expensive. Only generate a file hash if the modified time of the file is different, otherwise it is pointless to generate the file hash during each integrity check
* Only flush SHM and WAL post integrity check