### PR TITLE
Update ubuntu-package-install.md

### DIFF
--- a/docs/ubuntu-package-install.md
+++ b/docs/ubuntu-package-install.md
@@ -30,13 +30,8 @@ sudo add-apt-repository --remove ppa:yann1ck/onedrive
 Use a script, similar to the following to ensure your system is updated correctly:
 ```text
 #!/bin/bash
-rm -rf /var/lib/dpkg/lock-frontend
-rm -rf /var/lib/dpkg/lock
 apt-get update
-apt-get upgrade -y
-apt-get dist-upgrade -y
-apt-get autoremove -y
-apt-get autoclean -y
+apt-get upgrade
 ```
 
 Run this script as 'root' by using `su -` to elevate to 'root'. Example below:


### PR DESCRIPTION
There no need to remove locks from dpkg. Locks are there for a reason; no need to mess with it.

No need to run dist-upgrade instead of just upgrade. And running `dist-upgrade -y` is dangerous because it can remove packages! And autoremove and autoclean are useful commands, but are not required to install this package.