### PR TITLE
Fix error handling for version check

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -671,10 +671,8 @@ JSONValue getLatestReleaseDetails() {
         githubLatest = content.parseJSON();
     } catch (CurlException e) {
         addLogEntry("CurlException: Unable to query GitHub for latest release - " ~ e.msg, ["debug"]);
-        return parseJSON(`{"Error": "CurlException", "message": "` ~ e.msg ~ `"}`);
     } catch (JSONException e) {
         addLogEntry("JSONException: Unable to parse GitHub JSON response - " ~ e.msg, ["debug"]);
-        return parseJSON(`{"Error": "JSONException", "message": "` ~ e.msg ~ `"}`);
     }
 	
 	


### PR DESCRIPTION
This PR resolves the issue where progress crashes when the GitHub API is unavailable.

```
DEBUG: Shutting down HTTP engine as successfully reached OneDrive Login Service
DEBUG: Checking Application Version ...
DEBUG: CurlException: Unable to query GitHub for latest release - HTTP request returned status code 403 ()
DEBUG: Failure scope was called
DEBUG: Running performStandardExitProcess due to: failureScope
DEBUG: Shutdown Client Side Filtering instance
DEBUG: Shutdown Application Configuration instance
DEBUG: Setting ALL Class Objects to null due to failure scope
DEBUG: Exit scope was called
DEBUG: Running performStandardExitProcess due to: exitScope
DEBUG: Application exit
std.json.JSONException@std/json.d(687): Key not found: latestTag
----------------
/home/alan/dlang/dmd-2.105.3/linux/bin64/../../src/phobos/std/exception.d:518 pure @safe noreturn std.exception.bailOut!(std.json.JSONException).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x55e33d82e604]
??:? pure @safe inout(std.json.JSONValue)* std.exception.enforce!(std.json.JSONException).enforce!(inout(std.json.JSONValue)*).enforce(inout(std.json.JSONValue)*, lazy const(char)[], immutable(char)[], ulong) [0x55e33d987f9c]
??:? inout pure ref @safe inout(std.json.JSONValue) std.json.JSONValue.opIndex(return scope immutable(char)[]) [0x55e33d934421]
src/util.d:780 void util.checkApplicationVersion() [0x55e33d88991d]
src/main.d:410 _Dmain [0x55e33d7660b8]
```