### PR TITLE
Fix DMD 2.100.2 depreciation warning

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -611,7 +611,6 @@ final class Config
 				// close open file
 				file.close();
 			}
-			return false;
 		}
 		// - exit
 		scope(exit) {


### PR DESCRIPTION
DMD 2.100.2 creates a depreciation warning:

Deprecation: `return` statements cannot be in `scope(failure)` bodies.