### PR TITLE
Add quota status messages based on OneDrive Account API response

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -503,7 +503,7 @@ class SyncEngine {
 				addLogEntry("cachedOnlineDriveData.quotaRestricted = " ~ to!string(cachedOnlineDriveData.quotaRestricted), ["debug"]);
 			}
 			
-			// Regardless of this being all set - based on the JSON respone, check for 'quota' being present, to check 
+			// Regardless of this being all set - based on the JSON response, check for 'quota' being present, to check 
 			// for the following valid states: normal | nearing | critical | exceeded
 			//
 			// Based on this, then generate an applicable application message to advise the user of their quota status

--- a/src/util.d
+++ b/src/util.d
@@ -991,6 +991,10 @@ bool hasQuota(JSONValue item) {
 	return ("quota" in item) != null;
 }
 
+bool hasQuotaState(JSONValue item) {
+	return ("state" in item["quota"]) != null;
+}
+
 bool isItemDeleted(JSONValue item) {
 	return ("deleted" in item) != null;
 }


### PR DESCRIPTION
* Add quota status messages for nearing | critical | exceeded based on OneDrive Account API response
* Fix space calculations due to using ulong variable type to ensure that if calculation is negative, value is negative