### PR TITLE
Update URLs: http:// → https://

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 2.5.0 - TBA
 

--- a/docs/build-rpm-howto.md
+++ b/docs/build-rpm-howto.md
@@ -13,7 +13,7 @@ sudo yum install -y libcurl-devel
 sudo yum install -y sqlite-devel
 sudo yum install -y libnotify-devel
 sudo yum install -y wget
-sudo yum install -y http://downloads.dlang.org/releases/2.x/2.088.0/dmd-2.088.0-0.fedora.x86_64.rpm
+sudo yum install -y https://downloads.dlang.org/releases/2.x/2.088.0/dmd-2.088.0-0.fedora.x86_64.rpm
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,7 +37,7 @@ Only the current release version or greater is supported. Earlier versions are n
 ## Building from Source - High Level Requirements
 *   For successful compilation of this application, it's crucial that the build environment is equipped with a minimum of 1GB of memory and an additional 1GB of swap space.
 *   Install the required distribution package dependencies coverering the required development tools and development libraries for curl and sqlite
-*   Install the [Digital Mars D Compiler (DMD)](http://dlang.org/download.html) or [LDC – the LLVM-based D Compiler](https://github.com/ldc-developers/ldc)
+*   Install the [Digital Mars D Compiler (DMD)](https://dlang.org/download.html) or [LDC – the LLVM-based D Compiler](https://github.com/ldc-developers/ldc)
 
 > [!IMPORTANT]
 > To compile this application successfully, it is essential to use either DMD version **2.088.0** or higher, or LDC version **1.18.0** or higher. Ensuring compatibility and optimal performance necessitates the use of these specific versions or their more recent updates.

--- a/src/arsd/cgi.d
+++ b/src/arsd/cgi.d
@@ -764,7 +764,7 @@ class ConnectionClosedException : Exception {
 version(Windows) {
 // FIXME: ugly hack to solve stdin exception problems on Windows:
 // reading stdin results in StdioException (Bad file descriptor)
-// this is probably due to http://d.puremagic.com/issues/show_bug.cgi?id=3425
+// this is probably due to https://issues.dlang.org/show_bug.cgi?id=3425
 private struct stdin {
 	struct ByChunk { // Replicates std.stdio.ByChunk
 	private:
@@ -6278,7 +6278,7 @@ ByChunkRange byChunk(BufferedInputRange ir, size_t atMost) {
 }
 
 version(cgi_with_websocket) {
-	// http://tools.ietf.org/html/rfc6455
+	// https://tools.ietf.org/html/rfc6455
 
 	/**
 		WEBSOCKET SUPPORT:


### PR DESCRIPTION
Concerning the updates to [LICENSE](https://github.com/abraunegg/onedrive/blob/master/LICENSE), they have been pulled directly from https://www.gnu.org/licenses/gpl-3.0.txt.