### PR TITLE
Calculate file transfer metrics in a consistent manner

### DIFF
--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -21,6 +21,7 @@ Before reading this document, please ensure you are running application version 
   - [disable_notifications](#disable_notifications)
   - [disable_upload_validation](#disable_upload_validation)
   - [display_running_config](#display_running_config)
+  - [display_transfer_metrics](#display_transfer_metrics)
   - [dns_timeout](#dns_timeout)
   - [download_only](#download_only)
   - [drive_id](#drive_id)
@@ -301,6 +302,19 @@ _**Default Value:**_ False
 _**Config Example:**_ `display_running_config = "false"` or `display_running_config = "true"`
 
 _**CLI Option Use:**_ `--display-running-config`
+
+### display_transfer_metrics
+_**Description:**_ This option will display file transfer metrics when enabled.
+
+_**Value Type:**_ Boolean
+
+_**Default Value:**_ False
+
+_**Config Example:**_ `display_transfer_metrics = "false"` or `display_transfer_metrics = "true"`
+
+_**Output Example:**_ `Transfer Metrics -  File: path/to/file.data | Size: 35768 Bytes | Duration: 2.27 Seconds | Speed: 0.02 Mbps (approx)`
+
+_**CLI Option Use:**_ *None - this is a config file option only*
 
 ### dns_timeout
 _**Description:**_ This setting controls the libcurl DNS cache value. By default, libcurl caches this info for 60 seconds. This libcurl DNS cache timeout is entirely speculative that a name resolves to the same address for a small amount of time into the future as libcurl does not use DNS TTL properties. We recommend users not to tamper with this option unless strictly necessary.

--- a/src/config.d
+++ b/src/config.d
@@ -352,6 +352,10 @@ class ApplicationConfig {
 		// GUI File Transfer and Deletion Notifications
 		boolValues["notify_file_actions"] = false;
 		
+		// Display file transfer metrics
+		// - Enable the calculation of transfer metrics (duration,speed) for the transfer of a file
+		boolValues["display_transfer_metrics"] = false;
+		
 		// EXPAND USERS HOME DIRECTORY
 		// Determine the users home directory.
 		// Need to avoid using ~ here as expandTilde() below does not interpret correctly when running under init.d or systemd scripts

--- a/src/sync.d
+++ b/src/sync.d
@@ -10523,20 +10523,20 @@ class SyncEngine {
 	}
 	
 	// Calculate the transfer metrics for the file to aid in performance discussions when they are raised
-	void displayTransferMetrics(string fileTransfered, long transferedBytes, SysTime transferStartTime, SysTime transferEndTime) {
+	void displayTransferMetrics(string fileTransferred, long transferredBytes, SysTime transferStartTime, SysTime transferEndTime) {
 	
 		// We only calculate this if 'display_transfer_metrics' is enabled or we are doing debug logging
 		if (appConfig.getValueBool("display_transfer_metrics") || debugLogging) {
 	
-			// Calculations must be done on files > 0 transferedBytes
-			if (transferedBytes > 0) {
+			// Calculations must be done on files > 0 transferredBytes
+			if (transferredBytes > 0) {
 				// Calculate transfer metrics
 				auto transferDuration = transferEndTime - transferStartTime;
 				double transferDurationAsSeconds = (transferDuration.total!"msecs"/1e3); // msec --> seconds
-				double transferSpeedAsMbps = ((transferedBytes / transferDurationAsSeconds) / 1024 / 1024); // bytes --> Mbps
+				double transferSpeedAsMbps = ((transferredBytes / transferDurationAsSeconds) / 1024 / 1024); // bytes --> Mbps
 				
 				// Output the transfer metrics
-				string transferMetrics = format("File: %s | Size: %d Bytes | Duration: %.2f Seconds | Speed: %.2f Mbps (approx)", fileTransfered, transferedBytes, transferDurationAsSeconds, transferSpeedAsMbps);
+				string transferMetrics = format("File: %s | Size: %d Bytes | Duration: %.2f Seconds | Speed: %.2f Mbps (approx)", fileTransferred, transferredBytes, transferDurationAsSeconds, transferSpeedAsMbps);
 				addLogEntry("Transfer Metrics -  " ~ transferMetrics);
 				
 			} else {


### PR DESCRIPTION
* Add back file transfer metrics which was available in v2.4.x
* Calculate file transfer metrics in a consistent manner for all uploads and downloads