### PR TITLE
Fix Bug #3601: Fix Docker entrypoint handling for non-root --user execution

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -115,7 +115,7 @@ fi
 
 # Tell client to sync in download-only mode based on environment variable
 if [ "${ONEDRIVE_DOWNLOADONLY:=0}" == "1" ]; then
-	echo "# We are synchronizing in download-only mode"
+	echo "# We are synchronising in download-only mode"
 	echo "# Adding --download-only"
 	ARGS=(--download-only ${ARGS[@]})
 fi
@@ -129,14 +129,14 @@ fi
 
 # Tell client to sync in upload-only mode based on environment variable
 if [ "${ONEDRIVE_UPLOADONLY:=0}" == "1" ]; then
-	echo "# We are synchronizing in upload-only mode"
+	echo "# We are synchronising in upload-only mode"
 	echo "# Adding --upload-only"
 	ARGS=(--upload-only ${ARGS[@]})
 fi
 
 # Tell client to sync in no-remote-delete mode based on environment variable
 if [ "${ONEDRIVE_NOREMOTEDELETE:=0}" == "1" ]; then
-	echo "# We are synchronizing in no-remote-delete mode"
+	echo "# We are synchronising in no-remote-delete mode"
 	echo "# Adding --no-remote-delete"
 	ARGS=(--no-remote-delete ${ARGS[@]})
 fi
@@ -155,14 +155,14 @@ if [ "${ONEDRIVE_REAUTH:=0}" == "1" ]; then
 	ARGS=(--reauth ${ARGS[@]})
 fi
 
-# Tell client to utilize auth files at the provided locations based on environment variable
+# Tell client to utilise auth files at the provided locations based on environment variable
 if [ -n "${ONEDRIVE_AUTHFILES:=""}" ]; then
 	echo "# We are using auth files to perform authentication"
 	echo "# Adding --auth-files ARG"
 	ARGS=(--auth-files ${ONEDRIVE_AUTHFILES} ${ARGS[@]})
 fi
 
-# Tell client to utilize provided auth response based on environment variable
+# Tell client to utilise provided auth response based on environment variable
 if [ -n "${ONEDRIVE_AUTHRESPONSE:=""}" ]; then
 	echo "# We are providing the auth response directly to perform authentication"
 	echo "# Adding --auth-response ARG"
@@ -178,7 +178,7 @@ fi
 
 # Tell client to use sync single dir option
 if [ -n "${ONEDRIVE_SINGLE_DIRECTORY:=""}" ]; then
-	echo "# We are synchronizing in single-directory mode"
+	echo "# We are synchronising in single-directory mode"
 	echo "# Adding --single-directory ARG"
 	ARGS=(--single-directory \"${ONEDRIVE_SINGLE_DIRECTORY}\" ${ARGS[@]})
 fi


### PR DESCRIPTION
This change updates the Docker entrypoint.sh to correctly support containers started with a numeric UID/GID via --user or user: (Docker Compose).

Previously, the entrypoint unconditionally attempted user and group management (useradd, groupadd, usermod) before checking whether the container was running as root. When the container was started as a non-root user, this resulted in immediate startup failures due to insufficient privileges.

The updated logic now:

* Detects whether the container is started as root or non-root
* Skips all user/group creation and ownership changes when running as non-root
* Treats --user / user: as authoritative when provided
* Preserves existing behaviour when the container is started as root (including optional privilege drop via gosu)
* Ensures ONEDRIVE_RUNAS_ROOT is only honoured when the container is actually running as root

This makes the container compatible with:

* Numeric UID/GID execution
* NFS-backed volumes where the user does not exist on the host
* Read-only bind mounts for upload-only scenarios

No changes are made to the OneDrive client itself; this update strictly improves container startup behaviour and correctness.