### PR TITLE
Fix bug that 'items-dryrun.sqlite3' gets erroneously created when running a 'no sync' operation

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -427,33 +427,30 @@ int main(string[] cliArgs) {
 	// If this has been requested, we need to ensure that all actions are performed against the dry-run database copy, and, 
 	// no actual action takes place - such as deleting files if deleted online, moving files if moved online or local, downloading new & changed files, uploading new & changed files
 	if (dryRun || (noSyncTaskOperationRequested)) {
+		// Cleanup any existing dry-run elements ... these should never be left hanging around and should be cleaned up first
+		cleanupDatabaseFiles(appConfig.databaseFilePathDryRun);
+		
 		// If --dry-run
 		if (dryRun) {
 			// This is a --dry-run operation
 			addLogEntry("DRY-RUN Configured. Output below shows what 'would' have occurred.");
-		} 
-		
-		// Cleanup any existing dry-run elements ... these should never be left hanging around and should be cleaned up first
-		cleanupDatabaseFiles(appConfig.databaseFilePathDryRun);
-		
-		// Make a copy of the original items.sqlite3 for use as the dry run copy if it exists
-		if (exists(appConfig.databaseFilePath)) {
-			// In a --dry-run --resync scenario, we should not copy the existing database file
-			if (!appConfig.getValueBool("resync")) {
-				// Copy the existing DB file to the dry-run copy
-				if (dryRun) {
+		 
+			// Make a copy of the original items.sqlite3 for use as the dry run copy if it exists
+			if (exists(appConfig.databaseFilePath)) {
+				// In a --dry-run --resync scenario, we should not copy the existing database file
+				if (!appConfig.getValueBool("resync")) {
+					// Copy the existing DB file to the dry-run copy
 					addLogEntry("DRY-RUN: Copying items.sqlite3 to items-dryrun.sqlite3 to use for dry run operations");
-				}
-				copy(appConfig.databaseFilePath,appConfig.databaseFilePathDryRun);
-			} else {
-				// No database copy due to --resync
-				if (dryRun) {
+					copy(appConfig.databaseFilePath,appConfig.databaseFilePathDryRun);
+				} else {
+					// No database copy due to --resync - an empty DB file will be used for the resync operation
 					addLogEntry("DRY-RUN: No database copy created for --dry-run due to --resync also being used");
 				}
 			}
+			
+			// update runtimeDatabaseFile now that we are using the dry run path
+			runtimeDatabaseFile = appConfig.databaseFilePathDryRun;
 		}
-		// update runtimeDatabaseFile now that we are using the dry run path
-		runtimeDatabaseFile = appConfig.databaseFilePathDryRun;
 	} else {
 		// Cleanup any existing dry-run elements ... these should never be left hanging around
 		cleanupDatabaseFiles(appConfig.databaseFilePathDryRun);


### PR DESCRIPTION
* Fix bug that 'items-dryrun.sqlite3' gets erroneously created when running a 'no sync' operation task such as --logout