### PR TITLE
Fix Bug #3276: Fix implementation of 'write_xattr_data' to support FreeBSD

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -27,6 +27,7 @@ artix
 ASCIIHTML
 ASpurious
 AThings
+attrnamespace
 aufxw
 aur
 autoclean
@@ -113,6 +114,7 @@ eselect
 estr
 eventfd
 evt
+extattr
 fasynchronous
 fbc
 fcf

--- a/src/xattr.d
+++ b/src/xattr.d
@@ -8,23 +8,88 @@ import core.stdc.stdio;
 import std.string;
 import std.conv;
 
-extern (C) {
-    int setxattr(const(char)* path, const(char)* name, const(void)* value, size_t size, int flags);
-    ssize_t getxattr(const(char)* path, const(char)* name, void* value, size_t size);
-}
-
 class XAttrException : Exception {
     this(string message) {
         super(message);
     }
 }
 
+version (Linux) {
+    // Linux specific imports and C bindings
+    extern (C) {
+        int setxattr(const(char)* path, const(char)* name, const(void)* value, size_t size, int flags);
+        ssize_t getxattr(const(char)* path, const(char)* name, void* value, size_t size);
+        int removexattr(const(char)* path, const(char)* name);
+    }
+
+    // Define xattr flags for Linux
+    enum XATTR_FLAGS : int {
+        XATTR_CREATE = 0x1, // Set attribute only if it doesn't exist.
+        XATTR_REPLACE = 0x2 // Set attribute only if it already exists.
+    }
+} else { // Define even if not Linux
+    enum XATTR_FLAGS : int {
+        XATTR_CREATE = 0,
+        XATTR_REPLACE = 0
+    }
+}
+
+version (FreeBSD) {
+    // FreeBSD specific imports and C bindings
+    extern (C) {
+        // From <sys/extattr.h>
+        int extattr_get_file(const(char)* path, int attrnamespace, const(char)* attrname, void* data, size_t nbytes);
+        int extattr_set_file(const(char)* path, int attrnamespace, const(char)* attrname, const(void)* data, size_t nbytes);
+        int extattr_delete_file(const(char)* path, int attrnamespace, const(char)* attrname);
+        int extattr_list_file(const(char)* path, int attrnamespace, void* data, size_t nbytes);
+
+        // Define extattr namespaces for FreeBSD
+        enum EXTATTR_NAMESPACE : int {
+            EXTATTR_NAMESPACE_USER = 0x0001,
+            EXTATTR_NAMESPACE_SYSTEM = 0x0002
+        }
+    }
+
+    // FreeBSD: Helper function to get the size of an attribute
+    ssize_t extattr_get_size(const(char)* path, int attrnamespace, const(char)* attrname) {
+        int result = extattr_get_file(path, attrnamespace, attrname, null, 0);
+        if (result == -1) {
+            return -1;
+        }
+        return cast(ssize_t)result;
+    }
+} else { // Define even if not FreeBSD
+    enum EXTATTR_NAMESPACE : int {
+        EXTATTR_NAMESPACE_USER = 0,
+        EXTATTR_NAMESPACE_SYSTEM = 0
+    }
+}
+
 // Sets an extended attribute for a given file.
 // Throws `XAttrException` on failure.
