### PR TITLE
Fix Bug #3223: Fix uploading of modified files when using --upload-only & --remove-source-files

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -6229,6 +6229,14 @@ class SyncEngine {
 						}
 					}
 				}
+				
+				// Are we in an --upload-only & --remove-source-files scenario?
+				if ((uploadOnly) && (localDeleteAfterUpload)) {
+					// Log that we are deleting a local item
+					addLogEntry("Removing local file as --upload-only & --remove-source-files configured");	
+					if (debugLogging) {addLogEntry("Removing local file: " ~ localFilePath, ["debug"]);}
+					safeRemove(localFilePath);
+				}
 			}
 		}
 		


### PR DESCRIPTION
* When in a --upload-only & --remove-source-files scenario, modified files may not be in the database, even more so in a --resync scenario. When this happens, there is no DB entry regarding the detected modified file to be uploaded, thus, values are never set