### PR TITLE
Minor: gitignore consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ config.status
 autom4te.cache/
 contrib/pacman/PKGBUILD
 contrib/spec/onedrive.spec
+contrib/systemd/onedrive.service
+contrib/systemd/onedrive@.service
+
 
 # Ignore everything in the .github folder
 .github/*


### PR DESCRIPTION
> ### Ignoring files created during configure to be consistent with other files generated from `.in` templates
> 
> During a `./configure` run, files are being created from templates using user specific configuration. Most of them are correctly ignored. But somehow, `contrib/systemd/onedrive@.service` and `contrib/systemd/onedrive.service` were left behind and most probably forgotten.
> 
> Unless I am mistaken, this commit is a safe minor improvement for the dev side as, with it, these files do not need to be deleted manually anymore before making commits to a forked repo. Needs review.

Note: this is an PR from the exact same commit than PR #3187. The reason being detailed in 2nd option of _https://github.com/abraunegg/onedrive/issues/3187#issuecomment-2764815975_:
> I can check if enabling the workflows makes a difference by re-running the PR checks. 
> ### Debugging plan
>     1. ...
>     2. If not working, I'll try to close the PR unmerged, hoping I would then be allowed to make a new one.
>     3. ...