### PR TITLE
Properly set content-type header for subscription endpoints

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -732,7 +732,6 @@ class OneDriveApi {
 			"expirationDateTime": expirationDateTime.toISOExtString(),
  			"clientState": randomUUID().toString()
 		];
-		curlEngine.http.addRequestHeader("Content-Type", "application/json");
 		return post(url, request.toString());
 	}
 	
@@ -742,7 +741,6 @@ class OneDriveApi {
 		const JSONValue request = [
 			"expirationDateTime": expirationDateTime.toISOExtString()
 		];
-		curlEngine.http.addRequestHeader("Content-Type", "application/json");
 		return patch(url, request.toString());
 	}
 	


### PR DESCRIPTION
Remove the explict `curlEngine.http.addRequestHeader` calls because the header is already set by the `post` and `patch` methods.