### PR TITLE
Fix issue #2823: Fix regression of extra quotation marks when using ONEDRIVE_SINGLE_DIRECTORY with Docker

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -795,7 +795,9 @@ class ApplicationConfig {
 						setValueString("skip_dir", configFileSkipDir);
 					}
 				} else if (key == "single_directory") {
-					string configFileSingleDirectory = strip(value, "\"");
+					// --single-directory Strip quotation marks from path 
+					// This is an issue when using ONEDRIVE_SINGLE_DIRECTORY with Docker
+					string configFileSingleDirectory = strip(to!string(c.front.dup), "\"");
 					setValueString("single_directory", configFileSingleDirectory);
 				} else if (key == "azure_ad_endpoint") {
 					switch (value) {

--- a/src/main.d
+++ b/src/main.d
@@ -710,8 +710,12 @@ int main(string[] cliArgs) {
 		
 		// Are we doing a single directory operation (--single-directory) ?
 		if (!appConfig.getValueString("single_directory").empty) {
+			// Ensure that the value stored for appConfig.getValueString("single_directory") does not contain any extra quotation marks
+			string originalSingleDirectoryValue = appConfig.getValueString("single_directory");
+			// Strip quotation marks from provided path to ensure no issues within a Docker environment when using passed in values
+			string updatedSingleDirectoryValue = strip(originalSingleDirectoryValue, "\"");
 			// Set singleDirectoryPath
-			singleDirectoryPath = appConfig.getValueString("single_directory");
+			singleDirectoryPath = updatedSingleDirectoryValue;
 			
 			// Ensure that this is a normalised relative path to runtimeSyncDirectory
 			string normalisedRelativePath = replace(buildNormalizedPath(absolutePath(singleDirectoryPath)), buildNormalizedPath(absolutePath(runtimeSyncDirectory)), "." );


### PR DESCRIPTION
* Fix regression of extra quotation marks when using ONEDRIVE_SINGLE_DIRECTORY with Docker. Original issue #2318 , original fix #2319