### PR TITLE
Fix build error on OpenBSD

### DIFF
--- a/src/arsd/cgi.d
+++ b/src/arsd/cgi.d
@@ -575,6 +575,8 @@ version(Posix) {
 			// GDC doesn't support static foreach so I had to cheat on it :(
 		} else version(FreeBSD) {
 			// I never implemented the fancy stuff there either
+		} else version(OpenBSD) {
+			// Fix issue #2977 - adopt same approach as FreeBSD above
 		} else {
 			version=with_breaking_cgi_features;
 			version=with_sendfd;


### PR DESCRIPTION
* Add OS version handler for OpenBSD in the same way as FreeBSD is handled