### PR TITLE
Remove SHA1 use and cleanup defunct remaining CRC32 use

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -23,9 +23,8 @@ struct Item {
 	string   cTag;
 	SysTime  mtime;
 	string   parentId;
-	string   crc32Hash;
-	string   sha1Hash;
 	string   quickXorHash;
+	string   sha256Hash;
 	string   remoteDriveId;
 	string   remoteId;
 	string   syncStatus;
@@ -34,7 +33,7 @@ struct Item {
 final class ItemDatabase
 {
 	// increment this for every change in the db schema
-	immutable int itemDatabaseVersion = 10;
+	immutable int itemDatabaseVersion = 11;
 
 	Database db;
 	string insertItemStmt;
@@ -100,12 +99,12 @@ final class ItemDatabase
 		db.exec("PRAGMA locking_mode = EXCLUSIVE");
 		
 		insertItemStmt = "
-			INSERT OR REPLACE INTO item (driveId, id, name, type, eTag, cTag, mtime, parentId, crc32Hash, sha1Hash, quickXorHash, remoteDriveId, remoteId, syncStatus)
-			VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+			INSERT OR REPLACE INTO item (driveId, id, name, type, eTag, cTag, mtime, parentId, quickXorHash, sha256Hash, remoteDriveId, remoteId, syncStatus)
+			VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
 		";
 		updateItemStmt = "
 			UPDATE item
-			SET name = ?3, type = ?4, eTag = ?5, cTag = ?6, mtime = ?7, parentId = ?8, crc32Hash = ?9, sha1Hash = ?10, quickXorHash = ?11, remoteDriveId = ?12, remoteId = ?13, syncStatus = ?14
+			SET name = ?3, type = ?4, eTag = ?5, cTag = ?6, mtime = ?7, parentId = ?8, quickXorHash = ?9, sha256Hash = ?10, remoteDriveId = ?11, remoteId = ?12, syncStatus = ?13
 			WHERE driveId = ?1 AND id = ?2
 		";
 		selectItemByIdStmt = "
@@ -136,9 +135,8 @@ final class ItemDatabase
 				cTag             TEXT,
 				mtime            TEXT NOT NULL,
 				parentId         TEXT,
-				crc32Hash        TEXT,
-				sha1Hash         TEXT,
 				quickXorHash     TEXT,
+				sha256Hash       TEXT,
 				remoteDriveId    TEXT,
 				remoteId         TEXT,
 				deltaLink        TEXT,
@@ -321,19 +319,18 @@ final class ItemDatabase
 			bind(6, cTag);
 			bind(7, mtime.toISOExtString());
 			bind(8, parentId);
-			bind(9, crc32Hash);
-			bind(10, sha1Hash);
-			bind(11, quickXorHash);
-			bind(12, remoteDriveId);
-			bind(13, remoteId);
-			bind(14, syncStatus);
+			bind(9, quickXorHash);
+			bind(10, sha256Hash);
+			bind(11, remoteDriveId);
+			bind(12, remoteId);
+			bind(13, syncStatus);
 		}
 	}
 
 	private Item buildItem(Statement.Result result)
 	{
 		assert(!result.empty, "The result must not be empty");
-		assert(result.front.length == 15, "The result must have 15 columns");
+		assert(result.front.length == 14, "The result must have 14 columns");
 		Item item = {
 			driveId: result.front[0].dup,
 			id: result.front[1].dup,
@@ -342,12 +339,11 @@ final class ItemDatabase
 			cTag: result.front[5].dup,
 			mtime: SysTime.fromISOExtString(result.front[6]),
 			parentId: result.front[7].dup,
-			crc32Hash: result.front[8].dup,
-			sha1Hash: result.front[9].dup,
-			quickXorHash: result.front[10].dup,
-			remoteDriveId: result.front[11].dup,
-			remoteId: result.front[12].dup,
-			syncStatus: result.front[14].dup
+			quickXorHash: result.front[8].dup,
+			sha256Hash: result.front[9].dup,
+			remoteDriveId: result.front[10].dup,
+			remoteId: result.front[11].dup,
+			syncStatus: result.front[12].dup
 		};
 		switch (result.front[3]) {
 			case "file":    item.type = ItemType.file;    break;

--- a/src/sync.d
+++ b/src/sync.d
@@ -3158,9 +3158,8 @@ final class SyncEngine
 					// A 'file' was downloaded - does what we downloaded = reported fileSize or if there is some sort of funky local disk compression going on
 					// does the file hash OneDrive reports match what we have locally?
 					string quickXorHash = computeQuickXorHash(path);
-					string sha256Hash = computeSHA256Hash(path);
 					
-					if ((getSize(path) == fileSize) || (OneDriveFileHash == quickXorHash) || (OneDriveFileHash == sha256Hash)) {
+					if ((getSize(path) == fileSize) || (OneDriveFileHash == quickXorHash)) {
 						// downloaded matches either size or hash
 						log.vdebug("Downloaded file matches reported size and or reported file hash");
 						try {
@@ -3179,7 +3178,7 @@ final class SyncEngine
 							log.error("ERROR: File download size mis-match. Increase logging verbosity to determine why.");
 						}
 						// hash error?
-						if ((OneDriveFileHash != quickXorHash) || (OneDriveFileHash != sha256Hash))  {
+						if (OneDriveFileHash != quickXorHash)  {
 							// downloaded file hash does not match
 							log.vdebug("Actual file hash:           ", OneDriveFileHash);
 							log.vdebug("OneDrive API reported hash: ", quickXorHash);

--- a/src/sync.d
+++ b/src/sync.d
@@ -3178,7 +3178,7 @@ final class SyncEngine
 							log.error("ERROR: File download size mis-match. Increase logging verbosity to determine why.");
 						}
 						// hash error?
-						if (OneDriveFileHash != quickXorHash)  {
+						if (OneDriveFileHash != quickXorHash) {
 							// downloaded file hash does not match
 							log.vdebug("Actual file hash:           ", OneDriveFileHash);
 							log.vdebug("OneDrive API reported hash: ", quickXorHash);

--- a/src/util.d
+++ b/src/util.d
@@ -48,28 +48,6 @@ void safeRemove(const(char)[] path)
 	if (exists(path)) remove(path);
 }
 
-// returns the crc32 hex string of a file
-string computeCrc32(string path)
-{
-	CRC32 crc;
-	auto file = File(path, "rb");
-	foreach (ubyte[] data; chunks(file, 4096)) {
-		crc.put(data);
-	}
-	return crc.finish().toHexString().dup;
-}
-
-// returns the sha1 hash hex string of a file
-string computeSha1Hash(string path)
-{
-	SHA1 sha;
-	auto file = File(path, "rb");
-	foreach (ubyte[] data; chunks(file, 4096)) {
-		sha.put(data);
-	}
-	return sha.finish().toHexString().dup;
-}
-
 // returns the quickXorHash base64 string of a file
 string computeQuickXorHash(string path)
 {
@@ -79,6 +57,16 @@ string computeQuickXorHash(string path)
 		qxor.put(data);
 	}
 	return Base64.encode(qxor.finish());
+}
+
+// returns the SHA256 hex string of a file
+string computeSHA256Hash(string path) {
+	SHA256 sha256;
+    auto file = File(path, "rb");
+    foreach (ubyte[] data; chunks(file, 4096)) {
+        sha256.put(data);
+    }
+    return sha256.finish().toHexString().dup;
 }
 
 // converts wildcards (*, ?) to regex


### PR DESCRIPTION
* Remove SHA1 from being used by the client as this is being depreciated by Microsoft in July 2023 - https://devblogs.microsoft.com/microsoft365dev/deprecation-of-sha1hash-on-onedrive-personal/
* Complete the removal of CRC32 as this is also no longer present for a long time, but some code elements still existed