### PR TITLE
Fix --single-directory Shared Folder DB entry creation

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -332,7 +332,6 @@ sargs
 sbindir
 scgi
 sdlang
-sea8cc6beffdb43d7976fbc7da445c639
 semanage
 sendfd
 setsebool

--- a/src/sync.d
+++ b/src/sync.d
@@ -6764,6 +6764,7 @@ class SyncEngine {
 										// --upload-only being used
 										// we are not downloading a file, warn that file differences will exist
 										addLogEntry("WARNING: The file uploaded to Microsoft OneDrive has been modified through its SharePoint 'enrichment' process and no longer matches your local version.");
+										addLogEntry("WARNING: The online metadata will now be modified to match your local file which will create a new file version.");
 										addLogEntry("WARNING: Please refer to https://github.com/OneDrive/onedrive-api-docs/issues/935 for further details.");
 										// Create a new online version of the file by updating the metadata - this ensures that the file we uploaded is the file online
 										uploadLastModifiedTime(parentItem, parentItem.driveId, newFileId, mtime, newFileETag);


### PR DESCRIPTION
* Ensure that when using --single-directory that if the destination is a Shared Folder, the database records are created in a consistent manner