### PR TITLE
Fix UTC conversion for existing file timestamp post file download

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -1760,8 +1760,10 @@ void setLocalPathTimestamp(bool dryRun, string inputPath, SysTime newTimeStamp) 
 			// Compare the requested new modified timestamp to existing local modified timestamp
 			SysTime newTimeStampZeroFracSec = newTimeStamp;
 			SysTime existingTimeStampZeroFracSec = existingModificationTime;
+			// Convert timestamps to UTC
 			newTimeStampZeroFracSec = newTimeStampZeroFracSec.toUTC();
-			existingTimeStampZeroFracSec = newTimeStampZeroFracSec.toUTC();
+			existingTimeStampZeroFracSec = existingTimeStampZeroFracSec.toUTC();
+			// Drop fractional seconds on both
 			newTimeStampZeroFracSec.fracSecs = Duration.zero;
 			existingTimeStampZeroFracSec.fracSecs = Duration.zero;
 			


### PR DESCRIPTION
* Fix UTC conversion for existing file timestamp post file download due to bug introduced via https://github.com/abraunegg/onedrive/pull/3256/files#diff-3d0d233780406e4f1b1c07c79cdd189b98570ce886995af58a2ce3ed802e551e