### PR TITLE
Fix Bug #3115: Add further driveId validation when processing API response data for a OneDrive Personal Shared Folder

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -225,7 +225,7 @@ Item makeDatabaseItem(JSONValue driveItem) {
 
 final class ItemDatabase {
 	// increment this for every change in the db schema
-	immutable int itemDatabaseVersion = 15;
+	immutable int itemDatabaseVersion = 16;
 
 	Database db;
 	string insertItemStmt;

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -371,7 +371,7 @@ final class ItemDatabase {
 			SELECT *
 			FROM item
 			WHERE type = 'remote'
-			AND remoteDriveId = ?1
+			AND remoteDriveId = ?1 AND remoteId = ?2
 		";
 		selectItemByParentIdStmt = "SELECT * FROM item WHERE driveId = ? AND parentId = ?";
 		deleteItemByIdStmt = "DELETE FROM item WHERE driveId = ? AND id = ?";
@@ -634,12 +634,13 @@ final class ItemDatabase {
 	}
 
 	// This should return the 'remote' DB entry for the given 'remoteDriveId' and 'remoteId'
-	bool selectRemoteTypeByRemoteDriveId(const(char)[] remoteDriveId, out Item item) {
+	bool selectRemoteTypeByRemoteDriveId(const(char)[] remoteDriveId, const(char)[] remoteId, out Item item) {
 		synchronized(databaseLock) {
 			auto p = db.prepare(selectRemoteTypeByRemoteDriveIdStmt);
 			scope(exit) p.finalise(); // Ensure that the prepared statement is finalised after execution.
 			try {
 				p.bind(1, remoteDriveId);
+				p.bind(2, remoteId);
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -371,7 +371,7 @@ final class ItemDatabase {
 			SELECT *
 			FROM item
 			WHERE type = 'remote'
-			AND remoteDriveId = ?1 AND remoteId = ?2
+			AND remoteDriveId = ?1
 		";
 		selectItemByParentIdStmt = "SELECT * FROM item WHERE driveId = ? AND parentId = ?";
 		deleteItemByIdStmt = "DELETE FROM item WHERE driveId = ? AND id = ?";
@@ -634,13 +634,12 @@ final class ItemDatabase {
 	}
 
 	// This should return the 'remote' DB entry for the given 'remoteDriveId' and 'remoteId'
-	bool selectRemoteTypeByRemoteDriveId(const(char)[] remoteDriveId, const(char)[] remoteId, out Item item) {
+	bool selectRemoteTypeByRemoteDriveId(const(char)[] remoteDriveId, out Item item) {
 		synchronized(databaseLock) {
 			auto p = db.prepare(selectRemoteTypeByRemoteDriveIdStmt);
 			scope(exit) p.finalise(); // Ensure that the prepared statement is finalised after execution.
 			try {
 				p.bind(1, remoteDriveId);
-				p.bind(2, remoteId);
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -371,7 +371,7 @@ final class ItemDatabase {
 			SELECT *
 			FROM item
 			WHERE type = 'remote'
-			AND remoteDriveId = ?1
+			AND remoteDriveId = ?1 AND remoteId = ?2
 		";
 		selectItemByParentIdStmt = "SELECT * FROM item WHERE driveId = ? AND parentId = ?";
 		deleteItemByIdStmt = "DELETE FROM item WHERE driveId = ? AND id = ?";
@@ -633,13 +633,14 @@ final class ItemDatabase {
 		}
 	}
 
-	// This should return the 'remote' DB entry for the given 'remoteDriveId'
-	bool selectRemoteTypeByRemoteDriveId(const(char)[] entryName, out Item item) {
+	// This should return the 'remote' DB entry for the given 'remoteDriveId' and 'remoteId'
+	bool selectRemoteTypeByRemoteDriveId(const(char)[] remoteDriveId, const(char)[] remoteId, out Item item) {
 		synchronized(databaseLock) {
 			auto p = db.prepare(selectRemoteTypeByRemoteDriveIdStmt);
 			scope(exit) p.finalise(); // Ensure that the prepared statement is finalised after execution.
 			try {
-				p.bind(1, entryName);
+				p.bind(1, remoteDriveId);
+				p.bind(2, remoteId);
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);

--- a/src/main.d
+++ b/src/main.d
@@ -151,8 +151,9 @@ int main(string[] cliArgs) {
 	}
 	
 	// Determine the application logging verbosity
+	// - As these flags are used to reduce application processing when not required, specifically in a 'debug' scenario, both verboseLogging and debugLogging need to be enabled
 	if (verbosityCount == 1) { verboseLogging = true;} // set __gshared bool verboseLogging in log.d
-	if (verbosityCount >= 2) { debugLogging = true;}   // set __gshared bool debugLogging in log.d
+	if (verbosityCount >= 2) { verboseLogging = true; debugLogging = true;}   // set __gshared bool verboseLogging & debugLogging in log.d
 	
 	// Initialize the application logging class, as we know the application verbosity level
 	// If we need to enable logging to a file, we can only do this once we know the application configuration which is done slightly later on

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -574,10 +574,9 @@ class OneDriveApi {
 		string[string] requestHeaders;
 		
 		// From March 1st 2025, this needs to be added to ensure that Shared Folders are sent in the Delta Query Response
-		// TO BE CONFIRMED .. adding 'Include-Feature=AddToOneDrive' to header is NOT WORKING for /delta
 		if (appConfig.accountType == "personal") {
 			// OneDrive Personal Account
-			addIncludeFeatureRequestHeader(&requestHeaders); // NOT WORKING !!!!!!!
+			addIncludeFeatureRequestHeader(&requestHeaders);
 		} else {
 			// Business or SharePoint Library
 			// Only add if configured to do so

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -572,9 +572,19 @@ class OneDriveApi {
 	//   After you have finished receiving all the changes, you may apply them to your local state. To check for changes in the future, call delta again with the @odata.deltaLink from the previous successful response.
 	JSONValue getChangesByItemId(string driveId, string id, string deltaLink) {
 		string[string] requestHeaders;
-		// If Business Account add Prefer: Include-Feature=AddToOneDrive
-		if ((appConfig.accountType != "personal") && ( appConfig.getValueBool("sync_business_shared_items"))) {
-			addIncludeFeatureRequestHeader(&requestHeaders);
+		
+		// From March 1st 2025, this needs to be added to ensure that Shared Folders are sent in the Delta Query Response
+		// TO BE CONFIRMED .. adding 'Include-Feature=AddToOneDrive' to header is NOT WORKING for /delta
+		if (appConfig.accountType == "personal") {
+			// OneDrive Personal Account
+			addIncludeFeatureRequestHeader(&requestHeaders); // NOT WORKING !!!!!!!
+		} else {
+			// Business or SharePoint Library
+			// Only add if configured to do so
+			if (appConfig.getValueBool("sync_business_shared_items")) {
+				// Feature enabled, add headers
+				addIncludeFeatureRequestHeader(&requestHeaders);
+			}
 		}
 		
 		string url;
@@ -586,15 +596,26 @@ class OneDriveApi {
 		} else {
 			url = deltaLink;
 		}
+		
+		// get the response
 		return get(url, false, requestHeaders);
 	}
 	
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children
 	JSONValue listChildren(string driveId, string id, string nextLink) {
 		string[string] requestHeaders;
-		// If Business Account add addIncludeFeatureRequestHeader() which should add Prefer: Include-Feature=AddToOneDrive
-		if ((appConfig.accountType != "personal") && ( appConfig.getValueBool("sync_business_shared_items"))) {
+		
+		// From March 1st 2025, this needs to be added to ensure that Shared Folders are sent in the Delta Query Response
+		if (appConfig.accountType == "personal") {
+			// OneDrive Personal Account
 			addIncludeFeatureRequestHeader(&requestHeaders);
+		} else {
+			// Business or SharePoint Library
+			// Only add if configured to do so
+			if (appConfig.getValueBool("sync_business_shared_items")) {
+				// Feature enabled, add headers
+				addIncludeFeatureRequestHeader(&requestHeaders);
+			}
 		}
 		
 		string url;
@@ -819,7 +840,14 @@ class OneDriveApi {
 	
 	// Private OneDrive API Functions
 	private void addIncludeFeatureRequestHeader(string[string]* headers) {
-		if (debugLogging) {addLogEntry("Adding 'Include-Feature=AddToOneDrive' API request header as 'sync_business_shared_items' config option is enabled", ["debug"]);}
+		if (appConfig.accountType == "personal") {
+			// Add logging message for OneDrive Personal Accounts
+			if (debugLogging) {addLogEntry("Adding 'Include-Feature=AddToOneDrive' API request header for OneDrive Personal Account Type", ["debug"]);}
+		} else {
+			// Add logging message for OneDrive Business Accounts
+			if (debugLogging) {addLogEntry("Adding 'Include-Feature=AddToOneDrive' API request header as 'sync_business_shared_items' config option is enabled", ["debug"]);}
+		}
+		// Add feature to request headers
 		(*headers)["Prefer"] = "Include-Feature=AddToOneDrive";
 	}
 

--- a/src/sync.d
+++ b/src/sync.d
@@ -3931,6 +3931,13 @@ class SyncEngine {
 		string fullCalculatedPath;
 		bool calculateLocalExtension = false;
 		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			thisDriveId = testProvidedDriveIdForLengthIssue(thisDriveId);
+		}
+		
 		// What driveID and itemID we trying to calculate the path for
 		if (debugLogging) {addLogEntry("Attempting to calculate local filesystem path for " ~ thisDriveId ~ " and " ~ thisItemId, ["debug"]);}
 		

--- a/src/sync.d
+++ b/src/sync.d
@@ -13001,7 +13001,7 @@ class SyncEngine {
 		return true;
 	}
 	
-	// Sanatise the provided onedriveJSONItem into a string that can actually be printed without error or issue
+	// Sanitise the provided onedriveJSONItem into a string that can actually be printed without error or issue
 	string sanitiseJSONItem(JSONValue onedriveJSONItem) {
 		// Function Start Time
 		SysTime functionStartTime;

--- a/src/sync.d
+++ b/src/sync.d
@@ -4004,7 +4004,7 @@ class SyncEngine {
 			if (debugLogging) {addLogEntry("Attempting to calculate shared folder local filesystem path for " ~ thisDriveId ~ " and " ~ thisItemId, ["debug"]);}
 			
 			// Get the DB entry for this 'remote' item
-			itemDB.selectRemoteTypeByRemoteDriveId(thisDriveId, thisItemId, remoteEntryItem);
+			itemDB.selectRemoteTypeByRemoteDriveId(thisDriveId, remoteEntryItem);
 			
 			// What was returned from the Database?
 			if (debugLogging) {addLogEntry("remoteEntryItem: " ~ to!string(remoteEntryItem), ["debug"]);}

--- a/src/sync.d
+++ b/src/sync.d
@@ -2901,6 +2901,13 @@ class SyncEngine {
 			parentObjectId = onedriveJSONItem["remoteItem"]["id"].str;
 		}
 		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			parentDriveId = testProvidedDriveIdForLengthIssue(parentDriveId);
+		}
+		
 		// Try and fetch this shared folder parent's details
 		try {
 			if (debugLogging) {addLogEntry(format("Fetching Shared Folder online data for parentDriveId '%s' and parentObjectId '%s'", parentDriveId, parentObjectId), ["debug"]);}
@@ -3004,6 +3011,13 @@ class SyncEngine {
 			sharedFolderDatabaseTie.type = ItemType.root;
 		}
 		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			sharedFolderDatabaseTie.driveId = testProvidedDriveIdForLengthIssue(sharedFolderDatabaseTie.driveId);
+		}
+				
 		// Log action
 		addLogEntry("Creating|Updating a DB Tie Record for this Shared Folder from the online parental data: " ~ sharedFolderDatabaseTie.name, ["debug"]);
 		addLogEntry("Shared Folder DB Tie Record data: " ~ to!string(sharedFolderDatabaseTie), ["debug"]);
@@ -11845,6 +11859,13 @@ class SyncEngine {
 		
 		// ensure there is no parentId
 		tieDBItem.parentId = null;
+		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			tieDBItem.driveId = testProvidedDriveIdForLengthIssue(tieDBItem.driveId);
+		}
 		
 		// Add this DB Tie parent record to the local database
 		if (debugLogging) {addLogEntry("Creating|Updating into local database a 'root' DB Tie record for a OneDrive Shared Folder online: " ~ to!string(tieDBItem), ["debug"]);}

--- a/src/sync.d
+++ b/src/sync.d
@@ -13033,7 +13033,7 @@ class SyncEngine {
 		
 		// Validate UTF-8 before serialisation
 		if (!validateUTF8JSON(onedriveJSONItem)) {
-			return "JSON Validation Failed: Contains Invalid UTF-8 Data";
+			return "JSON Validation Failed: JSON data from OneDrive API contains invalid UTF-8 characters";
 		}
 		
 		// Try and serialise the JSON into a string

--- a/src/sync.d
+++ b/src/sync.d
@@ -7530,6 +7530,21 @@ class SyncEngine {
 					addLogEntry(" onlinePathData: " ~ to!string(onlinePathData), ["debug"]);
 				}
 				
+				// OneDrive Personal Shared Folder Check
+				if (appConfig.accountType == "personal") {
+					// We are a personal account, this existing online folder, it could be a Shared Online Folder could be a 'Add shortcut to My files' item
+					// Is this a remote folder
+					if (isItemRemote(onlinePathData)) {
+						// The folder is a remote item ...
+						if (debugLogging) {addLogEntry("The existing Remote Online Folder and 'onlinePathData' indicate this is most likely a OneDrive Personal Shared Folder Link added by 'Add shortcut to My files'", ["debug"]);}
+						
+						// It is a 'remote' JSON item denoting a potential shared folder
+						// Create a 'root' and 'Shared Folder' DB Tie Records for this JSON object in a consistent manner
+						createRequiredSharedFolderDatabaseRecords(onlinePathData);
+					}
+				}
+				
+				// OneDrive Business Shared Folder Check
 				if (appConfig.accountType == "business") {
 					// We are a business account, this existing online folder, it could be a Shared Online Folder could be a 'Add shortcut to My files' item
 					// Is this a remote folder

--- a/src/sync.d
+++ b/src/sync.d
@@ -737,24 +737,6 @@ class SyncEngine {
 			appConfig.defaultRootId = defaultOneDriveRootDetails["id"].str;
 			if (debugLogging) {addLogEntry("appConfig.defaultRootId      = " ~ appConfig.defaultRootId, ["debug"]);}
 			
-			// Issue #2957 Handling for the Personal Account Root ID issues. Shared Folders coming from another account where this issue exists will need a different approach.
-			// If the returned data for appConfig.defaultRootId contains the string 'sea8cc6beffdb43d7976fbc7da445c639' .. this account has account issues with Microsoft
-			// This is only applicable for Microsoft Personal Accounts
-			if (appConfig.accountType == "personal") {
-				// Does the string 'sea8cc6beffdb43d7976fbc7da445c639' exist in the root id for the account?
-				if (canFind(appConfig.defaultRootId, "sea8cc6beffdb43d7976fbc7da445c639")) {
-					// Yes ... flag account issue, we cannot proceed
-					addLogEntry();
-					addLogEntry("ERROR: You have a Microsoft OneDrive Account Problem. Please raise a support request with Microsoft. You cannot use Microsoft OneDrive at this point in time.", ["info", "notify"]);
-					addLogEntry("ERROR: Account Root ID contains the string 'sea8cc6beffdb43d7976fbc7da445c639'.");
-					addLogEntry("ERROR: Please refer to https://github.com/OneDrive/onedrive-api-docs/issues/1890 for further details.");
-					addLogEntry();
-					
-					// Force Exit
-					forceExit();
-				}
-			}
-			
 			// Save the item to the database, so the account root drive is is always going to be present in the DB
 			saveItem(defaultOneDriveRootDetails);
 		} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -591,6 +591,7 @@ class SyncEngine {
 			// What account type is this?
 			if (appConfig.accountType == "personal") {
 				// Test driveId length and validation
+				// Once checked and validated, we only need to check 'driveId' if it does not match exactly 'appConfig.defaultDriveId'
 				appConfig.defaultDriveId = testProvidedDriveIdForLengthIssue(appConfig.defaultDriveId);
 			}
 			
@@ -1090,8 +1091,10 @@ class SyncEngine {
 					// Issue #3115 - Validate driveId length
 					// What account type is this?
 					if (appConfig.accountType == "personal") {
-						// Test driveId length and validation
-						searchItem.driveId = testProvidedDriveIdForLengthIssue(searchItem.driveId);
+						// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+						if (searchItem.driveId != appConfig.defaultDriveId) {
+							searchItem.driveId = testProvidedDriveIdForLengthIssue(searchItem.driveId);
+						}
 					}
 					
 					// Create a 'root' and 'Shared Folder' DB Tie Records for this JSON object in a consistent manner
@@ -1348,8 +1351,10 @@ class SyncEngine {
 					// Issue #3115 - Validate driveId length
 					// What account type is this?
 					if (appConfig.accountType == "personal") {
-						// Test driveId length and validation
-						driveIdToQuery = testProvidedDriveIdForLengthIssue(driveIdToQuery);
+						// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+						if (driveIdToQuery != appConfig.defaultDriveId) {
+							driveIdToQuery = testProvidedDriveIdForLengthIssue(driveIdToQuery);
+						}
 					}
 					
 					// Update deltaLinkCache
@@ -2648,15 +2653,15 @@ class SyncEngine {
 			// What is the source of this item data?
 			string itemSource = "remote";
 			if (isItemSynced(newDatabaseItem, newItemPath, itemSource)) {
-			
 				// Issue #3115 - Personal Account Shared Folder
 				// What account type is this?
 				if (appConfig.accountType == "personal") {
 					// Is this a 'remote' DB record
 					if (newDatabaseItem.type == ItemType.remote) {
+						// Issue #3136, #3139 #3143
 						// Fetch the actual online record for this item
-						// This returns the actual OneDrive Personal driveId value and is 15 character checked
-						string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId);
+						// This returns the 'actual' OneDrive Personal driveId value and is 15 character checked
+						string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId));
 						newDatabaseItem.remoteDriveId = actualOnlineDriveId;
 					}
 				}
@@ -2955,8 +2960,10 @@ class SyncEngine {
 		// Issue #3115 - Validate driveId length
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			parentDriveId = testProvidedDriveIdForLengthIssue(parentDriveId);
+			// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+			if (parentDriveId != appConfig.defaultDriveId) {
+				parentDriveId = testProvidedDriveIdForLengthIssue(parentDriveId);
+			}
 		}
 		
 		// Try and fetch this shared folder parent's details
@@ -3014,6 +3021,7 @@ class SyncEngine {
 		// - This maps the Shared Folder 'driveId' with the parent folder where the shared folder exists, so we can call the parent folder to query for changes to this Shared Folder
 		createDatabaseRootTieRecordForOnlineSharedFolder(onlineParentData);
 		
+		// Log that we are created the Shared Folder Tie record now
 		if (debugLogging) {addLogEntry("Creating the Shared Folder DB Tie Record that binds the 'root' record to the 'folder'" , ["debug"]);}
 		
 		// Make an item from the online JSON data
@@ -3065,8 +3073,10 @@ class SyncEngine {
 		// Issue #3115 - Validate driveId length
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			sharedFolderDatabaseTie.driveId = testProvidedDriveIdForLengthIssue(sharedFolderDatabaseTie.driveId);
+			// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+			if (sharedFolderDatabaseTie.driveId != appConfig.defaultDriveId) {
+				sharedFolderDatabaseTie.driveId = testProvidedDriveIdForLengthIssue(sharedFolderDatabaseTie.driveId);
+			}
 		}
 				
 		// Log action
@@ -3203,9 +3213,10 @@ class SyncEngine {
 						if (appConfig.accountType == "personal") {
 							// Is this a 'remote' DB record
 							if (changedOneDriveItem.type == ItemType.remote) {
+								// Issue #3136, #3139 #3143
 								// Fetch the actual online record for this item
 								// This returns the actual OneDrive Personal driveId value and is 15 character checked
-								string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(changedOneDriveItem.remoteDriveId);
+								string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(changedOneDriveItem.remoteDriveId));
 								changedOneDriveItem.remoteDriveId = actualOnlineDriveId;
 							}
 						}
@@ -3250,9 +3261,10 @@ class SyncEngine {
 				if (appConfig.accountType == "personal") {
 					// Is this a 'remote' DB record
 					if (changedOneDriveItem.type == ItemType.remote) {
+						// Issue #3136, #3139 #3143
 						// Fetch the actual online record for this item
 						// This returns the actual OneDrive Personal driveId value and is 15 character checked
-						string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(changedOneDriveItem.remoteDriveId);
+						string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(changedOneDriveItem.remoteDriveId));
 						changedOneDriveItem.remoteDriveId = actualOnlineDriveId;
 					}
 				}
@@ -4107,13 +4119,6 @@ class SyncEngine {
 		string initialCalculatedPath;
 		string fullCalculatedPath;
 		bool calculateLocalExtension = false;
-		
-		// Issue #3115 - Validate driveId length
-		// What account type is this?
-		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			thisDriveId = testProvidedDriveIdForLengthIssue(thisDriveId);
-		}
 		
 		// What driveID and itemID we trying to calculate the path for
 		if (debugLogging) {
@@ -7214,8 +7219,11 @@ class SyncEngine {
 				// Issue #3115 - Validate driveId length
 				// What account type is this?
 				if (appConfig.accountType == "personal") {
-					// Test driveId length and validation
-					driveId = testProvidedDriveIdForLengthIssue(driveId);
+				
+					// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+					if (driveId != appConfig.defaultDriveId) {
+						driveId = testProvidedDriveIdForLengthIssue(driveId);
+					}
 				}
 			
 				if (debugLogging) {addLogEntry("Query DB with this driveID for the Parent Path: " ~ driveId, ["debug"]);}
@@ -7308,8 +7316,10 @@ class SyncEngine {
 			// Issue #3115 - Validate driveId length
 			// What account type is this?
 			if (appConfig.accountType == "personal") {
-				// Test driveId length and validation
-				queryItem.driveId = testProvidedDriveIdForLengthIssue(queryItem.driveId);
+				// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+				if (queryItem.driveId != appConfig.defaultDriveId) {
+					queryItem.driveId = testProvidedDriveIdForLengthIssue(queryItem.driveId);
+				}
 			}
 			
 			if (queryItem.driveId == appConfig.defaultDriveId) {
@@ -9040,8 +9050,10 @@ class SyncEngine {
 					// Issue #3115 - Validate driveId length
 					// What account type is this?
 					if (appConfig.accountType == "personal") {
-						// Test item.driveId length and validation
-						item.driveId = testProvidedDriveIdForLengthIssue(item.driveId);
+						// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+						if (item.driveId != appConfig.defaultDriveId) {
+							item.driveId = testProvidedDriveIdForLengthIssue(item.driveId);
+						}
 					}
 					
 					// Add to the local database
@@ -9095,10 +9107,14 @@ class SyncEngine {
 		if (appConfig.accountType == "personal") {
 			// Is this a 'remote' DB record
 			if (newDatabaseItem.type == ItemType.remote) {
-				// Fetch the actual online record for this item
-				// This returns the actual OneDrive Personal driveId value and is 15 character checked
-				string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId);
-				newDatabaseItem.remoteDriveId = actualOnlineDriveId;
+				// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+				if (newDatabaseItem.remoteDriveId != appConfig.defaultDriveId) {
+					// Issue #3136, #3139 #3143
+					// Fetch the actual online record for this item
+					// This returns the actual OneDrive Personal driveId value and is 15 character checked
+					string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId));
+					newDatabaseItem.remoteDriveId = actualOnlineDriveId;
+				}
 			}
 		}
 		
@@ -9196,47 +9212,12 @@ class SyncEngine {
 		// If this is a OneDrive Personal Account, ensure this value is 16 characters, padded by leading zero's if eventually required
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-		
 			// Check the newDatabaseItem.remoteDriveId
 			if (!newDatabaseItem.remoteDriveId.empty) {
-				// Ensure newDatabaseItem.remoteDriveId is 16 characters long by padding with leading zeros if required
-				if (newDatabaseItem.remoteDriveId.length < 16) {
-					// Debug logging
-					if (debugLogging) {addLogEntry("ONEDRIVE PERSONAL API BUG: The provided 'remoteDriveId' is not 16 Characters in length - fetching correct value from Microsoft Graph API via getDriveIdRoot call", ["debug"]);}
-					
-					// Generate the change
-					string oldEntry = newDatabaseItem.remoteDriveId;
-					string newEntry;
-					string onlineDriveValue;
-					
-					// Fetch the actual online record for this item
-					// This returns the actual OneDrive Personal driveId value and is 15 character checked
-					onlineDriveValue = fetchRealOnlineDriveIdentifier(oldEntry);
-					
-					// Check the onlineDriveValue value
-					if (!onlineDriveValue.empty) {
-						// Ensure onlineDriveValue is 16 characters long by padding with leading zeros if required
-						if (onlineDriveValue.length < 16) {
-							// online value is not 16 characters in length
-							// Debug logging
-							if (debugLogging) {addLogEntry("ONEDRIVE PERSONAL API BUG: The provided online ['parentReference']['driveId'] value is not 16 Characters in length - padding with leading zero's", ["debug"]);}
-							// Generate the change
-							newEntry = to!string(onlineDriveValue.padLeft('0', 16)); // Explicitly use padLeft for leading zero padding, leave case as-is
-						} else {
-							// Online value is 16 characters in length, use as-is
-							newEntry = onlineDriveValue;
-						}
-					}
-					
-					// Debug Logging of result
-					if (debugLogging) {
-							addLogEntry(" - old newDatabaseItem.remoteDriveId = " ~ oldEntry, ["debug"]);
-							addLogEntry(" - new newDatabaseItem.remoteDriveId = " ~ newEntry, ["debug"]);
-					}
-					
-					// Make the change to the generated new database item
-					newDatabaseItem.remoteDriveId = newEntry;
-				}
+				// Issue #3136, #3139 #3143
+				// Test searchItem.driveId length and validation
+				// - This check the length, fetch online value and return a 16 character driveId
+				newDatabaseItem.remoteDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId));
 			}
 		}
 		
@@ -9252,6 +9233,7 @@ class SyncEngine {
 	
 	// For OneDrive Personal Accounts, the case sensitivity depending on the API call means the 'driveId' can be uppercase or lowercase
 	// For this application use, this causes issues as, in POSIX environments - 024470056F5C3E43 != 024470056f5c3e43 despite on Windows this being treated as the same
+	// This function does NOT do a 15 character driveId validation
 	string fetchRealOnlineDriveIdentifier(string inputDriveId) {
 		// Function Start Time
 		SysTime functionStartTime;
@@ -9299,11 +9281,11 @@ class SyncEngine {
 		// Do we have details we can use?
 		if (hasParentReferenceDriveId(remoteDriveDetails)) {
 			// We have a [parentReference][driveId] reference driveId to use
-			outputDriveId = testProvidedDriveIdForLengthIssue(remoteDriveDetails["parentReference"]["driveId"].str);
+			outputDriveId = remoteDriveDetails["parentReference"]["driveId"].str;
 		} else {
 			// We dont have a value from online we can use
 			// Test existing driveId length and validation
-			outputDriveId = testProvidedDriveIdForLengthIssue(inputDriveId);
+			outputDriveId = inputDriveId;
 		}
 		
 		// Display function processing time if configured to do so
@@ -9426,8 +9408,9 @@ class SyncEngine {
 					// Issue #3115 - Personal Account Shared Folder
 					// What account type is this?
 					if (appConfig.accountType == "personal") {
+						// Issue #3136, #3139 #3143
 						// Fetch the actual online record for this item
-						// This returns the actual OneDrive Personal driveId value and is 15 character checked
+						// This returns the actual OneDrive Personal driveId value. The check of 'searchItem.driveId' to comply with 16 characters is done below
 						string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(searchItem.driveId);
 						searchItem.driveId = actualOnlineDriveId;
 					}
@@ -9458,8 +9441,10 @@ class SyncEngine {
 		// Issue #3072 - Validate searchItem.driveId length
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-			// Test searchItem.driveId length and validation
-			searchItem.driveId = testProvidedDriveIdForLengthIssue(searchItem.driveId);
+			// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+			if (searchItem.driveId != appConfig.defaultDriveId) {
+				searchItem.driveId = testProvidedDriveIdForLengthIssue(searchItem.driveId);
+			}
 		}
 		
 		// Before we get any data from the OneDrive API, flag any child object in the database as out-of-sync for this driveId & and object id
@@ -9699,8 +9684,10 @@ class SyncEngine {
 		// Issue #3115 - Validate driveId length
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			driveId = testProvidedDriveIdForLengthIssue(driveId);
+			// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+			if (driveId != appConfig.defaultDriveId) {
+				driveId = testProvidedDriveIdForLengthIssue(driveId);
+			}
 		}
 		
 		while (true) {
@@ -9815,11 +9802,8 @@ class SyncEngine {
 		}
 		
 		// Issue #3115 - Validate driveId length
-		// What account type is this?
-		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			driveId = testProvidedDriveIdForLengthIssue(driveId);
-		}
+		// - The function 'queryForChildren' checks the 'driveId' value and that value is the input to this function.
+		//   It is redundant to then check 'driveid' again as this is not changed when this function is called
 		
 		// function variables 
 		JSONValue thisLevelChildren;
@@ -12135,8 +12119,10 @@ class SyncEngine {
 		// Issue #3115 - Validate driveId length
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
-			// Test driveId length and validation
-			tieDBItem.driveId = testProvidedDriveIdForLengthIssue(tieDBItem.driveId);
+			// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+			if (tieDBItem.driveId != appConfig.defaultDriveId) {
+				tieDBItem.driveId = testProvidedDriveIdForLengthIssue(tieDBItem.driveId);
+			}
 		}
 		
 		// Add this DB Tie parent record to the local database
@@ -12188,9 +12174,10 @@ class SyncEngine {
 			tieDBItem.parentId = null;
 			tieDBItem.type = ItemType.root;
 			
+			// Issue #3136, #3139 #3143
 			// Fetch the actual online record for this item
 			// This returns the actual OneDrive Personal driveId value and is 15 character checked
-			string actualOnlineDriveId = fetchRealOnlineDriveIdentifier(tieDBItem.driveId);
+			string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(tieDBItem.driveId));
 			tieDBItem.driveId = actualOnlineDriveId;
 		} else {
 			// The tieDBItem.parentId needs to be the correct driveId id reference
@@ -12883,6 +12870,7 @@ class SyncEngine {
 				addLogEntry(validationMessage, ["debug"]);
 			}
 			
+			// Is this less than 16 characters
 			if (objectParentDriveId.length < 16) {
 				// Debug logging
 				if (debugLogging) {addLogEntry("ONEDRIVE PERSONAL API BUG (Issue #3072): The provided 'driveId' is not 16 characters in length - fetching the correct value from Microsoft Graph API via getDriveIdRoot call", ["debug"]);}
@@ -12892,16 +12880,17 @@ class SyncEngine {
 				string onlineDriveValue;
 				
 				// Fetch the actual online record for this item
-				// This returns the actual OneDrive Personal driveId value and is 15 character checked
+				// This returns the actual OneDrive Personal driveId value based on the input value.
+				// The function 'fetchRealOnlineDriveIdentifier' does not check for length issue, this is done below
 				onlineDriveValue = fetchRealOnlineDriveIdentifier(oldEntry);
 				
-				// Check the onlineDriveValue value
+				// Check the onlineDriveValue value for 15 character issue
 				if (!onlineDriveValue.empty) {
 					// Ensure remoteDriveId is 16 characters long by padding with leading zeros if required
 					if (onlineDriveValue.length < 16) {
 						// online value is not 16 characters in length
 						// Debug logging
-						if (debugLogging) {addLogEntry("ONEDRIVE PERSONAL API BUG: The provided online ['parentReference']['driveId'] value is not 16 Characters in length - padding with leading zero's", ["debug"]);}
+						if (debugLogging) {addLogEntry("ONEDRIVE PERSONAL API BUG (Issue #3072): The provided online ['parentReference']['driveId'] value is not 16 Characters in length - padding with leading zero's", ["debug"]);}
 						// Generate the change
 						newEntry = to!string(onlineDriveValue.padLeft('0', 16)); // Explicitly use padLeft for leading zero padding, leave case as-is
 					} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -8957,6 +8957,13 @@ class SyncEngine {
 						}
 					}
 					
+					// Issue #3115 - Validate driveId length
+					// What account type is this?
+					if (appConfig.accountType == "personal") {
+						// Test item.driveId length and validation
+						item.driveId = testProvidedDriveIdForLengthIssue(item.driveId);
+					}
+					
 					// Add to the local database
 					if (debugLogging) {addLogEntry("Saving this DB item record: " ~ to!string(item), ["debug"]);}
 					itemDB.upsert(item);

--- a/src/sync.d
+++ b/src/sync.d
@@ -9324,6 +9324,13 @@ class SyncEngine {
 		queryChildrenOneDriveApiInstance = new OneDriveApi(appConfig);
 		queryChildrenOneDriveApiInstance.initialise();
 		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			driveId = testProvidedDriveIdForLengthIssue(driveId);
+		}
+		
 		while (true) {
 			// Check if exitHandlerTriggered is true
 			if (exitHandlerTriggered) {
@@ -9433,6 +9440,13 @@ class SyncEngine {
 			functionStartTime = Clock.currTime();
 			logKey = generateAlphanumericString();
 			displayFunctionProcessingStart(thisFunctionName, logKey);
+		}
+		
+		// Issue #3115 - Validate driveId length
+		// What account type is this?
+		if (appConfig.accountType == "personal") {
+			// Test driveId length and validation
+			driveId = testProvidedDriveIdForLengthIssue(driveId);
 		}
 		
 		// function variables 

--- a/src/sync.d
+++ b/src/sync.d
@@ -3973,7 +3973,7 @@ class SyncEngine {
 		}
 		
 		// What driveID and itemID we trying to calculate the path for
-		if (debugLogging) {addLogEntry("Attempting to calculate local filesystem path for " ~ thisDriveId ~ " and " ~ thisItemId, ["debug"]);}
+		if (debugLogging) {addLogEntry("Attempting to calculate initial local filesystem path for " ~ thisDriveId ~ " and " ~ thisItemId, ["debug"]);}
 		
 		// Perform the original calculation of the path using the values provided
 		try {
@@ -3999,13 +3999,28 @@ class SyncEngine {
 			// Use the 'thisDriveId' value to obtain the 'remote' item type record which represents the local path junction point to the shared folder
 			Item remoteEntryItem;
 			string fullLocalPath;
+			string localPathExtension;
+			
+			if (debugLogging) {addLogEntry("Attempting to calculate shared folder local filesystem path for " ~ thisDriveId ~ " and " ~ thisItemId, ["debug"]);}
 			
 			// Get the DB entry for this 'remote' item
 			itemDB.selectRemoteTypeByRemoteDriveId(thisDriveId, thisItemId, remoteEntryItem);
-			// Calculate the local path extension for this item
-			string localPathExtension = itemDB.computePath(remoteEntryItem.driveId, remoteEntryItem.id);
+			
+			// What was returned from the Database?
+			if (debugLogging) {addLogEntry("remoteEntryItem: " ~ to!string(remoteEntryItem), ["debug"]);}
+			
+			// What details do we use?
+			if (!remoteEntryItem.driveId.empty) {
+				// use the returned 'remote' DB entry values
+				localPathExtension = itemDB.computePath(remoteEntryItem.driveId, remoteEntryItem.id);
+			} else {
+				// do nothing at the moment ....
+			}
+			
+			// result for localPathExtension
 			if (debugLogging) {addLogEntry(" localPathExtension = " ~ to!string(localPathExtension), ["debug"]);}
 			
+			// what do we use?
 			if (initialCalculatedPath == ".") {
 				// The '.' represents the root shared folder ... 
 				fullLocalPath = localPathExtension;

--- a/src/sync.d
+++ b/src/sync.d
@@ -5456,7 +5456,6 @@ class SyncEngine {
 					
 					// what are we checking
 					if (debugLogging) {addLogEntry("skip_file item to check (file name only - parent path not in database): " ~ exclusionTestPath, ["debug"]);}
-					clientSideRuleExcludesPath = selectiveSync.isFileNameExcluded(exclusionTestPath);
 				}
 				
 				// Perform the 'skip_file' evaluation

--- a/src/sync.d
+++ b/src/sync.d
@@ -1993,6 +1993,9 @@ class SyncEngine {
 							if (debugLogging) {addLogEntry("Personal Shared Item JSON object has the 'shared' JSON structure", ["debug"]);}
 							// Create a 'root' and 'Shared Folder' DB Tie Records for this JSON object in a consistent manner
 							createRequiredSharedFolderDatabaseRecords(onedriveJSONItem);
+						} else {
+							// The Shared JSON structure is missing .....
+							if (debugLogging) {addLogEntry("Personal Shared Item JSON object is MISSING the 'shared' JSON structure ... API BUG ?", ["debug"]);}
 						}
 						
 						// Ensure that this item has no parent
@@ -3997,8 +4000,8 @@ class SyncEngine {
 			Item remoteEntryItem;
 			string fullLocalPath;
 			
-			// Get the DB entry
-			itemDB.selectRemoteTypeByRemoteDriveId(thisDriveId, remoteEntryItem);
+			// Get the DB entry for this 'remote' item
+			itemDB.selectRemoteTypeByRemoteDriveId(thisDriveId, thisItemId, remoteEntryItem);
 			// Calculate the local path extension for this item
 			string localPathExtension = itemDB.computePath(remoteEntryItem.driveId, remoteEntryItem.id);
 			if (debugLogging) {addLogEntry(" localPathExtension = " ~ to!string(localPathExtension), ["debug"]);}

--- a/src/util.d
+++ b/src/util.d
@@ -496,27 +496,12 @@ bool isValidUTF8Timestamp(string input) {
 		// Validate the entire string for UTF-8 correctness
 		validate(input); // Throws UTFException if invalid UTF-8 is found
 
-		// Iterate through each character using byUTF to ensure proper UTF-8 decoding
-		auto it = input.byUTF!(char);
-		foreach (_; it) {
-			// Iterating over the range ensures every UTF-8 sequence in the string is decoded into valid `dchar`s.
-			// Throws a UTFException if an invalid UTF-8 sequence is encountered during decoding.
-		}
-
-		// Check for replacement characters
-		if (input.count!((dchar c) => c == '\uFFFD') > 0) {
-			// contains replacement character
-			addLogEntry("UTF-8 validation failed: Input contains replacement characters (�).");
+		// Validate the input against UTF-8 test cases
+		if (!isValidUTF8(input)) {
+			// error message already printed
 			return false;
 		}
-
-		// is the string empty?
-		if (input.empty) {
-			// input is empty
-			addLogEntry("UTF-8 validation failed: Input is empty.");
-			return false;
-		}
-	
+		
 		// Additional edge-case handling because the input format is known and controlled:
 		// Ensure input length is within the expected range for a UTC datetime
 		if (input.length < 20 || input.length > 30) {


### PR DESCRIPTION
* Add further personal account driveId length checks when generating a /delta response for a Shared Folder