### PR TITLE
Fix import of 'sync_list' and rule application

### DIFF
--- a/src/clientSideFiltering.d
+++ b/src/clientSideFiltering.d
@@ -101,7 +101,10 @@ class ClientSideFiltering {
 		auto range = file.byLine();
 		foreach (line; range) {
 			// Skip comments in file
-			if (line.length == 0 || line[0] == ';' || line[0] == '#') continue;
+			if (line[0] == ';' || line[0] == '#') continue;
+			
+			// Skip any line that is empty or just contains whitespace
+			if (line.strip.length == 0) continue;
 			
 			// Is the rule a legacy 'include all root files lazy rule?' 
 			if ((strip(line) == "/*") || (strip(line) == "/")) {
@@ -116,6 +119,12 @@ class ClientSideFiltering {
 		}
 		// Close reading the 'sync_list' file
 		file.close();
+	}
+	
+	// return true or false based on if we have loaded any valid sync_list rules
+	bool validSyncListRules() {
+		// If empty, will return true
+		return syncListRules.empty;
 	}
 	
 	// Configure the regex that will be used for 'skip_file'
@@ -237,7 +246,8 @@ class ClientSideFiltering {
 				
 		// always allow the root
 		if (path == ".") return false;
-		// if there are no allowed syncListRules always return false
+		
+		// if there are no allowed syncListRules always return false, meaning path is not excluded
 		if (syncListRules.empty) return false;
 		
 		// To ensure we are checking the 'right' path, build the path
@@ -247,7 +257,7 @@ class ClientSideFiltering {
 		if (debugLogging) {
 			addLogEntry("******************* SYNC LIST RULES EVALUATION START *******************", ["debug"]);
 			addLogEntry("Evaluation against 'sync_list' rules for this input path: " ~ path, ["debug"]);
-			addLogEntry("[S]excludeExactMatch       = " ~ to!string(excludeExactMatch), ["debug"]);
+			addLogEntry("[S]excludeExactMatch      = " ~ to!string(excludeExactMatch), ["debug"]);
 			addLogEntry("[S]excludeParentMatched   = " ~ to!string(excludeParentMatched), ["debug"]);
 			addLogEntry("[S]excludeAnywhereMatched = " ~ to!string(excludeAnywhereMatched), ["debug"]);
 			addLogEntry("[S]excludeWildcardMatched = " ~ to!string(excludeWildcardMatched), ["debug"]);
@@ -526,7 +536,7 @@ class ClientSideFiltering {
 			addLogEntry("------------------------------------------------------------------------", ["debug"]);
 		
 			// Interim results after checking each 'sync_list' rule against the input path
-			addLogEntry("[F]excludeExactMatch       = " ~ to!string(excludeExactMatch), ["debug"]);
+			addLogEntry("[F]excludeExactMatch      = " ~ to!string(excludeExactMatch), ["debug"]);
 			addLogEntry("[F]excludeParentMatched   = " ~ to!string(excludeParentMatched), ["debug"]);
 			addLogEntry("[F]excludeAnywhereMatched = " ~ to!string(excludeAnywhereMatched), ["debug"]);
 			addLogEntry("[F]excludeWildcardMatched = " ~ to!string(excludeWildcardMatched), ["debug"]);

--- a/src/sync.d
+++ b/src/sync.d
@@ -226,7 +226,20 @@ class SyncEngine {
 		}
 		
 		// Is there a sync_list file present?
-		if (exists(appConfig.syncListFilePath)) this.syncListConfigured = true;
+		if (exists(appConfig.syncListFilePath)) {
+			// yes there is a file present, but did we load any entries?
+			if (!selectiveSync.validSyncListRules) {
+				// function returned 'false' (array contains valid entries)
+				// flag there are rules to process when we are performing Client Side Filtering
+				if (debugLogging) {addLogEntry("Configuring syncListConfigured flag to TRUE as valid entries were loaded from 'sync_list' file", ["debug"]);}
+				this.syncListConfigured = true;
+			} else {
+				// function returned 'true' meaning there are are zero sync_list rules loaded despite the 'sync_list' file being present
+				// ensure this flag is false so we do not do any extra processing
+				if (debugLogging) {addLogEntry("Configuring syncListConfigured flag to FALSE as no valid entries were loaded from 'sync_list' file", ["debug"]);}
+				this.syncListConfigured = false;
+			}
+		}
 		
 		// Configure the uploadOnly flag to capture if --upload-only was used
 		if (appConfig.getValueBool("upload_only")) {


### PR DESCRIPTION
* The OneDriveGUI creates an empty sync_list file. If this file exists, and we loaded zero valid lines from it, flag that sync_list is not configured and not being used.