### PR TITLE
Fix api bug and curl issue

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -18,7 +18,7 @@ class CurlEngine {
 		http = HTTP();
 	}
 	
-	void initialise(long dnsTimeout, long connectTimeout, long dataTimeout, long operationTimeout, int maxRedirects, bool httpsDebug, string userAgent, bool httpProtocol, long userRateLimit, long protocolVersion) {
+	void initialise(long dnsTimeout, long connectTimeout, long dataTimeout, long operationTimeout, int maxRedirects, bool httpsDebug, string userAgent, bool httpProtocol, long userRateLimit, long protocolVersion, long forbidReuse=1) {
 		// Curl Timeout Handling
 		
 		// libcurl dns_cache_timeout timeout
@@ -83,7 +83,7 @@ class CurlEngine {
 		//   Setting this to 1 ensures that when we close the curl instance, any open sockets are closed - which we need to do when running 
 		//   multiple threads and API instances at the same time otherwise we run out of local files | sockets pretty quickly
 		//   The libcurl default is 1 - ensure we are configuring not to reuse connections and leave unused sockets open
-		http.handle.set(CurlOption.forbid_reuse,1);
+		http.handle.set(CurlOption.forbid_reuse,forbidReuse);
 		
 		if (httpsDebug) {
 			// Output what options we are using so that in the debug log this can be tracked
@@ -93,6 +93,7 @@ class CurlEngine {
 			log.vdebug("http.operationTimeout = ", operationTimeout);
 			log.vdebug("http.maxRedirects = ", maxRedirects);
 			log.vdebug("http.CurlOption.ipresolve = ", protocolVersion);
+			log.vdebug("http.forbid_reuse.forbidReuse = ", forbidReuse);
 		}
 	}
 	

--- a/src/main.d
+++ b/src/main.d
@@ -1139,6 +1139,8 @@ extern(C) nothrow @nogc @system void exitHandler(int value) {
 	try {
 		assumeNoGC ( () {
 			log.log("Got termination signal, performing clean up");
+			// Wait for all parallel jobs that depend on the database to complete
+			taskPool.finish(true);
 			// was itemDb initialised?
 			if (itemDB.isDatabaseInitialised()) {
 				// Make sure the .wal file is incorporated into the main db before we exit

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -622,8 +622,9 @@ class OneDriveApi {
 	JSONValue getPathDetailsByDriveId(string driveId, string path) {
 		checkAccessTokenExpired();
 		string url;
-		// Required format: /drives/{drive-id}/root:/{item-path}
-		url = driveByIdUrl ~ driveId ~ "/root:/" ~ encodeComponent(path);
+		// https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online
+		// Required format: /drives/{drive-id}/root:/{item-path}:
+		url = driveByIdUrl ~ driveId ~ "/root:/" ~ encodeComponent(path) ~ ":";
 		return get(url);
 	}
 	

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -208,10 +208,10 @@ class OneDriveApi {
 	}
 	
 	// Initialise the OneDrive API class
-	bool initialise() {
+	bool initialise(long forbidReuse=1) {
 		// Initialise the curl engine
 		curlEngine = new CurlEngine();
-		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"));
+		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"), forbidReuse);
 
 		// Authorised value to return
 		bool authorised = false;

--- a/src/sync.d
+++ b/src/sync.d
@@ -716,9 +716,11 @@ class SyncEngine {
 			}
 							
 			// Create a new API Instance for querying /delta and initialise it
+			// Reuse the socket to speed up
+			long forbidReuse = 0;
 			OneDriveApi getDeltaQueryOneDriveApiInstance;
 			getDeltaQueryOneDriveApiInstance = new OneDriveApi(appConfig);
-			getDeltaQueryOneDriveApiInstance.initialise();
+			getDeltaQueryOneDriveApiInstance.initialise(forbidReuse);
 			
 			for (;;) {
 				responseBundleCount++;


### PR DESCRIPTION
### Summary

This PR fixes an api resources addressing bug and another cause of curl performance issues mentioned in https://github.com/abraunegg/onedrive/discussions/2506#discussioncomment-7282164

### Changes
- Add missing ending `:` back to align with the [documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online)
- Make curl socket reusable when fetching /delta changes

### How Has This Been Tested?
testing for the changes are trivial 

### Effect
- Make some magic local paths work correctly when using the `Get item` api
- About two times faster for `/delta` downloads