### PR TITLE
Fix Bug #3355: Fix that long running big upload (250GB+) fails because of an expired access token

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -445,6 +445,7 @@ systemdsystemunitdir
 systemduserunitdir
 tbh
 tdcockers
+tempauth
 templ
 testbuild
 Thh

--- a/config
+++ b/config
@@ -76,6 +76,9 @@
 ## This setting controls the application logging all actions to a separate file.
 #enable_logging = "false"
 
+## This setting controls the file fragment size when uploading large files to Microsoft OneDrive. 
+#file_fragment_size = "10"
+
 ## This setting controls the application HTTP protocol version, downgrading to HTTP/1.1 when enabled.
 #force_http_11 = "false"
 

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -178,7 +178,7 @@ fi
 if [ -n "${ONEDRIVE_FILE_FRAGMENT_SIZE:=""}" ]; then
 	echo "# We are specifying the file fragment size for large file uploads (in MB)"
 	echo "# Adding --file-fragment-size ARG"
-	ARGS=(--file-fragment-size \"${ONEDRIVE_FILE_FRAGMENT_SIZE}\" ${ARGS[@]})
+	ARGS=(--file-fragment-size ${ONEDRIVE_FILE_FRAGMENT_SIZE} ${ARGS[@]})
 fi
 
 if [ ${#} -gt 0 ]; then

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -174,6 +174,13 @@ if [ "${ONEDRIVE_SYNC_SHARED_FILES:=0}" == "1" ]; then
 	ARGS=(--sync-shared-files ${ARGS[@]})
 fi
 
+# Tell client to use a different value for file fragment size for large file uploads
+if [ -n "${ONEDRIVE_FILE_FRAGMENT_SIZE:=""}" ]; then
+	echo "# We are specifying the file fragment size for large file uploads (in MB)"
+	echo "# Adding --file-fragment-size ARG"
+	ARGS=(--file-fragment-size \"${ONEDRIVE_FILE_FRAGMENT_SIZE}\" ${ARGS[@]})
+fi
+
 if [ ${#} -gt 0 ]; then
 	ARGS=("${@}")
 fi

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -29,6 +29,7 @@ Before reading this document, please ensure you are running application version 
   - [drive_id](#drive_id)
   - [dry_run](#dry_run)
   - [enable_logging](#enable_logging)
+  - [file_fragment_size](#file_fragment_size)
   - [force_http_11](#force_http_11)
   - [force_session_upload](#force_session_upload)
   - [inotify_delay](#inotify_delay)
@@ -411,6 +412,20 @@ _**CLI Option Use:**_ `--enable-logging`
 
 > [!IMPORTANT]
 > Additional configuration is potentially required to configure the default log directory. Refer to the [Enabling the Client Activity Log](./usage.md#enabling-the-client-activity-log) section in usage.md for details
+
+### file_fragment_size
+_**Description:**_ This option controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB.
+
+_**Value Type:**_ Integer
+
+_**Default Value:**_ 10
+
+_**Maximum Value:**_ 55
+
+_**Config Example:**_ `file_fragment_size = "25"`
+
+_**CLI Option Use:**_ *None - this is a config file option only*
+
 
 ### force_http_11
 _**Description:**_ This setting controls the application HTTP protocol version. By default, the application will use libcurl defaults for which HTTP protocol version will be used to interact with Microsoft OneDrive. Use this setting to downgrade libcurl to only use HTTP/1.1.
@@ -870,6 +885,10 @@ _**Default Value:**_ 0 (all files, regardless of size, are synced)
 _**Config Example:**_ `skip_size = "50"`
 
 _**CLI Option Use:**_ `--skip-size '50'`
+
+> [!NOTE]
+> This option is considered a 'Client Side Filtering Rule' and if configured, is utilised for all sync operations. After changing this option, you will be required to perform a resync.
+
 
 ### skip_symlinks
 _**Description:**_ This configuration option controls whether the application will skip all symbolic links when performing sync operations. Microsoft OneDrive has no concept or understanding of symbolic links, and attempting to upload a symbolic link to Microsoft OneDrive generates a platform API error. All data (files and folders) that are uploaded to OneDrive must be whole files or actual directories.

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -424,7 +424,7 @@ _**Maximum Value:**_ 55
 
 _**Config Example:**_ `file_fragment_size = "25"`
 
-_**CLI Option Use:**_ *None - this is a config file option only*
+_**CLI Option Use:**_ `--file-fragment-size = '25'`
 
 
 ### force_http_11

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -420,7 +420,7 @@ _**Value Type:**_ Integer
 
 _**Default Value:**_ 10
 
-_**Maximum Value:**_ 55
+_**Maximum Value:**_ 60
 
 _**Config Example:**_ `file_fragment_size = "25"`
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -290,6 +290,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
+| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 55 | 25 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -290,7 +290,7 @@ docker run $firstRun --restart unless-stopped --name onedrive -v onedrive_conf:/
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
-| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 55 | 25 |
+| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 60 | 25 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -305,7 +305,7 @@ podman run -it --name onedrive_work --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" \
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
-| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 55 | 25 |
+| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 60 | 25 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -305,6 +305,7 @@ podman run -it --name onedrive_work --user "${ONEDRIVE_UID}:${ONEDRIVE_GID}" \
 | <B>ONEDRIVE_SYNC_SHARED_FILES</B> | Controls "--sync-shared-files" option. Default is 0 | 1 |
 | <B>ONEDRIVE_RUNAS_ROOT</B> | Controls if the Docker container should be run as the 'root' user instead of 'onedrive' user. Default is 0 | 1 |
 | <B>ONEDRIVE_SYNC_ONCE</B> | Controls if the Docker container should be run in Standalone Mode. It will use Monitor Mode otherwise. Default is 0 | 1 |
+| <B>ONEDRIVE_FILE_FRAGMENT_SIZE</B> | Controls the fragment size when uploading large files to Microsoft OneDrive. The value specified is in MB. Default is 10, Limit is 55 | 25 |
 
 ### Environment Variables Usage Examples
 **Verbose Output:**

--- a/onedrive.1.in
+++ b/onedrive.1.in
@@ -205,6 +205,10 @@ Perform a trial sync with no changes made.
 Enable client activity to a separate log file.
 
 .TP
+\fB\-\-file-fragment-size\fR
+Specify the file fragment size for large file uploads (in MB).
+
+.TP
 \fB\-\-force\fR
 Force the deletion of data when a 'big delete' is detected.
 

--- a/src/config.d
+++ b/src/config.d
@@ -48,6 +48,7 @@ class ApplicationConfig {
 	immutable string defaultBusinessSharedFilesDirectoryName = "Files Shared With Me";
 	// - Default file fragment size for uploads
 	immutable long defaultFileFragmentSize = 10;
+	immutable long defaultMaxFileFragmentSize = 55;
 	
 	// Microsoft Requirements 
 	// - Default Application ID (abraunegg)
@@ -1053,9 +1054,9 @@ class ApplicationConfig {
 						tempValue = defaultFileFragmentSize;
 					}
 					// Enforce upper bound (safe maximum)
-					else if (tempValue > 55) {
+					else if (tempValue > defaultMaxFileFragmentSize) {
 						addLogEntry("Invalid value for key in config file (too high) - using maximum safe value: " ~ key);
-						tempValue = 55;
+						tempValue = defaultMaxFileFragmentSize;
 					}
 					setValueLong("file_fragment_size", tempValue);
 				}
@@ -1445,9 +1446,9 @@ class ApplicationConfig {
 				setValueLong("file_fragment_size", defaultFileFragmentSize);
 			}
 			// Enforce upper bound (safe maximum) for 'file_fragment_size'
-			if (getValueLong("file_fragment_size") > 55) {
-				addLogEntry("Invalid value for --file-fragment-size (too high) - using maximum safe value: 55");
-				setValueLong("file_fragment_size", 55);
+			if (getValueLong("file_fragment_size") > defaultMaxFileFragmentSize) {
+				addLogEntry("Invalid value for --file-fragment-size (too high) - using maximum safe value: " ~ to!string(defaultMaxFileFragmentSize));
+				setValueLong("file_fragment_size", defaultMaxFileFragmentSize);
 			}
 			
 			// Was --auth-files used?

--- a/src/config.d
+++ b/src/config.d
@@ -1057,7 +1057,6 @@ class ApplicationConfig {
 						addLogEntry("Invalid value for key in config file (too high) - using maximum safe value: " ~ key);
 						tempValue = 55;
 					}
-					
 					setValueLong("file_fragment_size", tempValue);
 				}
 			} else {

--- a/src/config.d
+++ b/src/config.d
@@ -1615,6 +1615,7 @@ class ApplicationConfig {
 		addLogEntry("Config option 'inotify_delay'                = " ~ to!string(getValueLong("inotify_delay")));
 		addLogEntry("Config option 'display_transfer_metrics'     = " ~ to!string(getValueBool("display_transfer_metrics")));
 		addLogEntry("Config option 'force_session_upload'         = " ~ to!string(getValueBool("force_session_upload")));
+		addLogEntry("Config option 'file_fragment_size'           = " ~ to!string(getValueLong("file_fragment_size")));
 		
 		// data integrity
 		addLogEntry("Config option 'classify_as_big_delete'       = " ~ to!string(getValueLong("classify_as_big_delete")));

--- a/src/config.d
+++ b/src/config.d
@@ -48,7 +48,7 @@ class ApplicationConfig {
 	immutable string defaultBusinessSharedFilesDirectoryName = "Files Shared With Me";
 	// - Default file fragment size for uploads
 	immutable long defaultFileFragmentSize = 10;
-	immutable long defaultMaxFileFragmentSize = 59;
+	immutable long defaultMaxFileFragmentSize = 60;
 	
 	// Microsoft Requirements 
 	// - Default Application ID (abraunegg)

--- a/src/config.d
+++ b/src/config.d
@@ -1048,7 +1048,7 @@ class ApplicationConfig {
 					ulong tempValue = thisConfigValue;
 					// If set, this must be greater than the default, but also aligning to Microsoft upper limit of 60 MiB
 					// Enforce lower bound (must be greater than default)
-					if (tempValue <= defaultFileFragmentSize) {
+					if (tempValue < defaultFileFragmentSize) {
 						addLogEntry("Invalid value for key in config file (too low) - using default value: " ~ key);
 						tempValue = defaultFileFragmentSize;
 					}
@@ -1156,25 +1156,25 @@ class ApplicationConfig {
 				std.getopt.config.bundling,
 				std.getopt.config.caseSensitive,
 				"auth-files",
-					"Perform authentication not via interactive dialog but via files read/writes to these files.",
+					"Perform authentication not via interactive dialog but via files read/writes to these files",
 					&stringValues["auth_files"],
 				"auth-response",
-					"Perform authentication not via interactive dialog but via providing the response url directly.",
+					"Perform authentication not via interactive dialog but via providing the response url directly",
 					&stringValues["auth_response"],
 				"check-for-nomount",
-					"Check for the presence of .nosync in the syncdir root. If found, do not perform sync.",
+					"Check for the presence of .nosync in the syncdir root. If found, do not perform sync",
 					&boolValues["check_nomount"],
 				"check-for-nosync",
-					"Check for the presence of .nosync in each directory. If found, skip directory from sync.",
+					"Check for the presence of .nosync in each directory. If found, skip directory from sync",
 					&boolValues["check_nosync"],
 				"classify-as-big-delete",
 					"Number of children in a path that is locally removed which will be classified as a 'big data delete'",
 					&longValues["classify_as_big_delete"],
 				"cleanup-local-files",
-					"Cleanup additional local files when using --download-only. This will remove local data.",
+					"Cleanup additional local files when using --download-only. This will remove local data",
 					&boolValues["cleanup_local_files"],	
 				"create-directory",
-					"Create a directory on OneDrive - no sync will be performed.",
+					"Create a directory on OneDrive - no sync will be performed",
 					&stringValues["create_directory"],
 				"create-share-link",
 					"Create a shareable link for an existing file on OneDrive",
@@ -1183,10 +1183,10 @@ class ApplicationConfig {
 					"Debug OneDrive HTTPS communication.",
 					&boolValues["debug_https"],
 				"destination-directory",
-					"Destination directory for renamed or move on OneDrive - no sync will be performed.",
+					"Destination directory for renamed or move on OneDrive - no sync will be performed",
 					&stringValues["destination_directory"],
 				"disable-notifications",
-					"Do not use desktop notifications in monitor mode.",
+					"Do not use desktop notifications in monitor mode",
 					&boolValues["disable_notifications"],
 				"disable-download-validation",
 					"Disable download validation when downloading from OneDrive",
@@ -1195,19 +1195,19 @@ class ApplicationConfig {
 					"Disable upload validation when uploading to OneDrive",
 					&boolValues["disable_upload_validation"],
 				"display-config",
-					"Display what options the client will use as currently configured - no sync will be performed.",
+					"Display what options the client will use as currently configured - no sync will be performed",
 					&boolValues["display_config"],
 				"display-running-config",
-					"Display what options the client has been configured to use on application startup.",
+					"Display what options the client has been configured to use on application startup",
 					&boolValues["display_running_config"],
 				"display-sync-status",
-					"Display the sync status of the client - no sync will be performed.",
+					"Display the sync status of the client - no sync will be performed",
 					&boolValues["display_sync_status"],
 				"display-quota",
-					"Display the quota status of the client - no sync will be performed.",
+					"Display the quota status of the client - no sync will be performed",
 					&boolValues["display_quota"],
 				"download-only",
-					"Replicate the OneDrive online state locally, by only downloading changes from OneDrive. Do not upload local changes to OneDrive.",
+					"Replicate the OneDrive online state locally, by only downloading changes from OneDrive. Do not upload local changes to OneDrive",
 					&boolValues["download_only"],
 				"dry-run",
 					"Perform a trial sync with no changes made",
@@ -1215,6 +1215,9 @@ class ApplicationConfig {
 				"enable-logging",
 					"Enable client activity to a separate log file",
 					&boolValues["enable_logging"],
+				"file-fragment-size",
+					"Specify the file fragment size for large file uploads (in MB)",
+					&longValues["file_fragment_size"],
 				"force-http-11",
 					"Force the use of HTTP 1.1 for all operations",
 					&boolValues["force_http_11"],
@@ -1240,10 +1243,10 @@ class ApplicationConfig {
 					"Sync OneDrive Business Shared Files to the local filesystem",
 					&boolValues["sync_business_shared_files"],
 				"local-first",
-					"Synchronize from the local directory source first, before downloading changes from OneDrive.",
+					"Synchronize from the local directory source first, before downloading changes from OneDrive",
 					&boolValues["local_first"],
 				"log-dir",
-					"Directory where logging output is saved to, needs to end with a slash.",
+					"Directory where logging output is saved to, needs to end with a slash",
 					&stringValues["log_dir"],
 				"logout",
 					"Logout the current user",
@@ -1255,7 +1258,7 @@ class ApplicationConfig {
 					"Keep monitoring for local and remote changes",
 					&boolValues["monitor"],
 				"monitor-interval",
-					"Number of seconds by which each sync operation is undertaken when idle under monitor mode.",
+					"Number of seconds by which each sync operation is undertaken when idle under monitor mode",
 					&longValues["monitor_interval"],
 				"monitor-fullscan-frequency",
 					"Number of sync runs before performing a full local scan of the synced directory",
@@ -1279,13 +1282,13 @@ class ApplicationConfig {
 					"Approve the use of performing a --resync action",
 					&boolValues["resync_auth"],
 				"remove-directory",
-					"Remove a directory on OneDrive - no sync will be performed.",
+					"Remove a directory on OneDrive - no sync will be performed",
 					&stringValues["remove_directory"],
 				"remove-source-files",
 					"Remove source file after successful transfer to OneDrive when using --upload-only",
 					&boolValues["remove_source_files"],
 				"single-directory",
-					"Specify a single local directory within the OneDrive root to sync.",
+					"Specify a single local directory within the OneDrive root to sync",
 					&stringValues["single_directory"],
 				"skip-dot-files",
 					"Skip dot files and folders from syncing",
@@ -1306,7 +1309,7 @@ class ApplicationConfig {
 					"Skip syncing of symlinks",
 					&boolValues["skip_symlinks"],
 				"source-directory",
-					"Source directory to rename or move on OneDrive - no sync will be performed.",
+					"Source directory to rename or move on OneDrive - no sync will be performed",
 					&stringValues["source_directory"],
 				"space-reservation",
 					"The amount of disk space to reserve (in MB) to avoid 100% disk space utilisation",
@@ -1324,10 +1327,10 @@ class ApplicationConfig {
 					"Perform a synchronisation with Microsoft OneDrive (DEPRECATED)",
 					&boolValues["synchronize"],
 				"sync-root-files",
-					"Sync all files in sync_dir root when using sync_list.",
+					"Sync all files in sync_dir root when using sync_list",
 					&boolValues["sync_root_files"],
 				"upload-only",
-					"Replicate the locally configured sync_dir state to OneDrive, by only uploading local changes to OneDrive. Do not download changes from OneDrive.",
+					"Replicate the locally configured sync_dir state to OneDrive, by only uploading local changes to OneDrive. Do not download changes from OneDrive",
 					&boolValues["upload_only"],
 				"confdir",
 					"Set the directory used to store the configuration files",
@@ -1343,7 +1346,7 @@ class ApplicationConfig {
 					&boolValues["with_editing_perms"]
 			);
 			
-			// Was --syncdir used?
+			// Was --syncdir specified?
 			if (!getValueString("sync_dir_cli").empty) {
 				// Build the line we need to update and/or write out
 				string newConfigOptionSyncDirLine = "sync_dir = \"" ~ getValueString("sync_dir_cli") ~ "\"";
@@ -1429,10 +1432,22 @@ class ApplicationConfig {
 				setValueString("sync_dir", getValueString("sync_dir_cli"));
 			}
 			
-			// was --monitor-interval used and now set to a value below minimum requirement?
+			// Was --monitor-interval specified and now set to a value below minimum requirement?
 			if (getValueLong("monitor_interval") < 300 ) {
 				addLogEntry("Invalid value for --monitor-interval - using default value: 300");
 				setValueLong("monitor_interval", 300);
+			}
+			
+			// Was --file-fragment-size specified and now set to a value below or above maximum?
+			// Enforce lower bound (must be greater than default) for 'file_fragment_size'
+			if (getValueLong("file_fragment_size") < defaultFileFragmentSize) {
+				addLogEntry("Invalid value for --file-fragment-size (too low) - using default value: " ~ to!string(defaultFileFragmentSize));
+				setValueLong("file_fragment_size", defaultFileFragmentSize);
+			}
+			// Enforce upper bound (safe maximum) for 'file_fragment_size'
+			if (getValueLong("file_fragment_size") > 55) {
+				addLogEntry("Invalid value for --file-fragment-size (too high) - using maximum safe value: 55");
+				setValueLong("file_fragment_size", 55);
 			}
 			
 			// Was --auth-files used?

--- a/src/config.d
+++ b/src/config.d
@@ -288,6 +288,8 @@ class ApplicationConfig {
 		longValues["rate_limit"] = 0;
 		// - To ensure we do not fill up the load disk, how much disk space should be reserved by default
 		longValues["space_reservation"] = 50 * 2^^20; // 50 MB as Bytes
+		// - How large should our file fragments be when uploading as an 'upload session' ?
+		longValues["file_fragment_size"] = 10; // whole number, treated as MB, will be converted to bytes within performSessionFileUpload()
 		
 		// HTTPS & CURL Operation Settings
 		// - Maximum time an operation is allowed to take

--- a/src/config.d
+++ b/src/config.d
@@ -48,7 +48,7 @@ class ApplicationConfig {
 	immutable string defaultBusinessSharedFilesDirectoryName = "Files Shared With Me";
 	// - Default file fragment size for uploads
 	immutable long defaultFileFragmentSize = 10;
-	immutable long defaultMaxFileFragmentSize = 55;
+	immutable long defaultMaxFileFragmentSize = 59;
 	
 	// Microsoft Requirements 
 	// - Default Application ID (abraunegg)

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1004,8 +1004,7 @@ class OneDriveApi {
 		
 		string contentRange = "bytes " ~ to!string(offset) ~ "-" ~ to!string(offset + offsetSize - 1) ~ "/" ~ to!string(fileSize);
 		if (debugLogging) {
-			addLogEntry("", ["debug"]); // Add an empty newline before log output
-			addLogEntry("contentRange: " ~ contentRange, ["debug"]);
+			addLogEntry("fragment contentRange: " ~ contentRange, ["debug"]);
 		}
 
 		return put(uploadUrl, filepath, true, contentRange, offset, offsetSize);

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1324,10 +1324,10 @@ class OneDriveApi {
 	// Check if the existing access token has expired, if it has, generate a new one
 	private void checkAccessTokenExpired() {
 		if (Clock.currTime() >= appConfig.accessTokenExpiration) {
-			if (debugLogging) {addLogEntry("Microsoft OneDrive Access Token has expired. Must generate a new Microsoft OneDrive Access Token", ["debug"]);}
+			if (debugLogging) {addLogEntry("Microsoft OneDrive OAuth2 Access Token has expired. Must generate a new Microsoft OneDrive OAuth2 Access Token", ["debug"]);}
 			generateNewAccessToken();
 		} else {
-			if (debugLogging) {addLogEntry("Existing Microsoft OneDrive Access Token Valid Until: " ~ to!string(appConfig.accessTokenExpiration), ["debug"]);}
+			if (debugLogging) {addLogEntry("Microsoft OneDrive OAuth2 Access Token Valid Until (Local): " ~ to!string(appConfig.accessTokenExpiration), ["debug"]);}
 		}
 	}
 	

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1341,7 +1341,9 @@ class OneDriveApi {
 	}
 	
 	private void connect(HTTP.Method method, const(char)[] url, bool skipToken, CurlResponse response, string[string] requestHeaders=null) {
-		if (debugLogging) {addLogEntry("Request URL = " ~ to!string(url), ["debug"]);}
+		// If we are debug logging, output the URL being accessed and the HTTP method being used to access that URL
+		if (debugLogging) {addLogEntry("HTTP " ~ to!string(method) ~ " request to URL: " ~ to!string(url), ["debug"]);}
+		
 		// Check access token first in case the request is overridden
 		if (!skipToken) addAccessTokenHeader(&requestHeaders);
 		curlEngine.setResponseHolder(response);

--- a/src/sync.d
+++ b/src/sync.d
@@ -9429,6 +9429,7 @@ class SyncEngine {
 				// Log URL 'updated' expirationDateTime
 				if (debugLogging) {
 					addLogEntry("Upload URL expiration extended to: " ~ uploadResponse["expirationDateTime"].str, ["debug"]);
+					addLogEntry("", ["debug"]); // Add new line as this fragment is complete
 				}
 				
 				// Save for reuse

--- a/src/sync.d
+++ b/src/sync.d
@@ -9223,6 +9223,7 @@ class SyncEngine {
 		long fragmentSize;
 		enum GIGABYTE = 1024L * 1024L * 1024L; // 1 GiB
 		enum CHUNK_SIZE = 327_680L; // 320 KiB
+		enum MAX_FRAGMENT_BYTES = 60L * 1_048_576L; // 60 MiB = 62,914,560 bytes
 		
 		if (thisFileSize > GIGABYTE) {
 			if (debugLogging) {
@@ -9235,8 +9236,13 @@ class SyncEngine {
 			baseSize = appConfig.getValueLong("file_fragment_size") * 2^^20;
 		}
 		
-		// Ensure 'fragmentSize' is a multiple of 327680 bytes
-		fragmentSize = (baseSize / CHUNK_SIZE) * CHUNK_SIZE;
+		// Ensure 'fragmentSize' is a multiple of 327680 bytes and < 60 MiB
+		if (baseSize >= MAX_FRAGMENT_BYTES) {
+			// Use the maximum valid size below 60 MiB, rounded down to nearest 320 KiB multiple
+			fragmentSize = ((MAX_FRAGMENT_BYTES - 1) / CHUNK_SIZE) * CHUNK_SIZE;
+		} else {
+			fragmentSize = (baseSize / CHUNK_SIZE) * CHUNK_SIZE;
+		}
 		
 		// Set the fragment count and fragSize
 		size_t fragmentCount = 0;

--- a/src/sync.d
+++ b/src/sync.d
@@ -9221,11 +9221,12 @@ class SyncEngine {
 		// Calculate File Fragment Size (must be valid multiple of 320 KiB)
 		long baseSize;
 		long fragmentSize;
-		enum GIGABYTE = 1024L * 1024L * 1024L; // 1 GiB
+		enum HUNDRED_MIB = 100L * 1024L * 1024L; // 100 MiB = 104,857,600 bytes
 		enum CHUNK_SIZE = 327_680L; // 320 KiB
 		enum MAX_FRAGMENT_BYTES = 60L * 1_048_576L; // 60 MiB = 62,914,560 bytes
 		
-		if (thisFileSize > GIGABYTE) {
+		// If file is > 100 MiB then automatically use the larger fragment size
+		if (thisFileSize > HUNDRED_MIB) {
 			if (debugLogging) {
 				addLogEntry("Large file detected (" ~ to!string(thisFileSize) ~ " bytes), automatically using max fragment size: " ~ to!string(appConfig.defaultMaxFileFragmentSize), ["debug"]);
 			}

--- a/src/sync.d
+++ b/src/sync.d
@@ -9358,8 +9358,8 @@ class SyncEngine {
 				// retry fragment upload in case error is transient
 				if (verboseLogging) {addLogEntry("Retrying fragment upload", ["verbose"]);}
 
+				// Retry fragment upload logic
 				try {
-					// retry
 					string effectiveRetryUploadURL;
 					string effectiveLocalPath;
 

--- a/src/sync.d
+++ b/src/sync.d
@@ -9219,7 +9219,16 @@ class SyncEngine {
 		// https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#upload-bytes-to-the-upload-session
 		// You can upload the entire file, or split the file into multiple byte ranges, as long as the maximum bytes in any given request is less than 60 MiB.
 		// Calculate File Fragment Size
-		long fragmentSize = appConfig.getValueLong("file_fragment_size") * 2^^20;
+		long fragmentSize;
+		enum GIGABYTE = 1024L * 1024L * 1024L;
+		if (thisFileSize > GIGABYTE) {
+			if (debugLogging) {
+				addLogEntry("Large file detected (" ~ to!string(thisFileSize) ~ " bytes), automatically using max fragment size: " ~ to!string(appConfig.defaultMaxFileFragmentSize), ["debug"]);
+			}
+			fragmentSize = appConfig.defaultMaxFileFragmentSize * 2^^20;
+		} else {
+			fragmentSize = appConfig.getValueLong("file_fragment_size") * 2^^20;
+		}
 		
 		// Set the fragment count and fragSize
 		size_t fragmentCount = 0;

--- a/src/sync.d
+++ b/src/sync.d
@@ -9216,6 +9216,8 @@ class SyncEngine {
 		// Response for upload
 		JSONValue uploadResponse;
 
+		// https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#upload-bytes-to-the-upload-session
+		// You can upload the entire file, or split the file into multiple byte ranges, as long as the maximum bytes in any given request is less than 60 MiB.
 		// Calculate File Fragment Size
 		long fragmentSize = appConfig.getValueLong("file_fragment_size") * 2^^20;
 		
@@ -9426,9 +9428,16 @@ class SyncEngine {
 				uploadSessionData["expirationDateTime"] = uploadResponse["expirationDateTime"];
 				uploadSessionData["nextExpectedRanges"] = uploadResponse["nextExpectedRanges"];
 				
-				// Log URL 'updated' expirationDateTime
+				// Log URL 'updated' expirationDateTime as 'UTC' and 'localTime'
 				if (debugLogging) {
-					addLogEntry("Upload URL expiration extended to: " ~ uploadResponse["expirationDateTime"].str, ["debug"]);
+					// Convert expiration time to localTime
+					string utcExpiry = uploadResponse["expirationDateTime"].str;
+					SysTime expiryUTC = SysTime.fromISOExtString(utcExpiry);
+					SysTime expiryLocal = expiryUTC.toLocalTime();
+				
+					// Display updated URL expiry as UTC and localTime
+					addLogEntry("Upload Session URL expiration extended to (UTC):   " ~ to!string(expiryUTC), ["debug"]);
+					addLogEntry("Upload Session URL expiration extended to (Local): " ~ to!string(expiryLocal), ["debug"]);
 					addLogEntry("", ["debug"]); // Add new line as this fragment is complete
 				}
 				

--- a/src/util.d
+++ b/src/util.d
@@ -809,8 +809,8 @@ void displayOneDriveErrorMessage(string message, string callingFunction) {
 	}
 	
 	// Where in the code was this error generated
-	if (verboseLogging) {addLogEntry("  Calling Function:    " ~ callingFunction, ["verbose"]);}
-	if (debugLogging) {addLogEntry("  Calling Function:    " ~ callingFunction, ["debug"]);}
+	if (verboseLogging) {addLogEntry("  Calling Function:    " ~ callingFunction, ["verbose"]);} // will get printed in debug
+	
 	// Extra Debug if we are using --verbose --verbose
 	if (debugLogging) {
 		addLogEntry("Raw Error Data: " ~ message, ["debug"]);


### PR DESCRIPTION
* Revert back to v2.5.5 performSessionFileUpload() and apply minimal change for upload session offset handling to prevent desynchronisation on large files