### PR TITLE
Update onedrive.spec.in to fix error building RPM

### DIFF
--- a/contrib/spec/onedrive.spec.in
+++ b/contrib/spec/onedrive.spec.in
@@ -59,7 +59,7 @@ make
 %{_docdir}/%{name}
 %{_bindir}/%{name}
 %if 0%{?with_systemd}
-%{_unitdir}/%{name}.service
+%{_userunitdir}/%{name}.service
 %{_unitdir}/%{name}@.service
 %else
 %{_bindir}/onedrive_service.sh


### PR DESCRIPTION
Updating the line
%{_unitdir}/%{name}.service
to 
%{_userunitdir}/%{name}.service

This fixes the issue when building the RPM on RHEL7/8/9 with the following error: RPM build errors:
    File not found: /root/rpmbuild/BUILDROOT/onedrive-2.4.20-1.el7.x86_64/usr/lib/systemd/system/onedrive.service

This is due to the file actually being created in: /root/rpmbuild/BUILDROOT/onedrive-2.4.20-1.el7.x86_64/usr/lib/systemd/user/onedrive.service

Changing _unitdir to _userunitdir fixes this error and allows the RPMs to be build correctly.