### PR TITLE
Implement --display-running-config

### DIFF
--- a/config
+++ b/config
@@ -51,3 +51,4 @@
 # webhook_expiration_interval = "86400"
 # webhook_renewal_interval = "43200"
 # space_reservation = "50"
+# display_running_config = "false"

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -97,6 +97,13 @@ if [ -n "${ONEDRIVE_AUTHRESPONSE:=""}" ]; then
    ARGS=(--auth-response \"${ONEDRIVE_AUTHRESPONSE}\" ${ARGS[@]})
 fi
 
+# Tell client to print the running configuration at application startup
+if [ "${ONEDRIVE_DISPLAY_CONFIG:=0}" == "1" ]; then
+   echo "# We are printing the application running configuration at application startup"
+   echo "# Adding --display-running-config"
+   ARGS=(--display-running-config ${ARGS[@]})
+fi
+
 if [ ${#} -gt 0 ]; then
   ARGS=("${@}")
 fi

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -210,6 +210,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_REAUTH</B> | Controls "--reauth" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_AUTHFILES</B> | Controls "--auth-files" option. Default is "" | "authUrl:responseUrl" |
 | <B>ONEDRIVE_AUTHRESPONSE</B> | Controls "--auth-response" option. Default is "" | See [here](https://github.com/abraunegg/onedrive/blob/master/docs/USAGE.md#authorize-the-application-with-your-onedrive-account) |
+| <B>ONEDRIVE_DISPLAY_CONFIG</B> | Controls "--display-running-config" switch on onedrive sync. Default is 0 | 1 |
 
 ### Usage Examples
 **Verbose Output:**

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1177,6 +1177,8 @@ Options:
       Disable upload validation when uploading to OneDrive
   --display-config
       Display what options the client will use as currently configured - no sync will be performed.
+  --display-running-config
+      Display what options the client has been configured to use on application startup.
   --display-sync-status
       Display the sync status of the client - no sync will be performed.
   --download-only

--- a/onedrive.1.in
+++ b/onedrive.1.in
@@ -76,6 +76,9 @@ Configuration file key: \fBdisable_upload_validation\fP (default: \fBfalse\fP)
 \fB\-\-display\-config\fP
 Display what options the client will use as currently configured \- no sync will be performed.
 .TP
+\fB\-\-display\-running\-config\fP
+Display what options the client has been configured to use on application startup.
+.TP
 \fB\-\-display\-sync\-status\fP
 Display the sync status of the client \- no sync will be performed.
 .TP

--- a/src/config.d
+++ b/src/config.d
@@ -134,6 +134,8 @@ final class Config
 		longValues["webhook_listening_port"] = 8888;
 		longValues["webhook_expiration_interval"] = 3600 * 24;
 		longValues["webhook_renewal_interval"] = 3600 * 12;
+		// Log to application output running configuration values
+		boolValues["display_running_config"] = false;
 
 		// DEVELOPER OPTIONS
 		// display_memory = true | false
@@ -377,6 +379,9 @@ final class Config
 				"display-config",
 					"Display what options the client will use as currently configured - no sync will be performed.",
 					&boolValues["display_config"],
+				"display-running-config",
+					"Display what options the client has been configured to use on application startup.",
+					&boolValues["display_running_config"],
 				"display-sync-status",
 					"Display the sync status of the client - no sync will be performed.",
 					&boolValues["display_sync_status"],

--- a/src/main.d
+++ b/src/main.d
@@ -622,8 +622,12 @@ int main(string[] args)
 		}
 	}
 	
-	// Display current application configuration, no application initialisation
-	if (cfg.getValueBool("display_config")){
+	// Display current application configuration
+	if ((cfg.getValueBool("display_config")) || (cfg.getValueBool("display_running_config"))) {
+		if (cfg.getValueBool("display_running_config")) {
+			writeln("--------------- Application Runtime Configuration ---------------");
+		}
+		
 		// Display application version
 		writeln("onedrive version                             = ", strip(import("version")));
 		// Display all of the pertinent configuration options
@@ -732,8 +736,14 @@ int main(string[] args)
 			writeln("Config option 'webhook_renewal_interval'     = ", cfg.getValueLong("webhook_renewal_interval"));
 		}
 		
-		// Exit
-		return EXIT_SUCCESS;
+		if (cfg.getValueBool("display_running_config")) {
+			writeln("-----------------------------------------------------------------");
+		}
+		
+		// Do we exit? We only exit if --display-config has been used
+		if (cfg.getValueBool("display_config")) {
+			return EXIT_SUCCESS;
+		}
 	}
 
 	// --upload-only and --download-only are mutually exclusive and cannot be used together


### PR DESCRIPTION
* Implement --display-running-config to display the running configuration as used at application startup
* Add ONEDRIVE_DISPLAY_CONFIG variable to control --display-running-config in Docker environments