### PR TITLE
Add --no-remote-delete flag to docker entrypoint

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -69,6 +69,13 @@ if [ "${ONEDRIVE_UPLOADONLY:=0}" == "1" ]; then
    ARGS=(--upload-only ${ARGS[@]})
 fi
 
+# Tell client to sync in no-remote-delete mode based on environment variable
+if [ "${ONEDRIVE_NOREMOTEDELETE:=1}" == "1" ]; then
+   echo "# We are synchronizing in no-remote-delete mode"
+   echo "# Adding --no-remote-delete"
+   ARGS=(--no-remote-delete ${ARGS[@]})
+fi
+
 # Tell client to logout based on environment variable
 if [ "${ONEDRIVE_LOGOUT:=0}" == "1" ]; then
    echo "# We are logging out"

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -70,7 +70,7 @@ if [ "${ONEDRIVE_UPLOADONLY:=0}" == "1" ]; then
 fi
 
 # Tell client to sync in no-remote-delete mode based on environment variable
-if [ "${ONEDRIVE_NOREMOTEDELETE:=1}" == "1" ]; then
+if [ "${ONEDRIVE_NOREMOTEDELETE:=0}" == "1" ]; then
    echo "# We are synchronizing in no-remote-delete mode"
    echo "# Adding --no-remote-delete"
    ARGS=(--no-remote-delete ${ARGS[@]})

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -207,7 +207,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_RESYNC</B> | Controls "--resync" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_DOWNLOADONLY</B> | Controls "--download-only" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_UPLOADONLY</B> | Controls "--upload-only" switch on onedrive sync. Default is 0 | 1 |
-| <B>ONEDRIVE_NOREMOTEDELETE</B> | Controls "--no-remote-delete" switch on onedrive sync. Default is 1 | 1 |
+| <B>ONEDRIVE_NOREMOTEDELETE</B> | Controls "--no-remote-delete" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_LOGOUT</B> | Controls "--logout" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_REAUTH</B> | Controls "--reauth" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_AUTHFILES</B> | Controls "--auth-files" option. Default is "" | "authUrl:responseUrl" |

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -207,6 +207,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_RESYNC</B> | Controls "--resync" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_DOWNLOADONLY</B> | Controls "--download-only" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_UPLOADONLY</B> | Controls "--upload-only" switch on onedrive sync. Default is 0 | 1 |
+| <B>ONEDRIVE_NOREMOTEDELETE</B> | Controls "--no-remote-delete" switch on onedrive sync. Default is 1 | 1 |
 | <B>ONEDRIVE_LOGOUT</B> | Controls "--logout" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_REAUTH</B> | Controls "--reauth" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_AUTHFILES</B> | Controls "--auth-files" option. Default is "" | "authUrl:responseUrl" |

--- a/docs/Podman.md
+++ b/docs/Podman.md
@@ -215,6 +215,7 @@ podman run -it --restart unless-stopped --name onedrive_work \
 | <B>ONEDRIVE_RESYNC</B> | Controls "--resync" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_DOWNLOADONLY</B> | Controls "--download-only" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_UPLOADONLY</B> | Controls "--upload-only" switch on onedrive sync. Default is 0 | 1 |
+| <B>ONEDRIVE_NOREMOTEDELETE</B> | Controls "--no-remote-delete" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_LOGOUT</B> | Controls "--logout" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_REAUTH</B> | Controls "--reauth" switch. Default is 0 | 1 |
 | <B>ONEDRIVE_AUTHFILES</B> | Controls "--auth-files" option. Default is "" | "authUrl:responseUrl" |


### PR DESCRIPTION
I think it would be a great improvement if the official base docker image for `onedrive` provided the possibility of having the `--no-remote-delete` flag.