### PR TITLE
Change the exit code of the application when a --resync is required

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -13,6 +13,7 @@ ItemDatabase itemDb;
 
 bool onedriveInitialised = false;
 const int EXIT_UNAUTHORIZED = 3;
+const int EXIT_RESYNC_REQUIRED = 126;
 
 enum MONITOR_LOG_SILENT = 2;
 enum MONITOR_LOG_QUIET  = 1;
@@ -462,7 +463,7 @@ int main(string[] args)
 			if (!cfg.getValueBool("resync")) {
 				// --resync not issued, fail fast
 				log.error("An application configuration change has been detected where a --resync is required");
-				return EXIT_FAILURE;
+				return EXIT_RESYNC_REQUIRED;
 			} else {
 				// --resync issued, update hashes of config files if they exist
 				if (!cfg.getValueBool("dry_run")) {


### PR DESCRIPTION
* Change the exit code of the application when a --resync is required from a generic exit code of 1 to exit code 126, as 126 is supposed to be used when a command invoked cannot be executed - which, in this case, when a --resync is needed - the original command cannot be executed.

This allows|enables watching for a 126 error code in automated environments, so that when 126 as the exit code is seen, the command can be re-tried potentially automatically with the appropriate resync arguments added.