### PR TITLE
[FIX] Drive listing does not loop on nextLink

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -701,9 +701,14 @@ class OneDriveApi {
 	}
 	
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/drive_list?view=odsp-graph-online
-	JSONValue o365SiteDrives(string site_id){
+	JSONValue o365SiteDrives(string site_id, string nextLink){
 		string url;
-		url = siteDriveUrl ~ site_id ~ "/drives";
+		// configure URL to query
+		if (nextLink.empty) {
+			url = siteDriveUrl ~ site_id ~ "/drives";
+		} else {
+			url = nextLink;
+		}
 		return get(url);
 	}
 


### PR DESCRIPTION
Closes #2771 

Before: [rc3-output.txt](https://github.com/user-attachments/files/16605142/rc3-output.txt)
After: [fix-output.txt](https://github.com/user-attachments/files/16605143/fix-output.txt)

Sensitive data removed from outputs.


Successfully compiled on minimum ldc:
```
(ldc-1.20.1)vscode@0dd308454835:/workspaces/onedrive$ ./configure --enable-debug --enable-notifications; make clean; make;
checking for a BSD-compatible install... /usr/bin/install -c
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for dmd... ldc2
checking version of D compiler... 1.20.1
checking for curl... yes
checking for sqlite... yes
checking for notify... no
configure: creating ./config.status
config.status: creating Makefile
config.status: creating contrib/pacman/PKGBUILD
config.status: creating contrib/spec/onedrive.spec
config.status: creating onedrive.1
config.status: creating contrib/systemd/onedrive.service
config.status: creating contrib/systemd/onedrive@.service
rm -f onedrive onedrive.o version
rm -rf autom4te.cache
rm -f config.log config.status
if [ -f .git/HEAD ] ; then \
        git describe --tags > version ; \
else \
        echo v2.5.0-rc3 > version ; \
fi
ldc2 -w -J. -g -d-debug -gc -L-lcurl -L-lsqlite3  -L-ldl src/main.d src/config.d src/log.d src/util.d src/qxor.d src/curlEngine.d src/onedrive.d src/webhook.d src/sync.d src/itemdb.d src/sqlite.d src/clientSideFiltering.d src/monitor.d src/arsd/cgi.d -ofonedrive
(ldc-1.20.1)vscode@0dd308454835:/workspaces/onedrive$ deactivate
vscode@0dd308454835:/workspaces/onedrive$ ./onedrive --version
onedrive v2.5.0-rc3-7-gbd92098
```