### PR TITLE
Fix: Initialization and Error Handling for Libnotify

### DIFF
--- a/src/log.d
+++ b/src/log.d
@@ -99,8 +99,13 @@ class LogBuffer {
 		shared void notify(string message) {
             // Use dnotify's functionality for GUI notifications, if GUI notifications is enabled
 			version(Notifications) {
-				auto n = new Notification("Log Notification", message, "IGNORED");
-				n.show();
+				try {
+					auto n = new Notification("Log Notification", message, "IGNORED");
+					n.show();
+				} catch (NotificationError e) {
+					sendGUINotification = false;
+					addLogEntry("Unable to send notification; disabled in the following: " ~ e.message);
+				}
 			}
         }
 

--- a/src/notifications/dnotify.d
+++ b/src/notifications/dnotify.d
@@ -79,11 +79,11 @@ void init(in char[] name) {
 alias notify_is_initted is_initted;
 alias notify_uninit uninit;
 
-static this() {
+shared static this() {
     init(__FILE__);
 }
 
-static ~this() {
+shared static ~this() {
     uninit();
 }
 


### PR DESCRIPTION
This PR addresses Libnotify-related issues
- Ensure un/initialization occurs only once to prevent race conditions.
- Implement error handling when notification system is not available.