-void setXAttr(string filePath, string attrName, string attrValue) {
-    int result = setxattr(filePath.toStringz(), attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length, 0);
-    if (result != 0) {
-        throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+void setXAttr(string filePath, string attrName, string attrValue, int flags = 0) { // Added flags with default
+    version (Linux) {
+        int result = setxattr(filePath.toStringz(), attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length, flags);
+        if (result != 0) {
+            throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+    } else version (FreeBSD) {
+        int result;
+        if (flags & XATTR_FLAGS.XATTR_CREATE) { // Mimic XATTR_CREATE
+            if (extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz()) >= 0) {
+                throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': Attribute already exists");
+            }
+        } else if (flags & XATTR_FLAGS.XATTR_REPLACE) { // Mimic XATTR_REPLACE
+            if (extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz()) < 0) {
+                throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': Attribute does not exist");
+            }
+        }
+        result = extattr_set_file(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length);
+        if (result != 0) {
+            throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+    } else {
+        throw new XAttrException("Extended attributes not supported on this OS.");
     }
 }
 
@@ -32,20 +97,41 @@ void setXAttr(string filePath, string attrName, string attrValue) {
 // Returns the attribute value as a string.
 // Throws `XAttrException` if the attribute cannot be read.
 string getXAttr(string filePath, string attrName) {
-    // First, determine the required buffer size
-    ssize_t size = getxattr(filePath.toStringz(), attrName.toStringz(), null, 0);
-    if (size == -1) {
-        throw new XAttrException("Failed to determine xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+    version (Linux) {
+        // First, determine the required buffer size
+        ssize_t size = getxattr(filePath.toStringz(), attrName.toStringz(), null, 0);
+        if (size == -1) {
+            throw new XAttrException("Failed to determine xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+
+        // Allocate buffer
+        char[] buffer = new char[size];
+
+        // Read the attribute value
+        ssize_t result = getxattr(filePath.toStringz(), attrName.toStringz(), cast(void*)buffer.ptr, buffer.length);
+        if (result == -1) {
+            throw new XAttrException("Failed to read xattr '" ~ attrName ~ "' from '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+
+        return buffer[0 .. result].idup;
+    } else version (FreeBSD) {
+        // FreeBSD: Determine the required buffer size
+        ssize_t size = extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz());
+        if (size == -1) {
+            throw new XAttrException("Failed to determine xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+
+        // Allocate buffer
+        char[] buffer = new char[cast(size_t)size];
+
+        // Read the attribute value
+        int result = extattr_get_file(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz(), cast(void*)buffer.ptr, cast(size_t)size);
+        if (result == -1) {
+            throw new XAttrException("Failed to read xattr '" ~ attrName ~ "' from '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        }
+
+        return buffer[0 .. result].idup;
+    } else {
+        throw new XAttrException("Extended attributes not supported on this OS.");
     }
-
-    // Allocate buffer
-    char[] buffer = new char[size];
-
-    // Read the attribute value
-    ssize_t result = getxattr(filePath.toStringz(), attrName.toStringz(), cast(void*)buffer.ptr, buffer.length);
-    if (result == -1) {
-        throw new XAttrException("Failed to read xattr '" ~ attrName ~ "' from '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
-    }
-
-    return buffer[0 .. result].idup;
 }

--- a/src/xattr.d
+++ b/src/xattr.d
@@ -8,130 +8,82 @@ import core.stdc.stdio;
 import std.string;
 import std.conv;
 
+version (linux) {
+    extern (C) {
+        int setxattr(const(char)* path, const(char)* name, const(void)* value, size_t size, int flags);
+        ssize_t getxattr(const(char)* path, const(char)* name, void* value, size_t size);
+    }
+}
+
+version (FreeBSD) {
+    extern (C) {
+        int extattr_set_file(const(char)* path, int attrnamespace, const(char)* name, const(void)* value, size_t size);
+        ssize_t extattr_get_file(const(char)* path, int attrnamespace, const(char)* name, void* value, size_t size);
+    }
+
+    enum EXTATTR_NAMESPACE_USER = 1;
+}
+
 class XAttrException : Exception {
     this(string message) {
         super(message);
     }
 }
 
-version (Linux) {
-    // Linux specific imports and C bindings
-    extern (C) {
-        int setxattr(const(char)* path, const(char)* name, const(void)* value, size_t size, int flags);
-        ssize_t getxattr(const(char)* path, const(char)* name, void* value, size_t size);
-        int removexattr(const(char)* path, const(char)* name);
-    }
-
-    // Define xattr flags for Linux
-    enum XATTR_FLAGS : int {
-        XATTR_CREATE = 0x1, // Set attribute only if it doesn't exist.
-        XATTR_REPLACE = 0x2 // Set attribute only if it already exists.
-    }
-} else { // Define even if not Linux
-    enum XATTR_FLAGS : int {
-        XATTR_CREATE = 0,
-        XATTR_REPLACE = 0
-    }
-}
-
-version (FreeBSD) {
-    // FreeBSD specific imports and C bindings
-    extern (C) {
-        // From <sys/extattr.h>
-        int extattr_get_file(const(char)* path, int attrnamespace, const(char)* attrname, void* data, size_t nbytes);
-        int extattr_set_file(const(char)* path, int attrnamespace, const(char)* attrname, const(void)* data, size_t nbytes);
-        int extattr_delete_file(const(char)* path, int attrnamespace, const(char)* attrname);
-        int extattr_list_file(const(char)* path, int attrnamespace, void* data, size_t nbytes);
-
-        // Define extattr namespaces for FreeBSD
-        enum EXTATTR_NAMESPACE : int {
-            EXTATTR_NAMESPACE_USER = 0x0001,
-            EXTATTR_NAMESPACE_SYSTEM = 0x0002
-        }
-    }
-
-    // FreeBSD: Helper function to get the size of an attribute
-    ssize_t extattr_get_size(const(char)* path, int attrnamespace, const(char)* attrname) {
-        int result = extattr_get_file(path, attrnamespace, attrname, null, 0);
-        if (result == -1) {
-            return -1;
-        }
-        return cast(ssize_t)result;
-    }
-} else { // Define even if not FreeBSD
-    enum EXTATTR_NAMESPACE : int {
-        EXTATTR_NAMESPACE_USER = 0,
-        EXTATTR_NAMESPACE_SYSTEM = 0
-    }
-}
-
 // Sets an extended attribute for a given file.
 // Throws `XAttrException` on failure.
-void setXAttr(string filePath, string attrName, string attrValue, int flags = 0) { // Added flags with default
-    version (Linux) {
-        int result = setxattr(filePath.toStringz(), attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length, flags);
+void setXAttr(string filePath, string attrName, string attrValue) {
+    version (linux) {
+        int result = setxattr(filePath.toStringz(), attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length, 0);
         if (result != 0) {
             throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
     } else version (FreeBSD) {
-        int result;
-        if (flags & XATTR_FLAGS.XATTR_CREATE) { // Mimic XATTR_CREATE
-            if (extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz()) >= 0) {
-                throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': Attribute already exists");
-            }
-        } else if (flags & XATTR_FLAGS.XATTR_REPLACE) { // Mimic XATTR_REPLACE
-            if (extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz()) < 0) {
-                throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': Attribute does not exist");
-            }
-        }
-        result = extattr_set_file(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length);
-        if (result != 0) {
+        int result = extattr_set_file(filePath.toStringz(), EXTATTR_NAMESPACE_USER, attrName.toStringz(), cast(const(void)*)attrValue.ptr, attrValue.length);
+        if (result < 0) {
             throw new XAttrException("Failed to set xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
     } else {
-        throw new XAttrException("Extended attributes not supported on this OS.");
+        throw new XAttrException("xattr not supported on this platform");
     }
 }
 
 // Retrieves an extended attribute value from a file.
-// Returns the attribute value as a string.
-// Throws `XAttrException` if the attribute cannot be read.
+// Returns the attribute value as a string or throws `XAttrException` on failure.
 string getXAttr(string filePath, string attrName) {
-    version (Linux) {
-        // First, determine the required buffer size
+    version (linux) {
+        // First, determine the size of the attribute value
         ssize_t size = getxattr(filePath.toStringz(), attrName.toStringz(), null, 0);
-        if (size == -1) {
-            throw new XAttrException("Failed to determine xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        if (size < 0) {
+            throw new XAttrException("Failed to get xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
 
-        // Allocate buffer
-        char[] buffer = new char[size];
+        void* buffer = malloc(size);
+        scope(exit) free(buffer);
 
-        // Read the attribute value
-        ssize_t result = getxattr(filePath.toStringz(), attrName.toStringz(), cast(void*)buffer.ptr, buffer.length);
-        if (result == -1) {
-            throw new XAttrException("Failed to read xattr '" ~ attrName ~ "' from '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        ssize_t ret = getxattr(filePath.toStringz(), attrName.toStringz(), buffer, cast(size_t)size);
+        if (ret < 0) {
+            throw new XAttrException("Failed to get xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
 
-        return buffer[0 .. result].idup;
+        return cast(string)(buffer[0 .. size]);
     } else version (FreeBSD) {
-        // FreeBSD: Determine the required buffer size
-        ssize_t size = extattr_get_size(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz());
-        if (size == -1) {
-            throw new XAttrException("Failed to determine xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        // First, determine the size
+        ssize_t size = extattr_get_file(filePath.toStringz(), EXTATTR_NAMESPACE_USER, attrName.toStringz(), null, 0);
+        if (size < 0) {
+            throw new XAttrException("Failed to get xattr size for '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
 
-        // Allocate buffer
-        char[] buffer = new char[cast(size_t)size];
+        void* buffer = malloc(size);
+        scope(exit) free(buffer);
 
-        // Read the attribute value
-        int result = extattr_get_file(filePath.toStringz(), EXTATTR_NAMESPACE.EXTATTR_NAMESPACE_USER, attrName.toStringz(), cast(void*)buffer.ptr, cast(size_t)size);
-        if (result == -1) {
-            throw new XAttrException("Failed to read xattr '" ~ attrName ~ "' from '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
+        ssize_t ret = extattr_get_file(filePath.toStringz(), EXTATTR_NAMESPACE_USER, attrName.toStringz(), buffer, cast(size_t)size);
+        if (ret < 0) {
+            throw new XAttrException("Failed to get xattr '" ~ attrName ~ "' on '" ~ filePath ~ "': " ~ to!string(strerror(errno)));
         }
 
-        return buffer[0 .. result].idup;
+        return cast(string)(buffer[0 .. size]);
     } else {
-        throw new XAttrException("Extended attributes not supported on this OS.");
+        throw new XAttrException("xattr not supported on this platform");
     }
 }


### PR DESCRIPTION


* Fix implementation of 'write_xattr_data' to support FreeBSD to resolve compilation failure