### PR TITLE
Fix that safeBackup crashes when attempting backing up a non-existent local path

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -85,10 +85,11 @@ void safeBackup(const(char)[] path, bool dryRun, bool bypassDataPreservation, ou
 		isDirectory = isDir(path);
 	} catch (FileException e) {
 		// Path disappeared or became inaccessible between exists() and isDir()
-		if (debugLogging) {
-			addLogEntry("safeBackup: Unable to determine if path is a directory, treating as non-directory: " ~ to!string(path) ~ " : " ~ e.msg, ["debug"]);
+		if (verboseLogging) {
+			addLogEntry("Path to backup no longer exists or is inaccessible: " ~ to!string(path) ~ " : " ~ e.msg, ["verbose"]);
 		}
-		isDirectory = false;
+		// Nothing left to back up — exit safely
+		return;
 	}
 	
 	// Is the input path a folder|directory? These should never be renamed


### PR DESCRIPTION
* Fix safeBackup() so that the application does not crash when probing if path is a directory and the actual path no longer exists locally