### PR TITLE
Restore RHEL7 spec file compatibility

### DIFF
--- a/contrib/spec/onedrive.spec.in
+++ b/contrib/spec/onedrive.spec.in
@@ -5,7 +5,7 @@
 %global with_systemd      0
 %endif
 
-%if 0%{?rhel} >= 7
+%if 0%{?rhel} == 7
 %global rhel_7      1
 %else
 %global rhel_7      0

--- a/contrib/spec/onedrive.spec.in
+++ b/contrib/spec/onedrive.spec.in
@@ -5,6 +5,12 @@
 %global with_systemd      0
 %endif
 
+%if 0%{?rhel} >= 7
+%global rhel_7      1
+%else
+%global rhel_7      0
+%endif
+
 Name:       onedrive
 Version:    2.4.22
 Release:    1%{?dist}
@@ -59,8 +65,13 @@ make
 %{_docdir}/%{name}
 %{_bindir}/%{name}
 %if 0%{?with_systemd}
+%if 0%{?rhel_7}
+%{_unitdir}/%{name}.service
+%{_unitdir}/%{name}@.service
+%else
 %{_userunitdir}/%{name}.service
 %{_unitdir}/%{name}@.service
+%endif
 %else
 %{_bindir}/onedrive_service.sh
 /etc/init.d/onedrive


### PR DESCRIPTION
* Restore RHEL7 spec file compatibility caused by https://github.com/abraunegg/onedrive/commit/a348750ec60d8fa5bad08d3df50c04b24c9624aa