### PR TITLE
Improve local-first synchronization time

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -1661,10 +1661,6 @@ class SyncEngine {
 				localModifiedTime.fracSecs = Duration.zero;
 				itemModifiedTime.fracSecs = Duration.zero;
 				
-				// If we need to rename the file, what do we rename it to?
-				auto ext = extension(newItemPath);
-				auto renamedNewItemPath = newItemPath.chomp(ext) ~ "-" ~ deviceName ~ ext;
-				
 				// Is the local modified time greater than that from OneDrive?
 				if (localModifiedTime > itemModifiedTime) {
 					// Local file is newer than item on OneDrive based on file modified time
@@ -1693,11 +1689,10 @@ class SyncEngine {
 							log.vlog("WARNING: Local Data Protection has been disabled. You may experience data loss on this file: ", newItemPath);
 						} else {
 							// local data protection is configured, renaming local file
-							log.log("The local item is out-of-sync with OneDrive, renaming to preserve existing file and prevent local data loss: ", newItemPath, " -> ", renamedNewItemPath);
 							// perform the rename action of the local file
 							if (!dryRun) {
 								// Perform the local rename of the existing local file
-								safeRename(newItemPath, renamedNewItemPath, dryRun);
+								safeBackup(newItemPath, dryRun);
 							} else {
 								// Expectation here is that there is a new file locally (renamedNewItemPath) however as we don't create this, the "new file" will not be uploaded as it does not exist
 								log.vdebug("DRY-RUN: Skipping local file rename");
@@ -1716,11 +1711,10 @@ class SyncEngine {
 						log.vlog("WARNING: Local Data Protection has been disabled. You may experience data loss on this file: ", newItemPath);
 					} else {
 						// local data protection is configured, renaming local file
-						log.vlog("The local item is out-of-sync with OneDrive, renaming to preserve existing file and prevent data loss: ", newItemPath, " -> ", renamedNewItemPath);
 						// perform the rename action of the local file
 						if (!dryRun) {
 							// Perform the local rename of the existing local file
-							safeRename(newItemPath, renamedNewItemPath, dryRun);
+							safeBackup(newItemPath, dryRun);
 						} else {
 							// Expectation here is that there is a new file locally (renamedNewItemPath) however as we don't create this, the "new file" will not be uploaded as it does not exist
 							log.vdebug("DRY-RUN: Skipping local file rename");
@@ -2007,12 +2001,8 @@ class SyncEngine {
 						
 						// do the rename if we are not in a --dry-run scenario
 						if (!dryRun) {
-							// If we need to rename the file, what do we rename it to?
-							auto ext = extension(newItemPath);
-							auto renamedNewItemPath = newItemPath.chomp(ext) ~ "-" ~ deviceName ~ ext;
-							
 							// Perform the local rename of the existing local file
-							safeRename(newItemPath, renamedNewItemPath, dryRun);
+							safeBackup(newItemPath, dryRun);
 						}
 					}
 				}

--- a/src/util.d
+++ b/src/util.d
@@ -53,7 +53,7 @@ void safeBackup(const(char)[] path, bool dryRun) {
 	// Perform the backup
 	log.vlog("The local item is out-of-sync with OneDrive, renaming to preserve existing file and prevent data loss: ", path, " -> ", newPath);
 	if (!dryRun) {
-		rename(path, newPath);
+		std.file.copy(path, newPath);
 	} else {
 		log.vdebug("DRY-RUN: Skipping local file backup");
 	}


### PR DESCRIPTION
### Summary
In local-first mode, local new file is first scanned and uploaded. With no prior sync state or a resync, it will require time proportional to the numbers of existing local files. In this PR, remote state is first downloaded before uploading new local files, so if most of the local file is actually already in-sync, we don't have to try to upload it one by one beforehand. And it doesn't bring any additional performance hit as well since we just change the execution order, download still download, upload still upload.

### Effect
With 800+ items, the synchronization time can be reduced from 4 minutes to 15 seconds if all the items are already in-sync.
```
$ find | wc -l
802

// This PR
$ time onedrive --local-first --sync --resync --resync-auth
Configuration file successfully loaded
Deleting the saved application sync status ...
Configuring Global Azure AD Endpoints
Sync Engine Initialised with new Onedrive API instance
Performing a database consistency and integrity check on locally stored data ... 
Fetching items from the OneDrive API for Drive ID: af2b5e52bea96776 .....
Processing 748 applicable changes and items received from Microsoft OneDrive ..
Scanning the local file system '~/OneDrive' for new data to upload ...
Performing a last examination of the most recent online data within Microsoft OneDrive to complete the reconciliation process
Fetching items from the OneDrive API for Drive ID: af2b5e52bea96776 ..
No additional changes or items that can be applied were discovered while processing the data received from Microsoft OneDrive

Sync with Microsoft OneDrive is complete

real    0m15.622s
user    0m1.297s
sys     0m0.161s

// Current version
$ time onedrive --local-first --sync --resync --resync-auth
Configuration file successfully loaded
Deleting the saved application sync status ...
Configuring Global Azure AD Endpoints
Sync Engine Initialised with new Onedrive API instance
Performing a database consistency and integrity check on locally stored data ... 
Scanning the local file system '~/OneDrive' for new data to upload ...
OneDrive Client requested to create this directory online: ./ok
Fetching items from the OneDrive API for Drive ID: af2b5e52bea96776 .....
Processing 748 applicable changes and items received from Microsoft OneDrive ..

Sync with Microsoft OneDrive is complete

real    4m1.885s
user    7m11.498s
sys     2m30.501s
```

### Changes
1. Merge the pipline of `performStandardSyncProcess`, only the order of `performDatabaseConsistencyAndIntegrityCheck` and `syncOneDriveAccountToLocalDisk` differs depending on whether the "local-first" mode is used.
2. When downloading remote state and in local first mode, if the item is out-of-sync, upload local version instead of download it.
3. Upload local-first items after downloading remote state before downloading remote items.

### What is still missing?
My test cases are very limited so far and I'm not quite sure how some of the cases are handled. So not 100% sure that this is a perfect solution, e.g., should we take care of shared folder handling as well?

Thank you.