### PR TITLE
Fix --display-config when dealing with empty sync_list

### DIFF
--- a/src/clientSideFiltering.d
+++ b/src/clientSideFiltering.d
@@ -100,13 +100,13 @@ class ClientSideFiltering {
 		auto file = File(filepath, "r");
 		auto range = file.byLine();
 		foreach (line; range) {
-			// Skip comments in file
-			if (line[0] == ';' || line[0] == '#') continue;
-			
 			// Skip any line that is empty or just contains whitespace
 			if (line.strip.length == 0) continue;
 			
-			// Is the rule a legacy 'include all root files lazy rule?' 
+			// Skip comments in file
+			if (line[0] == ';' || line[0] == '#') continue;
+			
+			// Is the rule a legacy 'include all root files lazy rule?'
 			if ((strip(line) == "/*") || (strip(line) == "/")) {
 				// yes ...
 				string errorMessage = "ERROR: Invalid sync_list rule '" ~ to!string(strip(line)) ~ "' detected. Please use 'sync_root_files = \"true\"' or --sync-root-files option to sync files in the root path.";

--- a/src/config.d
+++ b/src/config.d
@@ -1437,8 +1437,8 @@ class ApplicationConfig {
 			addLogEntry("Compile time option --enable-notifications   = false");
 		}
 		
-		// Is sync_list configured ?
-		if (exists(syncListFilePath)){
+		// Is sync_list configured and contains entries?
+		if (exists(syncListFilePath) && getSize(syncListFilePath) > 0) {
 			addLogEntry(); // used instead of an empty 'writeln();' to ensure the line break is correct in the buffered console output ordering
 			addLogEntry("Selective sync 'sync_list' configured        = true");
 			addLogEntry("sync_list config option 'sync_root_files'    = " ~ to!string(getValueBool("sync_root_files")));
@@ -1446,13 +1446,24 @@ class ApplicationConfig {
 			// Output the sync_list contents
 			auto syncListFile = File(syncListFilePath, "r");
 			auto range = syncListFile.byLine();
-			foreach (line; range)
-			{
+			addLogEntry("------------------------------'sync_list'------------------------------");
+			foreach (line; range) {
 				addLogEntry(to!string(line));
 			}
+			addLogEntry("-----------------------------------------------------------------------");
+			
+			// Close reading the 'sync_list' file
+			syncListFile.close();
 		} else {
+			// file does not exist or file size is not greater than 0
 			addLogEntry(); // used instead of an empty 'writeln();' to ensure the line break is correct in the buffered console output ordering
-			addLogEntry("Selective sync 'sync_list' configured        = false");
+			if (exists(syncListFilePath) && getSize(syncListFilePath) == 0) {
+				// 'sync_list' file exists, no entries
+				addLogEntry("Selective sync 'sync_list' configured        = file exists but contains zero data");
+			} else {
+				// no 'sync_list' file
+				addLogEntry("Selective sync 'sync_list' configured        = false");
+			}
 		}
 		
 		// Is sync_business_shared_items enabled and configured ?

--- a/src/main.d
+++ b/src/main.d
@@ -228,7 +228,7 @@ int main(string[] cliArgs) {
 			// add warning message
 			string curlWarningMessage = format("WARNING: Your cURL/libcurl version (%s) has known operational bugs that impact the use of this client.", curlVersion);
 			addLogEntry();
-			addLogEntry(curlWarningMessage); // curl HTTP/1.1 downgrade in place meaning user too steps to remediate, standard logging
+			addLogEntry(curlWarningMessage); // curl HTTP/1.1 downgrade in place meaning user took steps to remediate, perform standard logging with no GUI notification
 			addLogEntry(distributionWarning);
 			addLogEntry();
 		}


### PR DESCRIPTION
* When using --display-config ensure that when a sync_list file is being used, that this actually is a valid file with applicable contents to display