### PR TITLE
Fix the computePath() to track the parental path anchor

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -4419,7 +4419,7 @@ class SyncEngine {
 		if (debugLogging) {
 			string initialComputeLogMessage = format("Attempting to calculate local filesystem path for '%s' and '%s'", thisDriveId, thisItemId);
 			addLogEntry(initialComputeLogMessage, ["debug"]);
-			}
+		}
 		
 		// Perform the original calculation of the path using the values provided
 		try {


### PR DESCRIPTION
* Fix the computePath() to track the parental path anchor when a Shared Folder is relocated with a deeper path