### PR TITLE
Fix Aborted in monitor mode on interrupt

### DIFF
--- a/src/monitor.d
+++ b/src/monitor.d
@@ -254,6 +254,8 @@ final class Monitor {
 	bool initialised = false;
 	// Worker Tid
 	Tid workerTid;
+	// Caller Tid
+	Tid callerTid;
 	
 	// Configure Private Class Variables
 	shared(MonitorBackgroundWorker) worker;
@@ -312,6 +314,7 @@ final class Monitor {
 		addRecursive(monitorPath);
 		
 		// Start monitoring
+		callerTid = thisTid;
 		workerTid = spawn(&startMonitorJob, worker, thisTid);
 
 		initialised = true;
@@ -320,6 +323,11 @@ final class Monitor {
 	// Communication with worker
 	void send(bool isAlive) {
 		workerTid.send(isAlive);
+	}
+
+	void interrupt() {
+		// Wake up caller
+		callerTid.send(-1);
 	}
 
 	// Shutdown the monitor class


### PR DESCRIPTION
This PR resolves the error `Aborting from core/sync/mutex.d(149) Error: pthread_mutex_destroy failed.Aborted` on interruption in monitor mode. (https://github.com/abraunegg/onedrive/discussions/2710#discussioncomment-9559497)

Changes
1. Two stage interruption to resume threads before force exiting
2. Ensure the cleanup process executes only once.