### PR TITLE
Support adding SharePoint Libraries as Shared Folder Links

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -225,7 +225,7 @@ Item makeDatabaseItem(JSONValue driveItem) {
 
 final class ItemDatabase {
 	// increment this for every change in the db schema
-	immutable int itemDatabaseVersion = 14;
+	immutable int itemDatabaseVersion = 15;
 
 	Database db;
 	string insertItemStmt;

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -311,7 +311,7 @@ final class ItemDatabase {
 			db.exec("PRAGMA recursive_triggers = TRUE;");
 			// Set the journal mode for databases associated with the current connection
 			// https://www.sqlite.org/pragma.html#pragma_journal_mode
-			//db.exec("PRAGMA journal_mode = WAL;");
+			db.exec("PRAGMA journal_mode = WAL;");
 			// Automatic indexing is enabled by default as of version 3.7.17
 			// https://www.sqlite.org/pragma.html#pragma_automatic_index 
 			// PRAGMA automatic_index = boolean;

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -23,6 +23,7 @@ enum ItemType {
 	file,
 	dir,
 	remote,
+	root,
 	unknown
 }
 
@@ -127,21 +128,21 @@ Item makeDatabaseItem(JSONValue driveItem) {
 	bool typeSet = false;
 	if (isItemFile(driveItem)) {
 		// 'file' object exists in the JSON
-		if (debugLogging) {addLogEntry("Flagging object as a file", ["debug"]);}
+		if (debugLogging) {addLogEntry("Flagging database item.type as a file", ["debug"]);}
 		typeSet = true;
 		item.type = ItemType.file;
 	}
 	
 	if (isItemFolder(driveItem)) {
 		// 'folder' object exists in the JSON
-		if (debugLogging) {addLogEntry("Flagging object as a directory", ["debug"]);}
+		if (debugLogging) {addLogEntry("Flagging database item.type as a directory", ["debug"]);}
 		typeSet = true;
 		item.type = ItemType.dir;
 	}
 	
 	if (isItemRemote(driveItem)) {
 		// 'remote' object exists in the JSON
-		if (debugLogging) {addLogEntry("Flagging object as a remote", ["debug"]);}
+		if (debugLogging) {addLogEntry("Flagging database item.type as a remote", ["debug"]);}
 		typeSet = true;
 		item.type = ItemType.remote;
 	}
@@ -231,6 +232,7 @@ final class ItemDatabase {
 	string updateItemStmt;
 	string selectItemByIdStmt;
 	string selectItemByRemoteIdStmt;
+	string selectItemByRemoteDriveIdStmt;
 	string selectItemByParentIdStmt;
 	string deleteItemByIdStmt;
 	bool databaseInitialised = false;
@@ -309,7 +311,7 @@ final class ItemDatabase {
 			db.exec("PRAGMA recursive_triggers = TRUE;");
 			// Set the journal mode for databases associated with the current connection
 			// https://www.sqlite.org/pragma.html#pragma_journal_mode
-			db.exec("PRAGMA journal_mode = WAL;");
+			//db.exec("PRAGMA journal_mode = WAL;");
 			// Automatic indexing is enabled by default as of version 3.7.17
 			// https://www.sqlite.org/pragma.html#pragma_automatic_index 
 			// PRAGMA automatic_index = boolean;
@@ -351,6 +353,11 @@ final class ItemDatabase {
 			SELECT *
 			FROM item
 			WHERE remoteDriveId = ?1 AND remoteId = ?2
+		";
+		selectItemByRemoteDriveIdStmt = "
+			SELECT *
+			FROM item
+			WHERE remoteDriveId = ?1
 		";
 		selectItemByParentIdStmt = "SELECT * FROM item WHERE driveId = ? AND parentId = ?";
 		deleteItemByIdStmt = "DELETE FROM item WHERE driveId = ? AND id = ?";
@@ -571,6 +578,27 @@ final class ItemDatabase {
 			return false;
 		}
 	}
+	
+	// This should return the 'remote' DB entry for a given remote drive id
+	bool selectByRemoteDriveId(const(char)[] remoteDriveId, out Item item) {
+		synchronized(databaseLock) {
+			auto p = db.prepare(selectItemByRemoteDriveIdStmt);
+			scope(exit) p.finalise(); // Ensure that the prepared statement is finalised after execution.
+			try {
+				p.bind(1, remoteDriveId);
+				auto r = p.exec();
+				if (!r.empty) {
+					item = buildItem(r);
+					return true;
+				}
+			} catch (SqliteException exception) {
+				// Handle the error appropriately
+				detailSQLErrorMessage(exception);
+			}
+
+			return false;
+		}
+	}
 
 	// returns true if an item id is in the database
 	bool idInLocalDatabase(const(string) driveId, const(string) id) {
@@ -694,6 +722,7 @@ final class ItemDatabase {
 				case file:    typeStr = "file";    break;
 				case dir:     typeStr = "dir";     break;
 				case remote:  typeStr = "remote";  break;
+				case root:    typeStr = "root";    break;
 				case unknown: typeStr = "unknown"; break;
 				case none:    typeStr = null; break;
 			}
@@ -713,6 +742,7 @@ final class ItemDatabase {
 				case file:    remoteTypeStr = "file";    break;
 				case dir:     remoteTypeStr = "dir";     break;
 				case remote:  remoteTypeStr = "remote";  break;
+				case root:    remoteTypeStr = "root";    break;
 				case unknown: remoteTypeStr = "unknown"; break;
 				case none:    remoteTypeStr = null; break;
 			}
@@ -785,6 +815,7 @@ final class ItemDatabase {
 			case "file":    item.type = ItemType.file;    break;
 			case "dir":     item.type = ItemType.dir;     break;
 			case "remote":  item.type = ItemType.remote;  break;
+			case "root":    item.type = ItemType.root;    break;
 			default: assert(0, "Invalid item type");
 		}
 		

--- a/src/sync.d
+++ b/src/sync.d
@@ -2485,7 +2485,7 @@ class SyncEngine {
 		}
 		
 		
-		// Personal Account Shared Folder Handling
+		// Ensure 'parentId' is not empty, except for Personal Accounts 
 		if (appConfig.accountType != "personal") {
 			// Is sharedFolderDatabaseTie.parentId.empty?
 			if (sharedFolderDatabaseTie.parentId.empty) {
@@ -2506,6 +2506,16 @@ class SyncEngine {
 				addLogEntry(" sharedFolderDatabaseTie.type = ItemType.root", ["debug"]);
 			}
 			sharedFolderDatabaseTie.parentId = null;
+			sharedFolderDatabaseTie.type = ItemType.root;
+		}
+		
+		// Personal Account Shared Folder Handling 
+		if (appConfig.accountType == "personal") {
+			// Yes this is a personal account
+			if (debugLogging) {
+				addLogEntry("Updating Shared Folder DB Tie record entry with correct values as this is a 'root' object as it is a Personal Shared Folder Root Object" , ["debug"]);
+				addLogEntry(" sharedFolderDatabaseTie.type = ItemType.root", ["debug"]);
+			}
 			sharedFolderDatabaseTie.type = ItemType.root;
 		}
 		
@@ -9636,6 +9646,7 @@ class SyncEngine {
 		if (appConfig.accountType == "personal") {
 			// Set tieDBItem.parentId to null
 			tieDBItem.parentId = null;
+			tieDBItem.type = ItemType.root;
 		} else {
 			// The tieDBItem.parentId needs to be the correct driveId id reference
 			// Query the DB 

--- a/src/sync.d
+++ b/src/sync.d
@@ -4325,15 +4325,14 @@ class SyncEngine {
 				// In a --resync scenario - the database is empty
 				if (parentInDatabase) {
 					// Calculate this items path based on database entries
-					//addLogEntry("parent in DB");
+					if (debugLogging) {addLogEntry("Parent path details are in DB", ["debug"]);}
 					newItemPath = computeItemPath(thisItemDriveId, thisItemParentId) ~ "/" ~ thisItemName;
-					//addLogEntry("newItemPath (computeItemPath) = " ~ to!string(newItemPath));
 				} else {
 					// parent is not in the database .. we need to compute it .. why ????
 					if (appConfig.getValueBool("resync")) {
-						//addLogEntry("Parent NOT in DB .. we need to manually comute this path due to --resync being used");
+						if (debugLogging) {addLogEntry("Parent NOT in DB .. we need to manually compute this path due to --resync being used", ["debug"]);}
 					} else {
-						//addLogEntry("Parent NOT in DB .. we need to manually comute this path .......");
+						if (debugLogging) {addLogEntry("Parent NOT in DB .. we need to manually compute this path .......", ["debug"]);}
 					}
 					
 					// gather the applicable path details
@@ -4351,31 +4350,21 @@ class SyncEngine {
 						}
 						
 						// Issue #2731
-						// Is this potentially a shared folder?
+						// Is this potentially a shared folder? This is the only reliable way to determine this ...
 						if (onedriveJSONItem["parentReference"]["driveId"].str != appConfig.defaultDriveId) {
 							// Yes this JSON is from a Shared Folder
-							//addLogEntry("THIS WAS TRIGGERED");
-							
-							//addLogEntry("shared folder json = " ~ to!string(onedriveJSONItem));
-							
-							// Download item specifics
+							// Get the remoteDriveId from JSON record
 							string remoteDriveId = onedriveJSONItem["parentReference"]["driveId"].str;
-							//string remoteId = baseName(splitPaths[0]);
-						
-							// Query the database for the parent folder details
+							
+							// Query the database for the 'remote' folder details from the database
+							if (debugLogging) {addLogEntry("Query database for this 'remoteDriveId' record: " ~ to!string(remoteDriveId), ["debug"]);}
 							Item remoteItem;
 							itemDB.selectByRemoteDriveId(remoteDriveId, remoteItem);
+							if (debugLogging) {addLogEntry("Query returned result (itemDB.selectByRemoteDriveId): " ~ to!string(remoteItem), ["debug"]);}
 							
-							//addLogEntry("DB query remoteDriveId = " ~ remoteDriveId);
-							//addLogEntry("DB query remoteId = " ~ remoteId);
-						
-							//addLogEntry("returned result (itemDB.selectByRemoteId): " ~ to!string(remoteItem));
-							
-							// Update the path that will be used to check 'sync_list' with
+							// Update the path that will be used to check 'sync_list' with the 'name' of the remoteDriveId database record
 							selfBuiltPath = remoteItem.name ~ selfBuiltPath;
-							
-							//addLogEntry("selfBuiltPath after shared folder update = " ~ to!string(selfBuiltPath));
-							
+							if (debugLogging) {addLogEntry("selfBuiltPath after 'Shared Folder' DB details update = " ~ to!string(selfBuiltPath), ["debug"]);}
 						}
 						
 						// Issue #2740
@@ -4400,10 +4389,8 @@ class SyncEngine {
 							newItemPath = selfBuiltPath;
 						}
 						
-						// The final format of newItemPath when self building needs to be the same as newItemPath when computed using computeItemPath
-						
-						//addLogEntry("newItemPath built by selfBuiltPath = " ~ to!string(selfBuiltPath));
-						
+						// The final format of newItemPath when self building needs to be the same as newItemPath when computed using computeItemPath .. this is handled later below
+						if (debugLogging) {addLogEntry("newItemPath as manually computed by selfBuiltPath process = " ~ to!string(selfBuiltPath), ["debug"]);}
 					} else {
 						// no parent reference path available in provided JSON
 						newItemPath = thisItemName;
@@ -4411,12 +4398,11 @@ class SyncEngine {
 				}
 				
 				// The 'newItemPath' needs to be updated to ensure it is in the right format
-				//addLogEntry("newItemPath before modification = " ~ newItemPath);
+				// Regardless of built from DB or computed it needs to be in this format:
+				//   ./path/path/ etc
+				// This then makes the path output with 'sync_list' consistent, and, more importantly consistent for 'sync_list' evaluations
 				newItemPath = ensureStartsWithDotSlash(newItemPath);
-				//addLogEntry("newItemPath after modification = " ~ newItemPath);
-				// At this point 'newItemPath' should be in the same format
-				// ./path/path/ etc
-				
+								
 				// Check for HTML entities (e.g., '%20' for space) in newItemPath
 				if (containsURLEncodedItems(newItemPath)) {
 					addLogEntry("CAUTION:    The JSON element transmitted by the Microsoft OneDrive API includes HTML URL encoded items, which may complicate pattern matching and potentially lead to synchronisation problems for this item.");
@@ -4427,7 +4413,7 @@ class SyncEngine {
 				}
 				
 				
-				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........
+				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........ IF ZERO IMPACT WITH PERSONAL ACCOUNTS .. REMOVE
 				
 				/**
 				
@@ -4447,7 +4433,7 @@ class SyncEngine {
 				**/
 				
 				
-				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........
+				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........ IF ZERO IMPACT WITH PERSONAL ACCOUNTS .. REMOVE
 				
 				/**
 				

--- a/src/sync.d
+++ b/src/sync.d
@@ -4458,39 +4458,6 @@ class SyncEngine {
 					}
 				}
 				
-				
-				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........ IF ZERO IMPACT WITH PERSONAL ACCOUNTS .. REMOVE
-				
-				/**
-				
-				// If this is a Shared Folder, we need to 'trim' the resulting path to that of the 'folder' that is actually shared with us so that this can be appropriately checked against 'sync_list' entries
-				if (sharedFolderDeltaGeneration) {
-					// Find the index of 'currentSharedFolderName' in 'newItemPath'
-					int pos = cast(int) newItemPath.indexOf(currentSharedFolderName);
-					
-					// If currentSharedFolderName is found within newItemPath
-					if (pos != -1) {
-						// Get the substring from the position of currentSharedFolderName
-						string result = newItemPath[pos .. $];
-						newItemPath = result;
-					}
-				}
-				
-				**/
-				
-				
-				// THIS SECTION OF CODE DOES NOT MAKE MUCH SENSE ANYMORE ........ IF ZERO IMPACT WITH PERSONAL ACCOUNTS .. REMOVE
-				
-				/**
-				
-				
-				// Update newItemPath, remove leading '/' if present
-				if(newItemPath[0] == '/') {
-					newItemPath = newItemPath[1..$];
-				}
-				
-				**/
-				
 				// What path are we checking against sync_list?
 				if (debugLogging) {addLogEntry("Path to check against 'sync_list' entries: " ~ newItemPath, ["debug"]);}
 				

--- a/src/sync.d
+++ b/src/sync.d
@@ -1705,6 +1705,8 @@ class SyncEngine {
 							if (debugLogging) {addLogEntry("Personal Shared Item JSON object has the 'shared' JSON structure", ["debug"]);}
 							// Create a 'root' DB Tie Record for this JSON object
 							
+							addLogEntry("HITTING THIS - PERSONAL SHARED FOLDER");
+							
 							// THIS MAY NEED TO BE KEPT THE SAME 
 							//createDatabaseRootTieRecordForOnlineSharedFolder(onedriveJSONItem);
 							

--- a/src/sync.d
+++ b/src/sync.d
@@ -1462,8 +1462,9 @@ class SyncEngine {
 			// Debug output of change evaluation items
 			if (debugLogging) {
 				addLogEntry("defaultRootId                                        = " ~ appConfig.defaultRootId, ["debug"]);
-				addLogEntry("'search id'                                          = " ~ thisItemId, ["debug"]);
-				addLogEntry("id == defaultRootId                                  = " ~ to!string(itemIdMatchesDefaultRootId), ["debug"]);
+				addLogEntry("thisItemName                                         = " ~ onedriveJSONItem["name"].str, ["debug"]);
+				addLogEntry("thisItemId                                           = " ~ thisItemId, ["debug"]);
+				addLogEntry("thisItemId == defaultRootId                          = " ~ to!string(itemIdMatchesDefaultRootId), ["debug"]);
 				addLogEntry("isItemRoot(onedriveJSONItem)                         = " ~ to!string(itemIsRoot), ["debug"]);
 				addLogEntry("onedriveJSONItem['name'].str == 'root'               = " ~ to!string(itemNameExplicitMatchRoot), ["debug"]);
 				addLogEntry("itemHasParentReferenceId                             = " ~ to!string(itemHasParentReferenceId), ["debug"]);
@@ -1873,8 +1874,8 @@ class SyncEngine {
 			if (!unwanted) {
 				// Only check path if config is != ""
 				if (!appConfig.getValueString("skip_dir").empty) {
-					// Is the item a folder?
-					if (isItemFolder(onedriveJSONItem)) {
+					// Is the item a folder or a remote item? (which itself is a directory, but is missing the 'folder' JSON element we use to determine JSON being a directory or not)
+					if ((isItemFolder(onedriveJSONItem)) || (isRemoteFolderItem(onedriveJSONItem))) {
 						// work out the 'snippet' path where this folder would be created
 						string simplePathToCheck = "";
 						string complexPathToCheck = "";

--- a/src/sync.d
+++ b/src/sync.d
@@ -7533,7 +7533,7 @@ class SyncEngine {
 				}
 			} catch (OneDriveException exception) {
 				// Display error message
-				displayOneDriveErrorMessage(e.msg, getFunctionName!({}));
+				displayOneDriveErrorMessage(exception.msg, getFunctionName!({}));
 
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				generateDeltaResponseOneDriveApiInstance.releaseCurlEngine();

--- a/src/util.d
+++ b/src/util.d
@@ -1059,6 +1059,14 @@ bool isFolderItem(const ref JSONValue item) {
 	return ("folder" in item) != null;
 }
 
+bool isRemoteFolderItem(const ref JSONValue item) {
+	if (isItemRemote(item)) {
+		return ("folder" in item["remoteItem"]) != null;
+	} else {
+		return false;
+	}
+}
+
 bool isFileItem(const ref JSONValue item) {
 	return ("file" in item) != null;
 }

--- a/src/util.d
+++ b/src/util.d
@@ -697,7 +697,7 @@ void displayOneDriveErrorMessage(string message, string callingFunction) {
 	
 	// Where in the code was this error generated
 	if (verboseLogging) {addLogEntry("  Calling Function: " ~ callingFunction, ["verbose"]);}
-	
+	if (debugLogging) {addLogEntry("  Calling Function: " ~ callingFunction, ["debug"]);}
 	// Extra Debug if we are using --verbose --verbose
 	if (debugLogging) {
 		addLogEntry("Raw Error Data: " ~ message, ["debug"]);


### PR DESCRIPTION
* Fix the creation of Shared Folder 'root' and 'folder' DB tie records to be consistent in when they are created
* Fix path calculation to support Shared Folder Links when coming from a SharePoint Library root when testing 'sync_list' entries