### PR TITLE
FIX_REGEX_TO_CONTAIN_FULL_ISO_DATE

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -528,7 +528,7 @@ bool isValidUTF16(string path) {
 // Validate that the provided string is a valid date time stamp in UTC format
 bool isValidUTCDateTime(string dateTimeString) {
     // Regular expression for validating the string against UTC datetime format
-	auto pattern = regex(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$");
+	auto pattern = regex(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z$");
 	
 	// Validate for UTF-8 first
 	if (!isValidUTF8(dateTimeString)) {


### PR DESCRIPTION
Microsoft is sending the date with the fractional part of the second (i.e.: 2024-09-28T14:01:11.8894487Z), the REGEX checking the format is failing.