### PR TITLE
Implement FR #3234: Add configurable upload delay to support Obsidian

### DIFF
--- a/config
+++ b/config
@@ -40,6 +40,9 @@
 ## This setting controls whether the curl library is configured to output additional data to assist with diagnosing HTTPS issues and problems.
 #debug_https = "false"
 
+## This setting controls whether 'inotify' events should be delayed or not.
+#delay_inotify_processing = "false"
+
 ## This option determines whether the client will conduct integrity validation on files downloaded from Microsoft OneDrive.
 #disable_download_validation = "false"
 

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -17,6 +17,7 @@ Before reading this document, please ensure you are running application version 
   - [create_new_file_version](#create_new_file_version)
   - [data_timeout](#data_timeout)
   - [debug_https](#debug_https)
+  - [delay_inotify_processing](#delay_inotify_processing)
   - [disable_download_validation](#disable_download_validation)
   - [disable_notifications](#disable_notifications)
   - [disable_permission_set](#disable_permission_set)
@@ -30,6 +31,7 @@ Before reading this document, please ensure you are running application version 
   - [enable_logging](#enable_logging)
   - [force_http_11](#force_http_11)
   - [force_session_upload](#force_session_upload)
+  - [inotify_delay](#inotify_delay)
   - [ip_protocol_version](#ip_protocol_version)
   - [local_first](#local_first)
   - [log_dir](#log_dir)
@@ -253,6 +255,20 @@ _**CLI Option Use:**_ `--debug-https`
 > [!WARNING]
 > Whilst this option can be used at any time, it is advisable that you only use this option when advised as this will output your `Authorization: bearer` - which is your authentication token to Microsoft OneDrive.
 
+
+### delay_inotify_processing
+_**Description:**_ This setting controls whether 'inotify' events should be delayed or not. This option should only ever be enabled when attempting to reduce the impact of editors like Obsidian which constantly write change to disk in an atomic fashion.
+
+_**Value Type:**_ Boolean
+
+_**Default Value:**_ False
+
+_**Config Example:**_ `delay_inotify_processing = "false"` or `delay_inotify_processing = "true"`
+
+> [!NOTE]
+> If you enable this option you *must* also enable 'force_session_upload' to ensure that your data uploads are done in a manner that editors, like Obsidian expect.
+
+
 ### disable_download_validation
 _**Description:**_ This option determines whether the client will conduct integrity validation on files downloaded from Microsoft OneDrive. Sometimes, when downloading files, particularly from SharePoint, there is a discrepancy between the file size reported by the OneDrive API and the byte count received from the SharePoint HTTP Server for the same file. Enable this option to disable the integrity checks performed by this client.
 
@@ -416,6 +432,21 @@ _**Default Value:**_ False
 _**Config Example:**_ `force_session_upload = "false"` or `force_session_upload = "true"`
 
 _**CLI Option Use:**_ *None - this is a config file option only*
+
+
+### inotify_delay
+_**Description:**_ This option specifies the number of seconds 'inotify' events are paused before they are processed by this client. This value is used to overcome aggresive write applications such as Obsidian which write each keystroke in an atomic manner to the local disk. Due to this atomic write, each 'save' causes the existing file to be deleted and replaced with a new file, which this client sees as multiple constant 'inotify' events.
+
+_**Value Type:**_ Integer
+
+_**Default Value:**_ 5
+
+_**Maximum Value:**_ 16
+
+_**Config Example:**_ `inotify_delay = "10"`
+
+_**CLI Option Use:**_ *None - this is a config file option only*
+
 
 ### ip_protocol_version
 _**Description:**_ This setting controls the application IP protocol that should be used when communicating with Microsoft OneDrive. The default is to use IPv4 and IPv6 networks for communicating to Microsoft OneDrive.

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -447,6 +447,8 @@ _**Config Example:**_ `inotify_delay = "10"`
 
 _**CLI Option Use:**_ *None - this is a config file option only*
 
+> [!NOTE]
+> This option is only used if 'delay_inotify_processing' is enabled, otherwise this option is ignored.
 
 ### ip_protocol_version
 _**Description:**_ This setting controls the application IP protocol that should be used when communicating with Microsoft OneDrive. The default is to use IPv4 and IPv6 networks for communicating to Microsoft OneDrive.

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -435,7 +435,7 @@ _**CLI Option Use:**_ *None - this is a config file option only*
 
 
 ### inotify_delay
-_**Description:**_ This option specifies the number of seconds 'inotify' events are paused before they are processed by this client. This value is used to overcome aggresive write applications such as Obsidian which write each keystroke in an atomic manner to the local disk. Due to this atomic write, each 'save' causes the existing file to be deleted and replaced with a new file, which this client sees as multiple constant 'inotify' events.
+_**Description:**_ This option specifies the number of seconds 'inotify' events are paused before they are processed by this client. This value is used to overcome aggressive write applications such as Obsidian which write each keystroke in an atomic manner to the local disk. Due to this atomic write, each 'save' causes the existing file to be deleted and replaced with a new file, which this client sees as multiple constant 'inotify' events.
 
 _**Value Type:**_ Integer
 

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -441,7 +441,7 @@ _**Value Type:**_ Integer
 
 _**Default Value:**_ 5
 
-_**Maximum Value:**_ 16
+_**Maximum Value:**_ 15
 
 _**Config Example:**_ `inotify_delay = "10"`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -279,7 +279,7 @@ If you explicitly want to use HTTP/1.1, you can do so by using the `--force-http
 | 7.88.1       | Debian 12 (Bookworm) | 6,7,8,9,10,11,12,13 |
 | 8.2.1        | Alpine Linux 3.14 | 7,8,9,10,11,12,13 |
 | 8.5.0        | Alpine Linux 3.15, Ubuntu 24.04 LTS (Noble Numbat) | 8,9,10,11,12,13 |
-| 8.9.1        | Ubuntu 24.10 | 11,12,13 |
+| 8.9.1        | Ubuntu 24.10 (Oracular Oriole) | 11,12,13 |
 | 8.10.0       | Alpine Linux 3.17 | 13 |
 
 > [!IMPORTANT]

--- a/src/config.d
+++ b/src/config.d
@@ -376,6 +376,13 @@ class ApplicationConfig {
 		// and Microsoft OneDrive should be respecting this timestamp as the timestamp to use|set when storing that file online
 		boolValues["force_session_upload"] = false;
 		
+		// Obsidian Editor has been written in such a way that it is constantly writing each and every keystroke to a file.
+		// Not only is this really bad application behaviour, for this client, this means the application is constantly writing to disk, thus attempting to upload file changes.
+		// Unfortunatly Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
+		// This flag tells the 'onedrive' inotify monitor to 'sleep' for this period of time, so that constant system writes are not creating instant data uploads
+		boolValues["delay_inotify_processing"] = false;
+		longValues["inotify_delay"] = 5; // default of 5 seconds
+		
 		// Webhook Feature Options
 		boolValues["webhook_enabled"] = false;
 		stringValues["webhook_public_url"] = "";

--- a/src/config.d
+++ b/src/config.d
@@ -133,8 +133,11 @@ class ApplicationConfig {
 	bool fullScanTrueUpRequired = false;
 	bool suppressLoggingOutput = false;
 	
-	// Number of concurrent threads when downloading and uploading data
+	// Default number of concurrent threads when downloading and uploading data
 	ulong defaultConcurrentThreads = 8;
+	
+	// Default number of seconds inotify actions will be delayed by
+	ulong defaultInotifyDelay = 5;
 		
 	// All application run-time paths are formulated from this as a set of defaults
 	// - What is the home path of the actual 'user' that is running the application
@@ -381,7 +384,7 @@ class ApplicationConfig {
 		// Unfortunately Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
 		// This flag tells the 'onedrive' inotify monitor to 'sleep' for this period of time, so that constant system writes are not creating instant data uploads
 		boolValues["delay_inotify_processing"] = false;
-		longValues["inotify_delay"] = 5; // default of 5 seconds
+		longValues["inotify_delay"] = defaultInotifyDelay; // default of 5 seconds
 		
 		// Webhook Feature Options
 		boolValues["webhook_enabled"] = false;
@@ -985,6 +988,13 @@ class ApplicationConfig {
 						tempValue = defaultConcurrentThreads;
 					}
 					setValueLong("threads", tempValue);
+				} else if (key == "inotify_delay") {
+					ulong tempValue = thisConfigValue;
+					if ((tempValue < 5)||(tempValue > 15)) {
+						addLogEntry("Invalid value for key in config file - using default value: " ~ key);
+						tempValue = defaultInotifyDelay;
+					}
+					setValueLong("inotify_delay", tempValue);
 				}
 			} else {
 				addLogEntry("Unknown key in config file: " ~ key);

--- a/src/config.d
+++ b/src/config.d
@@ -378,7 +378,7 @@ class ApplicationConfig {
 		
 		// Obsidian Editor has been written in such a way that it is constantly writing each and every keystroke to a file.
 		// Not only is this really bad application behaviour, for this client, this means the application is constantly writing to disk, thus attempting to upload file changes.
-		// Unfortunatly Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
+		// Unfortunately Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
 		// This flag tells the 'onedrive' inotify monitor to 'sleep' for this period of time, so that constant system writes are not creating instant data uploads
 		boolValues["delay_inotify_processing"] = false;
 		longValues["inotify_delay"] = 5; // default of 5 seconds

--- a/src/main.d
+++ b/src/main.d
@@ -1208,7 +1208,7 @@ int main(string[] cliArgs) {
 							
 							// Obsidian Editor has been written in such a way that it is constantly writing each and every keystroke to a file.
 							// Not only is this really bad application behaviour, for this client, this means the application is constantly writing to disk, thus attempting to upload file changes.
-							// Unfortunatly Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
+							// Unfortunately Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
 							if (appConfig.getValueBool("delay_inotify_processing")) {
 								Thread.sleep(dur!("seconds")(to!int(appConfig.getValueLong("inotify_delay"))));
 							}

--- a/src/main.d
+++ b/src/main.d
@@ -1205,6 +1205,14 @@ int main(string[] cliArgs) {
 
 						if(filesystemMonitor.initialised) {
 							// If local monitor is on and is waiting (previous event was not from webhook)
+							
+							// Obsidian Editor has been written in such a way that it is constantly writing each and every keystroke to a file.
+							// Not only is this really bad application behaviour, for this client, this means the application is constantly writing to disk, thus attempting to upload file changes.
+							// Unfortunatly Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
+							if (appConfig.getValueBool("delay_inotify_processing")) {
+								Thread.sleep(dur!("seconds")(to!int(appConfig.getValueLong("inotify_delay"))));
+							}
+							
 							// start the worker and wait for event
 							if (!notificationReceived) {
 								filesystemMonitor.send(true);

--- a/src/util.d
+++ b/src/util.d
@@ -1592,7 +1592,8 @@ bool isBadCurlVersion(string curlVersion) {
 		"7.81.0", // Ubuntu 22.x
 		"7.88.1", // Debian 12
 		"8.2.1",  // Ubuntu 23.10
-		"8.5.0",  // Ubuntu 24.x
+		"8.5.0",  // Ubuntu 24.04
+		"8.9.1",  // Ubuntu 24.10
 		"8.10.0"  // Various - HTTP/2 bug which was fixed in 8.10.1
     ];
     


### PR DESCRIPTION
* As of now, Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration. Obsidian uses Electron and relies on the default save behavior of its underlying libraries and editor components (like CodeMirror), which typically perform atomic writes for every keystroke. This FR implements a delay in uploading changes to Microsoft OneDrive that is user configurable to better handle how Obsidian works