### PR TITLE
Clean up the removal of argument --operation-timeout

### DIFF
--- a/contrib/completions/complete.bash
+++ b/contrib/completions/complete.bash
@@ -11,7 +11,7 @@ _onedrive()
 	prev=${COMP_WORDS[COMP_CWORD-1]}
 
 	options='--check-for-nomount --check-for-nosync --debug-https --disable-notifications --display-config --display-sync-status --download-only --disable-upload-validation --dry-run --enable-logging --force-http-1.1 --force-http-2 --get-file-link --local-first --logout -m --monitor --no-remote-delete --print-token --reauth --resync --skip-dot-files --skip-symlinks --synchronize --upload-only -v --verbose --version -h --help'
-	argopts='--create-directory --get-O365-drive-id --operation-timeout --remove-directory --single-directory --source-directory'
+	argopts='--create-directory --get-O365-drive-id --remove-directory --single-directory --source-directory'
 
 	# Loop on the arguments to manage conflicting options
 	for (( i=0; i < ${#COMP_WORDS[@]}-1; i++ )); do
@@ -34,7 +34,7 @@ _onedrive()
 		fi
 		return 0
 		;;
-	--create-directory|--get-O365-drive-id|--operation-timeout|--remove-directory|--single-directory|--source-directory)
+	--create-directory|--get-O365-drive-id|--remove-directory|--single-directory|--source-directory)
 		return 0
 		;;
 	*)

--- a/contrib/completions/complete.fish
+++ b/contrib/completions/complete.fish
@@ -23,7 +23,6 @@ complete -c onedrive -l local-first -d 'Synchronize from the local directory sou
 complete -c onedrive -l logout -d 'Logout the current user.'
 complete -c onedrive -n "not __fish_seen_subcommand_from --synchronize" -a "-m --monitor" -d 'Keep monitoring for local and remote changes.'
 complete -c onedrive -l no-remote-delete -d 'Do not delete local file deletes from OneDrive when using --upload-only.'
-complete -c onedrive -l operation-timeout -d 'Specify the maximum amount of time (in seconds) an operation is allowed to take.'
 complete -c onedrive -l print-token -d 'Print the access token, useful for debugging.'
 complete -c onedrive -l remote-directory -d 'Remove a directory on OneDrive - no sync will be performed.'
 complete -c onedrive -l reauth -d 'Reauthenticate the client with OneDrive.'

--- a/contrib/completions/complete.zsh
+++ b/contrib/completions/complete.zsh
@@ -27,7 +27,6 @@ all_opts=(
   '--logout[Logout the current user]'
   '(-m --monitor)'{-m,--monitor}'[Keep monitoring for local and remote changes]'
   '--no-remote-delete[Do not delete local file deletes from OneDrive when using --upload-only]'
-  '--operation-timeout[Specify the maximum amount of time (in seconds) an operation is allowed to take.]:seconds:'
   '--print-token[Print the access token, useful for debugging]'
   '--reauth[Reauthenticate the client with OneDrive]'
   '--resync[Forget the last saved state, perform a full sync]'

--- a/onedrive.1.in
+++ b/onedrive.1.in
@@ -170,11 +170,6 @@ Do not delete local file 'deletes' from OneDrive when using \fB\-\-upload\-only\
 .br
 Configuration file key: \fBno_remote_delete\fP (default: \fBfalse\fP)
 .TP
-\fB\-\-operation\-timeout\fP ARG
-Set the maximum amount of time (seconds) a file operation is allowed to take. This includes DNS resolution, connecting, data transfer, etc.
-.br
-Configuration file key: \fBoperation_timeout\fP (default: \fB3600\fP)
-.TP
 \fB\-\-print\-token\fP
 Print the access token, useful for debugging
 .TP

--- a/src/config.d
+++ b/src/config.d
@@ -2318,7 +2318,6 @@ void outputLongHelp(Option[] opt) {
 			"--monitor-interval",
 			"--monitor-log-frequency",
 			"--monitor-fullscan-frequency",
-			"--operation-timeout",
 			"--remove-directory",
 			"--single-directory",
 			"--skip-dir",


### PR DESCRIPTION
Alright, take two.

### What is this?
This pull request removes the recently removed argument --operation-timeout from documentation, shell completions, and config.d

### Why this?
While --operation-timeout was removed, it is still present in the shell completions and documentation. This cleanup is to prevent confusion for anyone.
