### PR TITLE
Fix socket reuse

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -208,10 +208,10 @@ class OneDriveApi {
 	}
 	
 	// Initialise the OneDrive API class
-	bool initialise() {
+	bool initialise(bool keepAlive=false) {
 		// Initialise the curl engine
 		curlEngine = new CurlEngine();
-		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"));
+		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"), keepAlive);
 
 		// Authorised value to return
 		bool authorised = false;
@@ -758,8 +758,7 @@ class OneDriveApi {
 			}
 		}
 
-		curlEngine.http.method = HTTP.Method.put;
-		curlEngine.http.url = uploadUrl;
+		curlEngine.connect(HTTP.Method.put, uploadUrl);
 		curlEngine.http.addRequestHeader("Content-Range", contentRange);
 		curlEngine.http.onSend = data => file.rawRead(data).length;
 		// convert offsetSize to ulong
@@ -1230,8 +1229,7 @@ class OneDriveApi {
 	
 	private void performDelete(const(char)[] url) {
 		scope(exit) curlEngine.http.clearRequestHeaders();
-		curlEngine.http.method = HTTP.Method.del;
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.del, url);
 		addAccessTokenHeader();
 		auto response = performHTTPOperation();
 		checkHttpResponseCode(response);
@@ -1268,8 +1266,7 @@ class OneDriveApi {
 			}
 		}
 
-		curlEngine.http.method = HTTP.Method.get;
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.get, url);
 		addAccessTokenHeader();
 
 		curlEngine.http.onReceive = (ubyte[] data) {
@@ -1392,8 +1389,7 @@ class OneDriveApi {
 	private JSONValue get(string url, bool skipToken = false) {
 		scope(exit) curlEngine.http.clearRequestHeaders();
 		log.vdebug("Request URL = ", url);
-		curlEngine.http.method = HTTP.Method.get;
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.get, url);
 		if (!skipToken) addAccessTokenHeader(); // HACK: requestUploadStatus
 		JSONValue response;
 		response = performHTTPOperation();
@@ -1418,8 +1414,7 @@ class OneDriveApi {
 	
 	private auto patch(T)(const(char)[] url, const(T)[] patchData) {
 		scope(exit) curlEngine.http.clearRequestHeaders();
-		curlEngine.setMethodPatch();
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.patch, url);
 		addAccessTokenHeader();
 		auto response = perform(patchData);
 		checkHttpResponseCode(response);
@@ -1428,8 +1423,7 @@ class OneDriveApi {
 	
 	private auto post(T)(string url, const(T)[] postData) {
 		scope(exit) curlEngine.http.clearRequestHeaders();
-		curlEngine.setMethodPost();
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.post, url);
 		addAccessTokenHeader();
 		auto response = perform(postData);
 		checkHttpResponseCode(response);
@@ -1649,8 +1643,7 @@ class OneDriveApi {
 			}
 		}
 
-		curlEngine.http.method = HTTP.Method.put;
-		curlEngine.http.url = url;
+		curlEngine.connect(HTTP.Method.put, url);
 		addAccessTokenHeader();
 		curlEngine.http.addRequestHeader("Content-Type", "application/octet-stream");
 		curlEngine.http.onSend = data => file.rawRead(data).length;

--- a/src/sync.d
+++ b/src/sync.d
@@ -60,7 +60,7 @@ class SyncEngine {
 	OneDriveApi oneDriveApiInstance;
 	ItemDatabase itemDB;
 	ClientSideFiltering selectiveSync;
-	
+
 	// Array of directory databaseItem.id to skip while applying the changes.
 	// These are the 'parent path' id's that are being excluded, so if the parent id is in here, the child needs to be skipped as well
 	RedBlackTree!string skippedItems = redBlackTree!string();
@@ -716,9 +716,11 @@ class SyncEngine {
 			}
 							
 			// Create a new API Instance for querying /delta and initialise it
+			// Reuse the socket to speed up
+			bool keepAlive = true;
 			OneDriveApi getDeltaQueryOneDriveApiInstance;
 			getDeltaQueryOneDriveApiInstance = new OneDriveApi(appConfig);
-			getDeltaQueryOneDriveApiInstance.initialise();
+			getDeltaQueryOneDriveApiInstance.initialise(keepAlive);
 			
 			for (;;) {
 				responseBundleCount++;

--- a/src/util.d
+++ b/src/util.d
@@ -167,9 +167,8 @@ bool testInternetReachability(ApplicationConfig appConfig) {
 	
 	// Configure the remaining items required
 	// URL to use
-	curlEngine.http.url = "https://login.microsoftonline.com";
 	// HTTP connection test method
-	curlEngine.http.method = HTTP.Method.head;
+	curlEngine.connect(HTTP.Method.head, "https://login.microsoftonline.com");
 	// Attempt to contact the Microsoft Online Service
 	try {
 		log.vdebug("Attempting to contact Microsoft OneDrive Login Service");


### PR DESCRIPTION
### Summary
https://github.com/abraunegg/onedrive/blob/5dedd2635922f30e20acd7c2b366f25a74d96e37/src/curlEngine.d#L80-L86
The use of [CURLOPT_FORBID_REUSE](https://curl.se/libcurl/c/CURLOPT_FORBID_REUSE.html) above to handle socket exhaustion is a misuse, it does not help solve the problem at all, and will affect the performance of reusable sockets. Please check how [tcp socket termination](https://www.geeksforgeeks.org/tcp-connection-termination/) works to see why it doesn't help.

Note: Setting this option will force the socket to be closed on _every_ request. Even if you reuse the `curlEngine` instance, the socket will still be closed.

Changes
- Remove misuse of CURLOPT_FORBID_REUSE
- Use connection header to ask server close the connection