### PR TITLE
Cleanup debug logging output

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -80,7 +80,7 @@ class CurlResponse {
 		hasResponse = true;
 		this.responseHeaders = http.responseHeaders();
 		this.statusLine = http.statusLine;
-		if (debugLogging) {
+		if ((debugLogging) && (debugHTTPSResponse)) {
 			addLogEntry("HTTP Response Headers: " ~ to!string(this.responseHeaders), ["debug"]);
 			addLogEntry("HTTP Status Line: " ~ to!string(this.statusLine), ["debug"]);
 		}

--- a/src/log.d
+++ b/src/log.d
@@ -24,6 +24,7 @@ version(Notifications) {
 // Shared Application Logging Level Variables
 __gshared bool verboseLogging = false;
 __gshared bool debugLogging = false;
+__gshared bool debugHTTPSResponse = false;
 
 // Private Shared Module Objects
 private __gshared LogBuffer logBuffer;

--- a/src/main.d
+++ b/src/main.d
@@ -199,6 +199,9 @@ int main(string[] cliArgs) {
 		}
 	}
 	
+	// If --debug-https has been used, set the applicable flag
+	debugHTTPSResponse = appConfig.getValueBool("debug_https");
+	
 	// Common warning
 	string distributionWarning = "         Please report this to your distribution, requesting an update to a newer cURL version, or consider upgrading it yourself for optimal stability.";
 	

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -30,9 +30,6 @@ import log;
 import util;
 import curlEngine;
 
-// Shared variables between classes
-shared bool debugHTTPResponseOutput = false;
-
 // Define the 'OneDriveException' class
 class OneDriveException: Exception {
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/errors
@@ -87,7 +84,6 @@ class OneDriveApi {
 	string authScope = "";
 	const(char)[] refreshToken = "";
 	bool dryRun = false;
-	bool debugResponse = false;
 	bool keepAlive = false;
 
 	this(ApplicationConfig appConfig) {
@@ -148,11 +144,6 @@ class OneDriveApi {
 
 		// Did the user specify --dry-run
 		dryRun = appConfig.getValueBool("dry_run");
-		
-		// Did the user specify --debug-https
-		debugResponse = appConfig.getValueBool("debug_https");
-		// Flag this so if webhooks are being used, it can also be consumed
-		debugHTTPResponseOutput = appConfig.getValueBool("debug_https");
 		
 		// Set clientId to use the configured 'application_id'
 		clientId = appConfig.getValueString("application_id");
@@ -1187,8 +1178,8 @@ class OneDriveApi {
 				if (response.hasResponse) {
 					// Process the response
 					result = response.json();
-					// Print response if 'debugResponse' is flagged
-					if (debugResponse){
+					// Print response if 'debugHTTPSResponse' is flagged
+					if (debugHTTPSResponse){
 						if (debugLogging) {addLogEntry("Microsoft Graph API Response: " ~ response.dumpResponse(), ["debug"]);}
 					}
 					

--- a/src/util.d
+++ b/src/util.d
@@ -1458,7 +1458,7 @@ void checkOpenSSLVersion() {
 	auto matches = versionString.match(versionRegex);
 	if (matches.empty) {
 		if (!versionString.empty) {
-			if (verboseLogging) {addLogEntry("Unable to provided parse OpenSSL version: " ~ versionString, ["verbose"]);}
+			if (debugLogging) {addLogEntry("Unable to provided parse OpenSSL version: " ~ versionString, ["debug"]);}
 		}
 	} else {
 		// Extract major, minor, patch, and optional letter parts

--- a/src/webhook.d
+++ b/src/webhook.d
@@ -86,7 +86,7 @@ class OneDriveWebhook {
 	}
 
 	private static void handle(shared OneDriveWebhook _this, Cgi cgi) {
-		if (debugHTTPResponseOutput) {
+		if (debugHTTPSResponse) {
 			addLogEntry("Webhook request: " ~ to!string(cgi.requestMethod) ~ " " ~ to!string(cgi.requestUri));
 			if (!cgi.postBody.empty) {
 				addLogEntry("Webhook post body: " ~ to!string(cgi.postBody));


### PR DESCRIPTION
* Use debugHTTPSResponse as a global variable
* Only output HTTP response headers if using --debug-https