### PR TITLE
No useradd for root

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -13,14 +13,16 @@ else
   odgroup=${odgroup%%:*}
 fi
 
-# Create new user using target UID
-if ! oduser="$(getent passwd "$ONEDRIVE_UID")"; then
-  oduser='onedrive'
-  useradd -m "${oduser}" -u "$ONEDRIVE_UID" -g "$ONEDRIVE_GID"
-else
-  oduser="${oduser%%:*}"
-  usermod -g "${odgroup}" "${oduser}"
-  grep -qv root <( groups "${oduser}" ) || { echo 'ROOT level privileges prohibited!'; exit 1; }
+# Create new user using target UID except for root
+if [ "$ONEDRIVE_UID" != "0" ]; then
+  if ! oduser="$(getent passwd "$ONEDRIVE_UID")"; then
+    oduser='onedrive'
+    useradd -m "${oduser}" -u "$ONEDRIVE_UID" -g "$ONEDRIVE_GID"
+  else
+    oduser="${oduser%%:*}"
+    usermod -g "${odgroup}" "${oduser}"
+    grep -qv root <( groups "${oduser}" ) || { echo 'ROOT level privileges prohibited!'; exit 1; }
+  fi
 fi
 
 # Default parameters


### PR DESCRIPTION
In the docker context, if we need onedrive to run as userid 0 (root), avoid creating a user/groups, it's already exist in the initial image.

Useful if you have files owned by root on the hosting machine, this allow to make the onedrive copy without chown/chmod.

Best regards,
Azlux