### PR TITLE
Fix issue #2815

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -3835,7 +3835,17 @@ class SyncEngine {
 						if (containsURLEncodedItems(selfBuiltPath)) {
 							// decode it
 							addLogEntry("selfBuiltPath for sync_list check needs decoding: " ~ selfBuiltPath, ["debug"]);
-							newItemPath = decodeComponent(selfBuiltPath);
+							
+							try {
+								// try and decode selfBuiltPath
+								newItemPath = decodeComponent(selfBuiltPath);
+							} catch (URIException exception) {
+								// why?
+								addLogEntry("ERROR: Unable to URL Decode path: " ~ exception.msg);
+								addLogEntry("ERROR: To resolve, rename this item online: " ~ selfBuiltPath);
+								// have to use as-is due to decode error
+								newItemPath = selfBuiltPath;
+							}
 						} else {
 							// use as-is
 							newItemPath = selfBuiltPath;


### PR DESCRIPTION
* If 'sync_list' is being used, and the file online contains URL encoded items, and cannot be URL decoded, catch the exception generated and generate an error message regarding the issue to advise the user to rename the offending item online.