### PR TITLE
Add account root id check for id account issue

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -35,6 +35,7 @@ avmkfdiitirnrenzljwc
 avx
 baus
 bcdefghi
+beffdb
 bindir
 bir
 blargh
@@ -112,6 +113,7 @@ fcgid
 fcgienv
 FFFD
 FCGX
+fbc
 fcontext
 fedoraproject
 fefefe

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -329,6 +329,7 @@ sargs
 sbindir
 scgi
 sdlang
+sea8cc6beffdb43d7976fbc7da445c639
 semanage
 sendfd
 setsebool

--- a/src/sync.d
+++ b/src/sync.d
@@ -662,7 +662,7 @@ class SyncEngine {
 				if (appConfig.defaultRootId.indexOf("sea8cc6beffdb43d7976fbc7da445c639") != -1) {
 					// Yes ... flag account issue, we cannot proceed
 					addLogEntry();
-					addLogEntry("ERROR: You have a Microsoft OneDrive Account Problem. Please raise a support request with Microsoft. You cannot use Microsoft OneDrive at this point in time.");
+					addLogEntry("ERROR: You have a Microsoft OneDrive Account Problem. Please raise a support request with Microsoft. You cannot use Microsoft OneDrive at this point in time.", ["info", "notify"]);
 					addLogEntry("ERROR: Account Root ID contains the string 'sea8cc6beffdb43d7976fbc7da445c639'.");
 					addLogEntry();
 					// Force Exit

--- a/src/sync.d
+++ b/src/sync.d
@@ -648,9 +648,27 @@ class SyncEngine {
 		
 		// If the JSON response is a correct JSON object, and has an 'id' we can set these details
 		if ((defaultOneDriveRootDetails.type() == JSONType.object) && (hasId(defaultOneDriveRootDetails))) {
+		
+			// Read the returned JSON data for the root drive details
 			if (debugLogging) {addLogEntry("OneDrive Account Default Root Details:       " ~ to!string(defaultOneDriveRootDetails), ["debug"]);}
 			appConfig.defaultRootId = defaultOneDriveRootDetails["id"].str;
 			if (debugLogging) {addLogEntry("appConfig.defaultRootId      = " ~ appConfig.defaultRootId, ["debug"]);}
+			
+			// Issue #2957 Handling for the Account Root. Shared Folders coming from another account where this issue exists will need a different approach.
+			// If the returned data for appConfig.defaultRootId contains the string 'sea8cc6beffdb43d7976fbc7da445c639' .. this account has account issues with Microsoft
+			// This is only applicable for Microsoft Personal Accounts
+			if (appConfig.accountType == "personal") {
+				// Does the string 'sea8cc6beffdb43d7976fbc7da445c639' exist in the root id for the account?
+				if (appConfig.defaultRootId.indexOf("sea8cc6beffdb43d7976fbc7da445c639") != -1) {
+					// Yes ... flag account issue, we cannot proceed
+					addLogEntry();
+					addLogEntry("ERROR: You have a Microsoft OneDrive Account Problem. Please raise a support request with Microsoft. You cannot use Microsoft OneDrive at this point in time.");
+					addLogEntry("ERROR: Account Root ID contains the string 'sea8cc6beffdb43d7976fbc7da445c639'.");
+					addLogEntry();
+					// Force Exit
+					forceExit();
+				}
+			}
 			
 			// Save the item to the database, so the account root drive is is always going to be present in the DB
 			saveItem(defaultOneDriveRootDetails);

--- a/src/sync.d
+++ b/src/sync.d
@@ -654,7 +654,7 @@ class SyncEngine {
 			appConfig.defaultRootId = defaultOneDriveRootDetails["id"].str;
 			if (debugLogging) {addLogEntry("appConfig.defaultRootId      = " ~ appConfig.defaultRootId, ["debug"]);}
 			
-			// Issue #2957 Handling for the Account Root. Shared Folders coming from another account where this issue exists will need a different approach.
+			// Issue #2957 Handling for the Personal Account Root ID issues. Shared Folders coming from another account where this issue exists will need a different approach.
 			// If the returned data for appConfig.defaultRootId contains the string 'sea8cc6beffdb43d7976fbc7da445c639' .. this account has account issues with Microsoft
 			// This is only applicable for Microsoft Personal Accounts
 			if (appConfig.accountType == "personal") {


### PR DESCRIPTION
* Specifically add a check for the 'sea8cc6beffdb43d7976fbc7da445c639' string in the OneDrive Personal Account Root ID response that denotes that the account cannot access Microsoft OneDrive at this point in time.