### PR TITLE
Resolve segfault when running 'onedrive --display-sync-status' when run as 2nd process

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -42,6 +42,7 @@ final class ItemDatabase
 	string selectItemByIdStmt;
 	string selectItemByParentIdStmt;
 	string deleteItemByIdStmt;
+	bool databaseInitialised = false;
 
 	this(const(char)[] filename)
 	{
@@ -61,7 +62,7 @@ final class ItemDatabase
 				log.error("ERROR: An internal database error occurred: " ~ e.msg);
 				writeln();
 			}
-			exit(-1);
+			return;
 		}
 		
 		if (dbVersion == 0) {
@@ -114,6 +115,14 @@ final class ItemDatabase
 		";
 		selectItemByParentIdStmt = "SELECT * FROM item WHERE driveId = ? AND parentId = ?";
 		deleteItemByIdStmt = "DELETE FROM item WHERE driveId = ? AND id = ?";
+		
+		// flag that the database is accessible and we have control
+		databaseInitialised = true;
+	}
+
+	bool isDatabaseInitialised()
+	{
+		return databaseInitialised;
 	}
 
 	void createTable()

--- a/src/main.d
+++ b/src/main.d
@@ -70,7 +70,7 @@ int main(string[] args)
 			oneDrive.shutdown();
 		}
 		// was itemDb initialised?
-		if (itemDb !is null) {
+		if (itemDb.isDatabaseInitialised()) {
 			// Make sure the .wal file is incorporated into the main db before we exit
 			itemDb.performVacuum();
 			destroy(itemDb);
@@ -99,7 +99,7 @@ int main(string[] args)
 			oneDrive.shutdown();
 		}
 		// was itemDb initialised?
-		if (itemDb !is null) {
+		if (itemDb.isDatabaseInitialised()) {
 			// Make sure the .wal file is incorporated into the main db before we exit
 			itemDb.performVacuum();
 			destroy(itemDb);
@@ -1898,7 +1898,7 @@ extern(C) nothrow @nogc @system void exitHandler(int value) {
 				oneDrive.shutdown();
 			}
 			// was itemDb initialised?
-			if (itemDb !is null) {
+			if (itemDb.isDatabaseInitialised()) {
 				// Make sure the .wal file is incorporated into the main db before we exit
 				log.log("Shutting down db connection and merging temporary data");
 				itemDb.performVacuum();

--- a/src/main.d
+++ b/src/main.d
@@ -925,6 +925,14 @@ int main(string[] args)
 		log.vdebug("Using database file: ", asNormalizedPath(cfg.databaseFilePath));
 		itemDb = new ItemDatabase(cfg.databaseFilePath);
 	}
+	
+	// did we successfully initialise the database class?
+	if (!itemDb.isDatabaseInitialised()) {
+		// no .. destroy class
+		itemDb = null;
+		// exit application
+		return EXIT_FAILURE;
+	}
 
 	// What are the permission that have been set for the application?
 	// These are relevant for:

--- a/src/main.d
+++ b/src/main.d
@@ -70,7 +70,7 @@ int main(string[] args)
 			oneDrive.shutdown();
 		}
 		// was itemDb initialised?
-		if (itemDb.isDatabaseInitialised()) {
+		if (itemDb !is null) {
 			// Make sure the .wal file is incorporated into the main db before we exit
 			itemDb.performVacuum();
 			destroy(itemDb);
@@ -99,7 +99,7 @@ int main(string[] args)
 			oneDrive.shutdown();
 		}
 		// was itemDb initialised?
-		if (itemDb.isDatabaseInitialised()) {
+		if (itemDb !is null) {
 			// Make sure the .wal file is incorporated into the main db before we exit
 			itemDb.performVacuum();
 			destroy(itemDb);


### PR DESCRIPTION


* Rather than force exit if unable to lock the database, add a function and boolean to control if the database access has been init was successful. If not, use the exit scopes to exit the application.