### PR TITLE
Fix Bug #3250: Be consistent with application output when skipping integrity checks

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -37,6 +37,8 @@ avmkfdiitirnrenzljwc
 avx
 bak
 baus
+BBBA
+BBD
 bcdefghi
 beffdb
 bindir
@@ -175,6 +177,7 @@ journalctl
 jsvar
 kdbx
 keepass
+keyboxd
 kotlin
 lalen
 lbl
@@ -230,6 +233,7 @@ mswsock
 mtune
 mydir
 mynasau
+myuser
 myusername
 nadded
 nadjusted

--- a/src/sync.d
+++ b/src/sync.d
@@ -10951,8 +10951,10 @@ class SyncEngine {
 					uploadFileHash = uploadResponse["file"]["hashes"]["quickXorHash"].str;
 					localFileHash = computeQuickXorHash(localFilePath);
 				} else {
-					addLogEntry("Online file validation unable to be performed: input JSON whilst valid did not contain data which could be validated");
-					addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath);
+					if (verboseLogging) {
+						addLogEntry("Online file validation unable to be performed: input JSON whilst valid did not contain data which could be validated", ["verbose"]);
+						addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath, ["verbose"]);
+					}
 					return integrityValid;
 				}
 				
@@ -10993,13 +10995,16 @@ class SyncEngine {
 					addLogEntry("To disable the integrity checking of uploaded files use --disable-upload-validation");
 				}
 			} else {
-				addLogEntry("Online file validation unable to be performed: input JSON was invalid");
-				addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath);
+				if (verboseLogging) {
+					addLogEntry("Online file validation unable to be performed: input JSON whilst valid did not contain data which could be validated", ["verbose"]);
+					addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath, ["verbose"]);
+				}
 			}
 		} else {
 			// We are bypassing integrity checks due to --disable-upload-validation
 			if (debugLogging) {addLogEntry("Online file validation disabled due to --disable-upload-validation", ["debug"]);}
-			addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath, ["info", "notify"]);
+			// Skipping upload integrity check, do not notify the user via the GUI ... they have explicitly disabled upload validation
+			if (verboseLogging) {addLogEntry("WARNING: Skipping upload integrity check for: " ~ localFilePath, ["verbose"]);}
 		}
 		
 		// Display function processing time if configured to do so


### PR DESCRIPTION
* Be consistent with application output when skipping integrity checks. If integrity validation has been disabled, the user has configured this, do not sent a GUI or normal application log output.