### PR TITLE
Fix that Business Shared Items shortcuts are skipped

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -255,6 +255,7 @@ odata
 ofonedrive
 onbinarymessage
 onedrive
+onetoc
 onmicrosoft
 ontextmessage
 opensuse

--- a/src/sync.d
+++ b/src/sync.d
@@ -1402,8 +1402,6 @@ class SyncEngine {
 				// - Is not a folder
 				// - Has a 'size' element
 				
-				addLogEntry("onedriveJSONItem: " ~ to!string(onedriveJSONItem));
-				
 				// Online Shared Folder Shortcuts match the same criteria - we need to ensure this is not a Online Shared Folder Shortcuts
 				if (!isItemRemote(onedriveJSONItem)) {
 					// Not a pointer to a remote item, thus high confidence this is not a shared folder link

--- a/src/sync.d
+++ b/src/sync.d
@@ -1415,9 +1415,18 @@ class SyncEngine {
 			// Is there a 'file' JSON element and it has a 'mimeType' element?
 			if (isItemFile(onedriveJSONItem) && hasMimeType(onedriveJSONItem)) {
 				// and the mimeType is 'application/msonenote' or 'application/octet-stream'
+				
+				// However there is API inconsistency here between Personal and Business Accounts
+				// Personal OneNote .onetoc2 and .one items all report mimeType as 'application/msonenote'
+				// Business OneNote .onetoc2 and .one items however are different:
+				//  .onetoc2 = 'application/octet-stream' mimeType
+				//  .one = 'application/msonenote' mimeType
+				
 				if (isMicrosoftOneNoteMimeType1(onedriveJSONItem) || isMicrosoftOneNoteMimeType2(onedriveJSONItem)) {
 					// and must not have any hash
-					if (hasZeroHashes(onedriveJSONItem)) {
+					// Personal Accounts hashes are 100% missing
+					// Business Accounts hashes exist, but JSON array is empty	
+					if ((!hasHashes(onedriveJSONItem)) || (hasZeroHashes(onedriveJSONItem))) {
 						// extreme confidence these are Microsoft OneNote file references which cannot be supported
 						// Log that this was skipped as this was a Microsoft OneNote item and unsupported
 						if (verboseLogging) {addLogEntry("Skipping path - The Microsoft OneNote Notebook File '" ~ generatePathFromJSONData(onedriveJSONItem) ~ "' is not supported by this client", ["verbose"]);}

--- a/src/util.d
+++ b/src/util.d
@@ -1069,6 +1069,17 @@ bool hasHashes(const ref JSONValue item) {
 	return ("hashes" in item["file"]) != null;
 }
 
+bool hasZeroHashes(const ref JSONValue item) {
+    // Check if "hashes" exists under "file" and is empty
+    if ("hashes" in item["file"]) {
+        auto hashes = item["file"]["hashes"];
+        if (hashes.type == JSONType.object && hashes.object.keys.length == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool hasQuickXorHash(const ref JSONValue item) {
 	return ("quickXorHash" in item["file"]["hashes"]) != null;
 }


### PR DESCRIPTION
* Fix that Business Shared Items shortcuts are skipped as being incorrectly detected as Microsoft OneNote Notebook items