### PR TITLE
Fix Bug #3536: Fix that large files fail to download due operational timeout being exceeded

### DIFF
--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -661,13 +661,19 @@ _**Config Example:**_ `notify_file_actions = "true"`
 > GUI Notification Support must be compiled in first, otherwise this option will have zero effect and will not be used.
 
 ### operation_timeout
-_**Description:**_ This configuration option controls the maximum amount of time (seconds) a file operation is allowed to take. This includes DNS resolution, connecting, data transfer, etc. We recommend users not to tamper with this option unless strictly necessary. This option controls the CURLOPT_TIMEOUT setting of libcurl.
+_**Description:**_ This configuration option controls the maximum total time (in seconds) that any network operation is allowed to take. This limit applies to the *entire* request, including DNS resolution, connection setup, TLS negotiation, and data transfer.  This option maps directly to libcurl’s `CURLOPT_TIMEOUT`.
 
 _**Value Type:**_ Integer
 
-_**Default Value:**_ 3600
+_**Default Value:**_ 0 (no timeout)
 
 _**Config Example:**_ `operation_timeout = "3600"`
+
+> [!IMPORTANT]
+> Setting a non-zero value will cause libcurl to abort the operation once the specified time has elapsed — even if data is still flowing normally.
+> For large file downloads, particularly on slower connections, enabling a finite timeout may cause transfers to be terminated prematurely.
+>
+> It is strongly recommend to leave this option at its default of `0` unless you specifically require a hard global time limit.
 
 ### permanent_delete
 _**Description:**_ Permanently delete an item online when it is removed locally. When using this method, they're permanently removed and aren't sent to the Microsoft OneDrive Recycle Bin. Therefore, permanently deleted drive items can't be restored afterward. Online data loss MAY occur in this scenario.

--- a/src/config.d
+++ b/src/config.d
@@ -78,10 +78,22 @@ class ApplicationConfig {
 	// Default data timeout for HTTP operations
 	// curl.d has a default of: _defaultDataTimeout = dur!"minutes"(2);
 	immutable int defaultDataTimeout = 60; // in seconds
-	// Maximum time any operation is allowed to take
-	// This includes dns resolution, connecting, data transfer, etc.
-	// Controls CURLOPT_TIMEOUT
-	immutable int defaultOperationTimeout = 3600; // in seconds
+	// Maximum total time (in seconds) that any transfer operation is allowed to take.
+	// This maps directly to libcurl's CURLOPT_TIMEOUT.
+	//
+	// IMPORTANT:
+	//   • CURLOPT_TIMEOUT applies to the *entire* operation — DNS lookup, TCP connect,
+	//     TLS negotiation, and the full data transfer.
+	//   • If this timeout is reached, libcurl will abort the request even if data is
+	//     flowing normally.
+	//   • For large file downloads, especially on slower links, setting a non-zero
+	//     timeout can cause the transfer to be killed prematurely.
+	//
+	// Behaviour:
+	//   • A value of 0 disables the limit entirely (libcurl’s default behaviour).
+	//   • It is strongly recommended to keep this at 0 unless a hard global cap is
+	//     explicitly required by the user or their environment.
+	immutable int defaultOperationTimeout = 0; // 0 = no timeout (safe for extremely large file downloads)
 	// Specify what IP protocol version should be used when communicating with OneDrive
 	immutable int defaultIpProtocol = 0; // 0 = IPv4 + IPv6, 1 = IPv4 Only, 2 = IPv6 Only
 	// Specify how many redirects should be allowed


### PR DESCRIPTION


* Adjust default 'operation_timeout' value to align to CURLOPT_TIMEOUT default
* Update downloadFile() to ensure correct handling when operational timeouts occur to correctly resume download and use correct offset for download