### PR TITLE
Add SSL Certificate Verify Peer workaround

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -424,6 +424,7 @@ userns
 userpass
 usl
 valgrind
+verifypeer
 vti
 wal
 websockets

--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -540,6 +540,45 @@ class CurlEngine {
 		// Return free memory to the OS
 		GC.minimize();
 	}
+	
+	// Disable SSL certificate peer verification for libcurl operations.
+	//
+	// This function disables the verification of the SSL peer's certificate
+	// by setting CURLOPT_SSL_VERIFYPEER to 0. This means that libcurl will
+	// accept any certificate presented by the server, regardless of whether
+	// it is signed by a trusted certificate authority.
+	//
+	// -------------------------------------------------------------------------------------
+	// WARNING: Disabling SSL peer verification introduces significant security risks:
+	// -------------------------------------------------------------------------------------
+	// - Man-in-the-Middle (MITM) attacks become trivially possible.
+	// - Malicious servers can impersonate trusted endpoints.
+	// - Confidential data (authentication tokens, file contents) can be intercepted.
+	// - Violates industry security standards and regulatory compliance requirements.
+	// - Should never be used in production environments or on untrusted networks.
+	//
+	// This option should only be enabled for internal testing, debugging self-signed
+	// certificates, or explicitly controlled environments with known risks.
+	//
+	// See also:
+	// https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html
+	void setDisableSSLVerifyPeer() {
+		// Emit a runtime warning if debug logging is enabled
+		if (debugLogging) {
+			addLogEntry("WARNING: SSL peer verification has been DISABLED!", ["debug"]);
+			addLogEntry("         This allows invalid or self-signed certificates to be accepted.", ["debug"]);
+			addLogEntry("         Use ONLY for testing. This severely weakens HTTPS security.", ["debug"]);
+		}
+
+		// Disable SSL certificate verification (DANGEROUS)
+		http.handle.set(CurlOption.ssl_verifypeer, 0);
+	}
+	
+	// Enable SSL Certificate Verification
+	void setEnableSSLVerifyPeer() {
+		// Enable SSL certificate verification
+		http.handle.set(CurlOption.ssl_verifypeer, 1);
+	}
 }
 
 // Methods to control obtaining and releasing a CurlEngine instance from the curlEnginePool

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1687,8 +1687,9 @@ class OneDriveApi {
 						//  https://stackoverflow.com/questions/45829588/brew-install-fails-curl77-error-setting-certificate-verify
 						//  https://forum.dlang.org/post/vwvkbubufexgeuaxhqfl@forum.dlang.org
 						
-						addLogEntry("Problem with reading the local SSL CA cert via libcurl - please repair your system SSL CA Certificates");
-						throw new OneDriveError("OneDrive operation encountered an issue with libcurl reading the local SSL CA Certificates");
+						string sslCertReadErrorMessage = "System SSL CA certificates are missing or unreadable by libcurl – please ensure the correct CA bundle is installed and is accessible.";
+						addLogEntry("ERROR: " ~ sslCertReadErrorMessage);
+						throw new OneDriveError(sslCertReadErrorMessage);
 					} else {
 						// Was this a curl initialization error?
 						if (canFind(errorMessage, "Failed initialization on handle")) {
@@ -1819,7 +1820,7 @@ class OneDriveApi {
 					forceExit();
 				} else {
 					// Catch the SSL error
-					addLogEntry("Attempting a work around to disable SSL Peer Validation due to SSL is passing back a bad value due to 'stdio' compile time option");
+					addLogEntry("Attempting a work around to disable SSL Peer Validation due to SSL passing back a bad value due to 'stdio' compile time option");
 					sslVerifyPeerDisabled = true;
 					curlEngine.setDisableSSLVerifyPeer();
 				}


### PR DESCRIPTION
* Bring forward from v.2.5.0 alpha codebase setDisableSSLVerifyPeer() and setEnableSSLVerifyPeer() as a workaround to SSL certificate read issues on Debian 12