### PR TITLE
Update Debian Dockerfile to use 'curl' from backports

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,9 +6,9 @@ on:
     tags: [ 'v*' ]
   pull_request:
     # Comment these out to force a test build on a PR
-    branches:
-      - master
-    types: [closed]
+    #branches:
+    #  - master
+    #types: [closed]
 
 env:
   DOCKER_HUB_SLUG: driveone/onedrive

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,9 +6,9 @@ on:
     tags: [ 'v*' ]
   pull_request:
     # Comment these out to force a test build on a PR
-    #branches:
-    #  - master
-    #types: [closed]
+    branches:
+      - master
+    types: [closed]
 
 env:
   DOCKER_HUB_SLUG: driveone/onedrive

--- a/contrib/docker/Dockerfile-debian
+++ b/contrib/docker/Dockerfile-debian
@@ -4,9 +4,15 @@ ARG DEBIAN_VERSION=stable
 
 FROM debian:${DEBIAN_VERSION} AS builder-onedrive
 
+# Add backports repository and update before initial DEBIAN_FRONTEND installation
 RUN apt-get clean \
+ && echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/debian-12-backports.list \
+ && apt-get update \
+ && apt-get upgrade -y \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential curl ca-certificates libcurl4-openssl-dev libsqlite3-dev libxml2-dev pkg-config git ldc \
+ # Install|update curl from backports
+ && apt-get install -t bookworm-backports -y curl \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /usr/src/onedrive
@@ -19,10 +25,14 @@ RUN ./configure --enable-debug\
 
 FROM debian:${DEBIAN_VERSION}-slim
 
+# Add backports repository and update after DEBIAN_FRONTEND installation
 RUN apt-get clean \
+ && echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/debian-12-backports.list \
  && apt-get update \
  && apt-get upgrade -y \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libcurl4 libsqlite3-0 ca-certificates libphobos2-ldc-shared100 \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu libsqlite3-0 ca-certificates libphobos2-ldc-shared100 \
+ # Install|update curl from backports
+ && apt-get install -t bookworm-backports -y curl \
  && rm -rf /var/lib/apt/lists/* \
  # Fix bug with ssl on armhf: https://serverfault.com/a/1045189
  && /usr/bin/c_rehash \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -304,9 +304,13 @@ docker container run -e ONEDRIVE_RESYNC=1 -v onedrive_conf:/onedrive/conf -v "${
 ```bash
 docker container run -e ONEDRIVE_RESYNC=1 -e ONEDRIVE_VERBOSE=1 -v onedrive_conf:/onedrive/conf -v "${ONEDRIVE_DATA_DIR}:/onedrive/data" driveone/onedrive:edge
 ```
-**Perform a --logout and re-authenticate:**
+**Perform a --logout:**
 ```bash
 docker container run -it -e ONEDRIVE_LOGOUT=1 -v onedrive_conf:/onedrive/conf -v "${ONEDRIVE_DATA_DIR}:/onedrive/data" driveone/onedrive:edge
+```
+**Perform a --logout and re-authenticate:**
+```bash
+docker container run -it -e ONEDRIVE_REAUTH=1 -v onedrive_conf:/onedrive/conf -v "${ONEDRIVE_DATA_DIR}:/onedrive/data" driveone/onedrive:edge
 ```
 
 ## Building a custom Docker image

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -321,9 +321,13 @@ podman run -e ONEDRIVE_RESYNC=1 -v onedrive_conf:/onedrive/conf:U,Z -v "${ONEDRI
 ```bash
 podman run -e ONEDRIVE_RESYNC=1 -e ONEDRIVE_VERBOSE=1 -v onedrive_conf:/onedrive/conf:U,Z -v "${ONEDRIVE_DATA_DIR}:/onedrive/data:U,Z" --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" driveone/onedrive:edge
 ```
-**Perform a --logout and re-authenticate:**
+**Perform a --logout:**
 ```bash
 podman run -it -e ONEDRIVE_LOGOUT=1 -v onedrive_conf:/onedrive/conf:U,Z -v "${ONEDRIVE_DATA_DIR}:/onedrive/data:U,Z" --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" driveone/onedrive:edge
+```
+**Perform a --logout and re-authenticate:**
+```bash
+podman run -it -e ONEDRIVE_REAUTH=1 -v onedrive_conf:/onedrive/conf:U,Z -v "${ONEDRIVE_DATA_DIR}:/onedrive/data:U,Z" --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" driveone/onedrive:edge
 ```
 
 ## Building a custom Podman image


### PR DESCRIPTION
* Due to the significant issues with Debian and it's default version of 'curl' ensure that the Debian Docker image will update 'curl' from the relevant backports repository