### PR TITLE
Fix RHEL detection on AlmaLinux

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,7 +55,7 @@ user_unit_files = contrib/systemd/onedrive.service
 DOCFILES = readme.md config LICENSE changelog.md docs/advanced-usage.md docs/application-config-options.md docs/application-security.md docs/business-shared-items.md docs/client-architecture.md docs/contributing.md docs/docker.md docs/install.md docs/national-cloud-deployments.md docs/podman.md docs/privacy-policy.md docs/sharepoint-libraries.md docs/terms-of-service.md docs/ubuntu-package-install.md docs/usage.md docs/known-issues.md docs/webhooks.md
 
 ifneq ("$(wildcard /etc/redhat-release)","")
-RHEL = $(shell cat /etc/redhat-release | grep -E "(Red Hat Enterprise Linux|CentOS)" | wc -l)
+RHEL = $(shell cat /etc/redhat-release | grep -E "(Red Hat Enterprise Linux|CentOS|AlmaLinux)" | wc -l)
 RHEL_VERSION = $(shell rpm --eval "%{rhel}")
 else
 RHEL = 0


### PR DESCRIPTION
I faced with a build failure on AlmaLinux
You can find the logs here:
[mock_build.331687.1761058319.log](https://build.almalinux.org/build/45709/logs/331687?project_name=onedrive-2&arch=x86_64_v2)

The issue occurs because, during the build on AlmaLinux, the RHEL variable in the Makefile is set to 0 due to the detection method.
With this patch, the detection works correctly, and the build completes successfully.