### PR TITLE
Update --get-O365-drive-id error handling

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -616,6 +616,12 @@ final class OneDriveApi
 		redeemToken(c.front);
 		return true;
 	}
+	
+	string getSiteSearchUrl()
+	{
+		// Return the actual siteSearchUrl being used and/or requested when performing 'siteQuery = onedrive.o365SiteSearch(nextLink);' call
+		return .siteSearchUrl;
+	}
 
 	ulong getRetryAfterValue()
 	{
@@ -1780,7 +1786,7 @@ final class OneDriveApi
 			case 403:
 				// OneDrive responded that the user is forbidden
 				log.vlog("OneDrive returned a 'HTTP 403 - Forbidden' - gracefully handling error");
-				// Throw this as a specific exception so this is caught when performing sync.o365SiteSearch
+				// Throw this as a specific exception so this is caught when performing 'siteQuery = onedrive.o365SiteSearch(nextLink);' call
 				throw new OneDriveException(http.statusLine.code, http.statusLine.reason, response);
 
 			//	412 - Precondition Failed

--- a/src/sync.d
+++ b/src/sync.d
@@ -6181,7 +6181,14 @@ final class SyncEngine
 				}
 				// Requested resource cannot be found
 				if (e.httpStatusCode == 404) {
-					log.error("ERROR: Your OneDrive Account and Authentication Scope cannot access this OneDrive API: /sites?search={query}");
+					string siteSearchUrl;
+					if (nextLink.empty) {
+						siteSearchUrl = onedrive.getSiteSearchUrl();
+					} else {
+						siteSearchUrl = nextLink;
+					}
+					// log the error
+					log.error("ERROR: Your OneDrive Account and Authentication Scope cannot access this OneDrive API: ", siteSearchUrl);
 					log.error("ERROR: To resolve, please discuss this issue with whomever supports your OneDrive and SharePoint environment.");
 					return;
 				}

--- a/src/sync.d
+++ b/src/sync.d
@@ -6160,6 +6160,13 @@ final class SyncEngine
 		string nextLink;
 		string[] siteSearchResults;
 		
+		// The account type must not be a personal account type
+		if (accountType == "personal"){
+			log.error("ERROR: A OneDrive Personal Account cannot be used with --get-O365-drive-id. Please re-authenticate your client using a OneDrive Business Account.");
+			return;
+		}
+		
+		// What query are we performing?
 		log.log("Office 365 Library Name Query: ", o365SharedLibraryName);
 		
 		for (;;) {
@@ -6167,9 +6174,15 @@ final class SyncEngine
 				siteQuery = onedrive.o365SiteSearch(nextLink);
 			} catch (OneDriveException e) {
 				log.error("ERROR: Query of OneDrive for Office 365 Library Name failed");
+				// Forbidden - most likely authentication scope needs to be updated
 				if (e.httpStatusCode == 403) {
-					// Forbidden - most likely authentication scope needs to be updated
 					log.error("ERROR: Authentication scope needs to be updated. Use --reauth and re-authenticate client.");
+					return;
+				}
+				// Requested resource cannot be found
+				if (e.httpStatusCode == 404) {
+					log.error("ERROR: Your OneDrive Account and Authentication Scope cannot access this OneDrive API: /sites?search={query}");
+					log.error("ERROR: To resolve, please discuss this issue with whomever supports your OneDrive and SharePoint environment.");
 					return;
 				}
 				// HTTP request returned status code 429 (Too Many Requests)


### PR DESCRIPTION
* Ensure a 'Personal' account type is not being used
* If the /sites?search API cannot be found, display a more appropriate error message