### PR TITLE
Fix foreign key issue when performing a --resync

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -519,7 +519,7 @@ final class ItemDatabase {
 			
 			try {
 				if (debugLogging) {
-					addLogEntry("Attempting upsert for item: id='" ~ item.id ~ "', parentId='" ~ item.parentId ~ "', name='" ~ item.name ~ "'", ["debug"]);
+					addLogEntry("Attempting upsert for item: driveId='" ~ item.driveId ~ "', id='" ~ item.id ~ "', parentId='" ~ item.parentId ~ "', name='" ~ item.name ~ "'", ["debug"]);
 				}
 				
 				selectStmt.bind(1, item.driveId);
@@ -541,7 +541,7 @@ final class ItemDatabase {
 					if (orphanCount == 0) {
 						// No match on name+parentId either — new insert
 						if (debugLogging) {
-							addLogEntry("Inserting new item: id='" ~ item.id ~ "', parentId='" ~ item.parentId ~ "', name='" ~ item.name ~ "'", ["debug"]);
+							addLogEntry("Inserting new item: driveId='" ~ item.driveId ~ "', id='" ~ item.id ~ "', parentId='" ~ item.parentId ~ "', name='" ~ item.name ~ "'", ["debug"]);
 						}
 						executionStmt = db.prepare(insertItemStmt);
 					} else {

--- a/src/sync.d
+++ b/src/sync.d
@@ -10160,18 +10160,22 @@ class SyncEngine {
 		// Issue #3115 - Personal Account Shared Folder
 		// What account type is this?
 		if (appConfig.accountType == "personal") {
+			// Issue #3336 - Convert driveId to lowercase for the DB record
+			string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.driveId));
+			newDatabaseItem.driveId = actualOnlineDriveId;
+			
 			// Is this a 'remote' DB record
 			if (newDatabaseItem.type == ItemType.remote) {
-				// Issue #3336 - Convert driveId to lowercase before any test
+				// Issue #3336 - Convert remoteDriveId to lowercase before any test
 				newDatabaseItem.remoteDriveId = transformToLowerCase(newDatabaseItem.remoteDriveId);
 			
-				// Test driveId length and validation if the driveId we are testing is not equal to appConfig.defaultDriveId
+				// Test remoteDriveId length and validation if the remoteDriveId we are testing is not equal to appConfig.defaultDriveId
 				if (newDatabaseItem.remoteDriveId != appConfig.defaultDriveId) {
 					// Issue #3136, #3139 #3143
 					// Fetch the actual online record for this item
-					// This returns the actual OneDrive Personal driveId value and is 15 character checked
-					string actualOnlineDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId));
-					newDatabaseItem.remoteDriveId = actualOnlineDriveId;
+					// This returns the actual OneDrive Personal remoteDriveId value and is 15 character checked
+					string actualOnlineRemoteDriveId = testProvidedDriveIdForLengthIssue(fetchRealOnlineDriveIdentifier(newDatabaseItem.remoteDriveId));
+					newDatabaseItem.remoteDriveId = actualOnlineRemoteDriveId;
 				}
 			}
 		}


### PR DESCRIPTION
* Fix foreign key issue when performing a --resync due to a missed conversion of driveId to lowercase values (#3336) and path is covered by 'sync_list' entries