### PR TITLE
Fix setting of xattr values if file fails to download

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -3942,9 +3942,11 @@ class SyncEngine {
 				lastModifiedBy = "Unknown";
 			}
 			
-			// Set the xattr values
-			setXAttr(filePath, "user.onedrive.createdBy", createdBy);
-			setXAttr(filePath, "user.onedrive.lastModifiedBy", lastModifiedBy);
+			// Set the xattr values, file must exist to set these values
+			if (exists(filePath)) {
+				setXAttr(filePath, "user.onedrive.createdBy", createdBy);
+				setXAttr(filePath, "user.onedrive.lastModifiedBy", lastModifiedBy);
+			}
 		}
 		
 		// Display function processing time if configured to do so


### PR DESCRIPTION
* If a file fails to download, path fails to exist. Check path existence before setting xattr values