### PR TITLE
Fix resumable downloads so that offset point is reset

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -598,6 +598,11 @@ class CurlEngine {
 	void setDownloadResumeOffset(long offset) {
 		resumeFromOffset = offset;
 	}
+	
+	// reset resumable offset point to negative value
+	void resetDownloadResumeOffset() {
+		resumeFromOffset = -1;
+	}
 }
 
 // Methods to control obtaining and releasing a CurlEngine instance from the curlEnginePool

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1559,6 +1559,9 @@ class OneDriveApi {
 			
 			// Safe remove 'threadResumeDownloadFilePath' as if we get to this point, the file has been download successfully
 			safeRemove(threadResumeDownloadFilePath);
+			
+			// Reset this curlEngine offset value now that the file has been downloaded successfully
+			curlEngine.resetDownloadResumeOffset();
 
 			// Return the applicable result
 			return result;


### PR DESCRIPTION
* Ensure that post any successful download, the resumable offset point is reset to avoid `HTTP request returned status code 416 (Requested Range Not Satisfiable)` if the reset point is not reset