### PR TITLE
Add OneDrive Personal Drive ID and Remote Drive ID length check

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2606,6 +2606,9 @@ class SyncEngine {
 				addLogEntry(" sharedFolderDatabaseTie.type = ItemType.root", ["debug"]);
 			}
 			sharedFolderDatabaseTie.type = ItemType.root;
+			
+			// Issue #3072 - Validate sharedFolderDatabaseTie.driveId length and case
+			sharedFolderDatabaseTie.driveId = testParentReferenceForLengthIssue(sharedFolderDatabaseTie.driveId);
 		}
 		
 		// Log action

--- a/src/sync.d
+++ b/src/sync.d
@@ -7579,7 +7579,7 @@ class SyncEngine {
 					
 					// Generate the change
 					string oldEntry = newDatabaseItem.driveId;
-					string newEntry = to!string(oldEntry.padLeft('0', 16)); // Explicitly use padLeft for leading zero padding
+					string newEntry = to!string(oldEntry.padLeft('0', 16)).toLower; // Explicitly use padLeft for leading zero padding
 					
 					if (debugLogging) {
 							addLogEntry(" - old newDatabaseItem.driveId = " ~ oldEntry, ["debug"]);
@@ -7600,7 +7600,7 @@ class SyncEngine {
 					
 					// Generate the change
 					string oldEntry = newDatabaseItem.remoteDriveId;
-					string newEntry = to!string(oldEntry.padLeft('0', 16)); // Explicitly use padLeft for leading zero padding
+					string newEntry = to!string(oldEntry.padLeft('0', 16)).toLower; // Explicitly use padLeft for leading zero padding
 					
 					if (debugLogging) {
 							addLogEntry(" - old newDatabaseItem.remoteDriveId = " ~ oldEntry, ["debug"]);
@@ -10558,7 +10558,7 @@ class SyncEngine {
 				
 				// Generate the change
 				oldEntry = objectParentDriveId;
-				newEntry = to!string(oldEntry.padLeft('0', 16)); // Explicitly use padLeft for leading zero padding
+				newEntry = to!string(oldEntry.padLeft('0', 16)).toLower; // Explicitly use padLeft for leading zero padding
 				if (debugLogging) {
 					addLogEntry(" - old value = " ~ oldEntry, ["debug"]);
 					addLogEntry(" - new value = " ~ newEntry, ["debug"]);

--- a/src/sync.d
+++ b/src/sync.d
@@ -10535,7 +10535,7 @@ class SyncEngine {
 		return loggingOptions;
 	}
 	
-	// OneDrive Personal parentReference driveId must be 16 characters in length
+	// OneDrive Personal driveId or parentReference driveId must be 16 characters in length, and must be returned as lower case
 	string testParentReferenceForLengthIssue(string objectParentDriveId) {
 	
 		// Issue #3072 (https://github.com/abraunegg/onedrive/issues/3072) illustrated that the OneDrive API is inconsistent in response for:
@@ -10565,14 +10565,14 @@ class SyncEngine {
 				}
 				
 				// Return the new padded value
-				return newEntry;
+				return newEntry.toLower;
 			} else {
 				// Return input value
-				return objectParentDriveId;
+				return objectParentDriveId.toLower;
 			}
 		} else {
 			// Return input value
-			return objectParentDriveId;
+			return objectParentDriveId.toLower;
 		}
 	}
 }

--- a/src/sync.d
+++ b/src/sync.d
@@ -1777,6 +1777,10 @@ class SyncEngine {
 						remoteItem.parentId = null;
 						// Add this record to the local database
 						if (debugLogging) {addLogEntry("Update/Insert local database with Personal Shared Item JSON object with remoteItem.parentId as null: " ~ to!string(remoteItem), ["debug"]);}
+						
+						// Issue #3072 - Validate length and must be lowercase
+						remoteItem.driveId = testParentReferenceForLengthIssue(remoteItem.driveId);
+						
 						itemDB.upsert(remoteItem);
 						// Due to OneDrive API inconsistency, again with European Data Centres, as we have handled this JSON - flag as unwanted as processing is complete for this JSON item
 						unwanted = true;
@@ -2308,6 +2312,13 @@ class SyncEngine {
 					addLogEntry("The item to sync is already present on the local filesystem and is in-sync with what is reported online", ["debug"]);
 					addLogEntry("Update/Insert local database with item details: " ~ to!string(newDatabaseItem), ["debug"]);
 				}
+				
+				// Issue #3072 - Validate length and must be lowercase
+				// What account type is this?
+				if (appConfig.accountType == "personal") {
+					newDatabaseItem.driveId = testParentReferenceForLengthIssue(newDatabaseItem.driveId);
+				}
+				
 				// Add item to database
 				itemDB.upsert(newDatabaseItem);
 				
@@ -2403,6 +2414,14 @@ class SyncEngine {
 							addLogEntry("File timestamps are equal, no further action required", ["debug"]); // correct message as timestamps are equal
 							addLogEntry("Update/Insert local database with item details: " ~ to!string(newDatabaseItem), ["debug"]);
 						}
+						
+						// Issue #3072 - Validate length and must be lowercase
+						// What account type is this?
+						if (appConfig.accountType == "personal") {
+							newDatabaseItem.driveId = testParentReferenceForLengthIssue(newDatabaseItem.driveId);
+						}
+						
+						// Add item to database
 						itemDB.upsert(newDatabaseItem);
 						return;
 					}


### PR DESCRIPTION
* Add a check to ensure that OneDrive Personal Drive ID and Remote Drive ID values are 16 characters, padded by leading zeros if the provided JSON data has dropped these leading zeros
* If OneDrive Personal Account, validate all use of 'onedriveJSONItem["parentReference"]["driveId"].str' within application to ensure consistency in use and application