### PR TITLE
Update testbuild.yaml

### DIFF
--- a/.github/workflows/testbuild.yaml
+++ b/.github/workflows/testbuild.yaml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
-    #runs-on: ubuntu-latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check out code from GitHub


### PR DESCRIPTION
* Ubuntu 20.04 runners are retired and removed as per: This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101