### PR TITLE
Implement FR #3387: Show GUI notification when sync suspends due to 'large delete' threshold

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -9719,7 +9719,10 @@ class SyncEngine {
 					// A big delete has been detected
 					flagAsBigDelete = true;
 					if (!appConfig.getValueBool("force")) {
-						addLogEntry("ERROR: An attempt to remove a large volume of data from OneDrive has been detected. Exiting client to preserve your data on Microsoft OneDrive");
+						// Send this message to the GUI
+						addLogEntry("ERROR: An attempt to remove a large volume of data from OneDrive has been detected. Exiting client to preserve your data on Microsoft OneDrive", ["info", "notify"]);
+						
+						// Additional application logging
 						addLogEntry("ERROR: The total number of items being deleted is: " ~ to!string(itemsToDelete));
 						addLogEntry("ERROR: To delete a large volume of data use --force or increase the config value 'classify_as_big_delete' to a larger value");
 						addLogEntry("ERROR: Optionally, perform a --resync to reset your local synchronisation state");


### PR DESCRIPTION


* Implement #3387 to show GUI notification when sync suspends due to 'large delete' threshold