### PR TITLE
Fix path calculation for Client Side Filtering evaluations

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2119,7 +2119,7 @@ class SyncEngine {
 						
 						if (hasParentReference(onedriveJSONItem)) {
 							// we need to workout the FULL path for this item
-							// simple path caclulation
+							// simple path calculation
 							if (("name" in onedriveJSONItem["parentReference"]) != null) {
 								// how do we build the simplePathToCheck path up ?
 								// did we flag this as the root shared folder object earlier?

--- a/src/sync.d
+++ b/src/sync.d
@@ -2089,6 +2089,7 @@ class SyncEngine {
 				} else {
 					// Why was this unwanted?
 					if (newItemPath.empty) {
+						if (debugLogging) {addLogEntry("OOPS: newItemPath is empty ....... need to calculate it", ["debug"]);}
 						// Compute this item path & need the full path for this file
 						newItemPath = computeItemPath(thisItemDriveId, thisItemParentId) ~ "/" ~ thisItemName;
 						if (debugLogging) {addLogEntry("New Item calculated full path is: " ~ newItemPath, ["debug"]);}
@@ -2228,6 +2229,7 @@ class SyncEngine {
 					if (parentInDatabase) {
 						// Compute this item path & need the full path for this file
 						if (newItemPath.empty) {
+							if (debugLogging) {addLogEntry("OOPS: newItemPath is empty ....... need to calculate it", ["debug"]);}
 							newItemPath = computeItemPath(thisItemDriveId, thisItemParentId) ~ "/" ~ thisItemName;
 							if (debugLogging) {addLogEntry("New Item calculated full path is: " ~ newItemPath, ["debug"]);}
 						}
@@ -2262,6 +2264,7 @@ class SyncEngine {
 					// Compute the item path if empty - as to check sync_list we need an actual path to check
 					if (newItemPath.empty) {
 						// Calculate this items path
+						if (debugLogging) {addLogEntry("OOPS: newItemPath is empty ....... need to calculate it", ["debug"]);}
 						newItemPath = computeItemPath(thisItemDriveId, thisItemParentId) ~ "/" ~ thisItemName;
 						if (debugLogging) {addLogEntry("New Item calculated full path is: " ~ newItemPath, ["debug"]);}
 					}


### PR DESCRIPTION
* Correct the path calculation for 'skip_dir' evaluations to correctly cater for Shared Folders and the 'root' object