### PR TITLE
Perform safeBackup() on deleted items only when a hash change is detected

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -2043,7 +2043,7 @@ class SyncEngine {
 					//   file":{"hashes":{"quickXorHash":"AAAAAAAAAAAAAAAAAAAAAAAAAAA="}},
 					// Thus this makes using the provided data via the API useless for a hash comparison test
 					
-					// Test the existing database item hash against the hash on the local disk - as this is what we know was in-sync with online
+					// Test the existing database item hash against the hash on the local disk - as this is what we know was in-sync with online prior to online deletion event
 					if (!testFileHash(localPathToDelete, existingDatabaseItem)) {
 						// Current file on disk is different by hash / content
 						// If local data protection is configured (bypassDataPreservation = false), safeBackup the local file, passing in if we are performing a --dry-run or not


### PR DESCRIPTION
* When Microsoft OneDrive sends a JSON for a deleted item, rather than blindly calling safeBackup() when the item to be deleted is determined to not be currently in sync with the local filesystem, perform some addition validation and only perform safeBackup() if there is a hash difference to the prior known state