### PR TITLE
Fix unable to parse SSL version

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -1446,7 +1446,7 @@ void checkOpenSSLVersion() {
 
 	auto matches = versionString.match(versionRegex);
 	if (matches.empty) {
-		if (debugLogging) {addLogEntry("Unable to parse OpenSSL version: " ~ versionString, ["debug"]);}
+		if (verboseLogging) {addLogEntry("Unable to parse OpenSSL version: " ~ versionString, ["verbose"]);}
 	} else {
 		// Extract major, minor, patch, and optional letter parts
 		uint major = matches.captures[1].to!uint;

--- a/src/util.d
+++ b/src/util.d
@@ -1446,7 +1446,9 @@ void checkOpenSSLVersion() {
 
 	auto matches = versionString.match(versionRegex);
 	if (matches.empty) {
-		if (verboseLogging) {addLogEntry("Unable to parse OpenSSL version: " ~ versionString, ["verbose"]);}
+		if (!versionString.empty) {
+			if (verboseLogging) {addLogEntry("Unable to provided parse OpenSSL version: " ~ versionString, ["verbose"]);}
+		}
 	} else {
 		// Extract major, minor, patch, and optional letter parts
 		uint major = matches.captures[1].to!uint;


### PR DESCRIPTION
* On some systems OpenSSL version cannot be parsed. When this cannot be parsed, do not force exit, allow the client to continue operations.