### PR TITLE
Fix OneDrive Personal Shared Folder removal issue

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -8753,6 +8753,7 @@ class SyncEngine {
 					// OneDrive Business Shared Folder Deletion Handling
 					// Is this a Business Account with Sync Business Shared Items enabled?
 					if ((appConfig.accountType == "business") && (appConfig.getValueBool("sync_business_shared_items"))) {
+						// Syncing Business Shared Items is enabled
 						businessSharingEnabled = true;
 					}
 					


### PR DESCRIPTION
* When removing the a Shared Folder locally, ensure we are only removing our 'link' to the folder, not the entire folder from the remote user