### PR TITLE
feat: optionally use standalone mode for syncing using Docker container

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -34,8 +34,19 @@ else
 fi
 
 # Default parameters
-ARGS=(--monitor --confdir /onedrive/conf --syncdir /onedrive/data)
+ARGS=(--confdir /onedrive/conf --syncdir /onedrive/data)
 echo "# Base Args: ${ARGS}"
+
+# Tell client to use Standalone Mode, based on an environment variable. Otherwise Monitor Mode is used.
+if [ "${ONEDRIVE_SYNC_ONCE:=0}" == "1" ]; then
+	echo "# We run in Standalone Mode"
+	echo "# Adding --sync"
+	ARGS=(--sync ${ARGS[@]})
+else
+	echo "# We run in Monitor Mode"
+	echo "# Adding --monitor"
+	ARGS=(--monitor ${ARGS[@]})
+fi
 
 # Make Verbose output optional, based on an environment variable
 if [ "${ONEDRIVE_VERBOSE:=0}" == "1" ]; then

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -287,6 +287,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_DISABLE_UPLOAD_VALIDATION</B> | Controls "--disable-upload-validation" option. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
+| <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -304,6 +304,7 @@ podman run -it --name onedrive_work --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" \
 | <B>ONEDRIVE_DISABLE_UPLOAD_VALIDATION</B> | Controls "--disable-upload-validation" option. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
+| <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**


### PR DESCRIPTION
I am using the Docker container to sync the files from a Onedrive account to my NAS. There I take a ZFS snapshot of the files every night. The Docker container currently only supports monitor mode. 

It would be better if the sync only runs once in the night via a cronjob. When the sync is finished the ZFS snapshot can be taken. This saves a lot of CPU cycles during the day and enables the snapshot to be taken after the sync has finished. Also when the sync would error it would return a non-zero exitcode. This enables error to be send by the error reporting of the cronjobs.