### PR TITLE
Ensure file is closed before renaming to improve compatibility with GCS buckets and network filesystems

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -465,6 +465,11 @@ class CurlEngine {
 		
 		http.perform();
 		
+		// close open file - avoids problems with renaming on GCS Buckets and other semi-POSIX systems
+		if (file.isOpen()){
+			file.close();
+		}
+		
 		// Rename downloaded file
 		rename(downloadFilename, originalFilename);
 


### PR DESCRIPTION
Some filesystems (e.g. GCS FUSE, Samba, NFS) may fail or behave unpredictably when attempting to rename an open file. This update explicitly closes the file before calling rename(), ensuring cross-platform and cloud storage compatibility. The original scope(exit) remains as a fallback to guarantee cleanup.

Source: https://github.com/Wave1art/onedrive/commit/d5d7fb90cc537e520e5e203a9ed8ff263a4d4abf

Attributed to: @Wave1art