### PR TITLE
Add --dry-run parameter through docker environment

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -118,6 +118,13 @@ if [ -n "${ONEDRIVE_SINGLE_DIRECTORY:=""}" ]; then
    ARGS=(--single-directory \"${ONEDRIVE_SINGLE_DIRECTORY}\" ${ARGS[@]})
 fi
 
+# Tell client run in dry-run mode
+if [ "${ONEDRIVE_DRYRUN:=0}" == "1" ]; then
+   echo "# We are running in dry-run mode"
+   echo "# Adding --dry-run"
+   ARGS=(--dry-run ${ARGS[@]})
+fi
+
 if [ ${#} -gt 0 ]; then
   ARGS=("${@}")
 fi

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -214,6 +214,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_AUTHRESPONSE</B> | Controls "--auth-response" option. Default is "" | See [here](https://github.com/abraunegg/onedrive/blob/master/docs/USAGE.md#authorize-the-application-with-your-onedrive-account) |
 | <B>ONEDRIVE_DISPLAY_CONFIG</B> | Controls "--display-running-config" switch on onedrive sync. Default is 0 | 1 |
 | <B>ONEDRIVE_SINGLE_DIRECTORY</B> | Controls "--single-directory" option. Default = "" | "mydir" |
+| <B>ONEDRIVE_DRYRUN</B> | Controls "--dry-run" option. Default = 0 | 1 |
 
 ### Usage Examples
 **Verbose Output:**


### PR DESCRIPTION
Add the ONEDRIVE_DRYRUN=1 check to the entrypoint.sh to allow for a DRY-RUN on a docker only environment.