### PR TITLE
Refactoring CurlEngine + Add Curl Socket Reuse Support

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1126,6 +1126,9 @@ void performStandardExitProcess(string scopeCaller = null) {
 		}
 		object.destroy(itemDB);
 	}
+
+	// Shutdown cached sockets
+	CurlEngine.releaseAll();
 	
 	// Set all objects to null
 	if (scopeCaller == "failureScope") {

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -488,15 +488,9 @@ class OneDriveApi {
 			webhook.stop();
 			object.destroy(webhook);
 		}
-		if (curlEngine !is null) { 
-			// Reset any values to defaults, freeing any set objects
-			curlEngine.http.clearRequestHeaders();
-			curlEngine.http.onSend = null;
-			curlEngine.http.onReceive = null;
-			curlEngine.http.onReceiveHeader = null;
-			curlEngine.http.onReceiveStatusLine = null;
-			curlEngine.http.contentLength = 0;
-			// Release curl instance
+		
+		// Release curl instance
+		if (curlEngine !is null) {
 			curlEngine.release();
 			curlEngine = null;
 		}

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -225,9 +225,9 @@ class OneDriveApi {
 	}
 	
 	// Initialise the OneDrive API class
-	bool initialise(bool keepAlive=false) {
+	bool initialise(bool keepAlive=true) {
 		// Initialise the curl engine
-		curlEngine = new CurlEngine();
+		curlEngine = CurlEngine.get();
 		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"), keepAlive);
 
 		// Authorised value to return
@@ -488,18 +488,18 @@ class OneDriveApi {
 			webhook.stop();
 			object.destroy(webhook);
 		}
-		
-		// Reset any values to defaults, freeing any set objects
-		curlEngine.http.clearRequestHeaders();
-		curlEngine.http.onSend = null;
-		curlEngine.http.onReceive = null;
-		curlEngine.http.onReceiveHeader = null;
-		curlEngine.http.onReceiveStatusLine = null;
-		curlEngine.http.contentLength = 0;
-		// Shut down the curl instance & close any open sockets
-		curlEngine.http.shutdown();
-		// Free object and memory
-		object.destroy(curlEngine);
+		if (curlEngine !is null) { 
+			// Reset any values to defaults, freeing any set objects
+			curlEngine.http.clearRequestHeaders();
+			curlEngine.http.onSend = null;
+			curlEngine.http.onReceive = null;
+			curlEngine.http.onReceiveHeader = null;
+			curlEngine.http.onReceiveStatusLine = null;
+			curlEngine.http.contentLength = 0;
+			// Release curl instance
+			curlEngine.release();
+			curlEngine = null;
+		}
 	}
 	
 	// Authenticate this client against Microsoft OneDrive API

--- a/src/util.d
+++ b/src/util.d
@@ -206,7 +206,7 @@ bool testInternetReachability(ApplicationConfig appConfig) {
     bool result = false;
     try {
 		// Use preconfigured object with all the correct http values assigned
-		curlEngine = new CurlEngine();
+		curlEngine = CurlEngine.get();
 		curlEngine.initialise(appConfig.getValueLong("dns_timeout"), appConfig.getValueLong("connect_timeout"), appConfig.getValueLong("data_timeout"), appConfig.getValueLong("operation_timeout"), appConfig.defaultMaxRedirects, appConfig.getValueBool("debug_https"), appConfig.getValueString("user_agent"), appConfig.getValueBool("force_http_11"), appConfig.getValueLong("rate_limit"), appConfig.getValueLong("ip_protocol_version"));
 
 		// Configure the remaining items required
@@ -228,8 +228,8 @@ bool testInternetReachability(ApplicationConfig appConfig) {
         displayOneDriveErrorMessage(e.msg, getFunctionName!({}));
     } finally {
         if (curlEngine) {
-            curlEngine.http.shutdown();
-            object.destroy(curlEngine);
+            curlEngine.release();
+			curlEngine = null;
         }
     }
 	


### PR DESCRIPTION
This pull request resolves the CurlEngine refactoring part of #2530. And introduce socket pool support for caching and reusing sockets, addressing the session rate issue discussed in detail at https://github.com/abraunegg/onedrive/discussions/2585#discussioncomment-8234231.

Changes
- Refactor CurlEngine
  - Add socket cleanup/setup/execution functions
  - Add a Response class for storing the request and response info
- Caching and reusing sockets
  - Create a socket pool for management and reuse of sockets

Notes
- Socket caching significantly enhances throughput in my environment but often leads to 429 errors. Should consider introducing a delay for specific actions to alleviate this issue.
- There are some overlapping changes between the two major modifications, so I submitted them together.