### PR TITLE
Update --resync handling of database file removal

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -743,9 +743,14 @@ int main(string[] args)
 		return EXIT_FAILURE;
 	}
 
-	// Handle --resync to remove local files
+	// Handle the actual --resync to remove local files
 	if (cfg.getValueBool("resync")) {
 		log.vdebug("--resync requested");
+		log.vdebug("Testing if we have exclusive access to local database file");
+		// Are we the only running instance? Test that we can open the database file path
+		itemDb = new ItemDatabase(cfg.databaseFilePath);
+		destroy(itemDb);
+		// If we have exclusive access we will not have exited
 		log.log("Deleting the saved application sync status ...");
 		if (!cfg.getValueBool("dry_run")) {
 			safeRemove(cfg.databaseFilePath);


### PR DESCRIPTION
* Only safe remove the files from the local file system if these are exclusively available for this running instance to perform a delete - otherwise this allows multiple clients to perform a --resync on the same data, which, could lead to a data loss scenario