### PR TITLE
Shutdown Inotify Monitor Gracefully

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1139,7 +1139,9 @@ void performStandardExitProcess(string scopeCaller = null) {
 		selectiveSync = null;
 		syncEngineInstance = null;
 	} else {
-		addLogEntry("Application exit", ["debug"]);
+		addLogEntry("Waiting for all servicecs to shutdown");
+		thread_joinAll();
+		addLogEntry("Application exit");
 		addLogEntry("#######################################################################################################################################", ["logFileOnly"]);
 		// Sleep to allow any final logging output to be printed - this is needed as we are using buffered logging output
 		Thread.sleep(dur!("msecs")(500));

--- a/src/main.d
+++ b/src/main.d
@@ -1139,7 +1139,7 @@ void performStandardExitProcess(string scopeCaller = null) {
 		selectiveSync = null;
 		syncEngineInstance = null;
 	} else {
-		addLogEntry("Waiting for all internal threads to complete before exiting application");
+		addLogEntry("Waiting for all internal threads to complete before exiting application", ["verbose"]);
 		thread_joinAll();
 		addLogEntry("Application exit", ["debug"]);
 		addLogEntry("#######################################################################################################################################", ["logFileOnly"]);

--- a/src/main.d
+++ b/src/main.d
@@ -1139,10 +1139,8 @@ void performStandardExitProcess(string scopeCaller = null) {
 		selectiveSync = null;
 		syncEngineInstance = null;
 	} else {
-		if (appConfig.getValueBool("monitor")) {
-			addLogEntry("Waiting for all servicecs to shutdown");
-			thread_joinAll();
-		}
+		addLogEntry("Waiting for all internal threads to complete before exiting application");
+		thread_joinAll();
 		addLogEntry("Application exit", ["debug"]);
 		addLogEntry("#######################################################################################################################################", ["logFileOnly"]);
 		// Destroy the shared logging buffer

--- a/src/main.d
+++ b/src/main.d
@@ -802,8 +802,7 @@ int main(string[] cliArgs) {
 				// Not using --download-only
 				try {
 					addLogEntry("Initialising filesystem inotify monitoring ...");
-					filesystemMonitor.initialise();
-					workerTid = filesystemMonitor.watch();
+					workerTid = filesystemMonitor.initialise();
 					addLogEntry("Performing initial syncronisation to ensure consistent local state ...");
 				} catch (MonitorException e) {	
 					// monitor class initialisation failed
@@ -1000,9 +999,7 @@ int main(string[] cliArgs) {
 						if(filesystemMonitor.initialised) {
 							// If local monitor is on
 							// start the worker and wait for event
-							if(!filesystemMonitor.isWorking()) {
-								workerTid.send(1);
-							}
+							workerTid.send(1);
 						}
 
 						if(webhookEnabled) {
@@ -1050,6 +1047,13 @@ int main(string[] cliArgs) {
 								}
 								break;
 							}
+						}
+						while (res != -1) {
+							signalExists = receiveTimeout(dur!"seconds"(-1), (int msg) {
+								res = msg;
+							});
+							if (!signalExists)
+								break;
 						}
 
 						if(res == -1) {

--- a/src/main.d
+++ b/src/main.d
@@ -722,7 +722,6 @@ int main(string[] cliArgs) {
 			}
 			
 			// Configure the monitor class
-			Tid workerTid;
 			filesystemMonitor = new Monitor(appConfig, selectiveSync);
 			
 			// Delegated function for when inotify detects a new local directory has been created
@@ -802,7 +801,7 @@ int main(string[] cliArgs) {
 				// Not using --download-only
 				try {
 					addLogEntry("Initialising filesystem inotify monitoring ...");
-					workerTid = filesystemMonitor.initialise();
+					filesystemMonitor.initialise();
 					addLogEntry("Performing initial syncronisation to ensure consistent local state ...");
 				} catch (MonitorException e) {	
 					// monitor class initialisation failed
@@ -999,7 +998,7 @@ int main(string[] cliArgs) {
 						if(filesystemMonitor.initialised) {
 							// If local monitor is on
 							// start the worker and wait for event
-							workerTid.send(1);
+							filesystemMonitor.send(true);
 						}
 
 						if(webhookEnabled) {
@@ -1047,13 +1046,6 @@ int main(string[] cliArgs) {
 								}
 								break;
 							}
-						}
-						while (res != -1) {
-							signalExists = receiveTimeout(dur!"seconds"(-1), (int msg) {
-								res = msg;
-							});
-							if (!signalExists)
-								break;
 						}
 
 						if(res == -1) {

--- a/src/main.d
+++ b/src/main.d
@@ -1139,9 +1139,11 @@ void performStandardExitProcess(string scopeCaller = null) {
 		selectiveSync = null;
 		syncEngineInstance = null;
 	} else {
-		addLogEntry("Waiting for all servicecs to shutdown");
-		thread_joinAll();
-		addLogEntry("Application exit");
+		if (appConfig.getValueBool("monitor")) {
+			addLogEntry("Waiting for all servicecs to shutdown");
+			thread_joinAll();
+		}
+		addLogEntry("Application exit", ["debug"]);
 		addLogEntry("#######################################################################################################################################", ["logFileOnly"]);
 		// Destroy the shared logging buffer
 		(cast() logBuffer).shutdown();

--- a/src/monitor.d
+++ b/src/monitor.d
@@ -102,7 +102,7 @@ class MonitorBackgroundWorker {
 			FD_SET((cast()p).readEnd.fileno, &fds);
 			
 			res = select(FD_SETSIZE, &fds, null, null, null);
-			
+
 			if(res == -1) {
 				if(errno() == EINTR) {
 					// Received an interrupt signal but no events are available
@@ -121,7 +121,6 @@ class MonitorBackgroundWorker {
 					isAlive = receiveOnly!bool();
 			}
 		}
-		callerTid.send(0);
 	}
 
 	shared void interrupt() {
@@ -234,16 +233,9 @@ final class Monitor {
 		initialised = false;
 		// Release all resources
 		removeAll();
-		worker.interrupt();
 		// Notify the worker that the monitor has been shutdown
-		receiveTimeout(dur!"seconds"(-1), (int _) {});
+		worker.interrupt();
 		send(false);
-		// Wait for the worker to terminate
-		int result = 1;
-		while(result == 1) {
-			result = receiveOnly!int();
-		}
-		worker.shutdown();
 		wdToDirName = null;
 	}
 


### PR DESCRIPTION
This pull request adds functionality to gracefully shut down the inotify monitor when the user sends a SIGINT signal (Ctrl+C). When the monitor receives the SIGINT signal, it closes the inotify file descriptor and exits the program gracefully.

Changes
- Add interrupt mechanism to monitor worker
- Add shutdown process for Monitor
- Improve communication between monitor worker