### PR TITLE
Makefile.in: Pass libraries after source files in compiler invocation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,7 +100,7 @@ onedrive: $(SOURCES)
 	else \
 		echo $(version) > version ; \
 	fi
-	$(DC) -J. $(NOTIF_VERSIONS) $(DCFLAGS) $(addprefix $(LINKER_DCFLAG),$(all_libs)) $^ $(OUTPUT_DCFLAG)$@
+	$(DC) -J. $(NOTIF_VERSIONS) $(DCFLAGS) $^ $(addprefix $(LINKER_DCFLAG),$(all_libs)) $(OUTPUT_DCFLAG)$@
 
 install: all
 	mkdir -p $(DESTDIR)$(bindir)


### PR DESCRIPTION
When building with gdc alongside the linker flag -Wl,--as-needed the build fails with unresolved symbol errors. dmd and ldc2 are not affected since they internally pass the generated object file before other linker flags.

This also matches the standard GNU make rules.