### PR TITLE
Correct Docker documentation

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,14 +3,14 @@ This client can be run as a Docker container, with 3 available container base op
 
 | Container Base | Docker Tag  | Description                                                    | i686 | x86_64 | ARMHF | AARCH64 |
 |----------------|-------------|----------------------------------------------------------------|:------:|:------:|:-----:|:-------:|
-| Alpine Linux   | edge-alpine | Docker container based on Alpine 3.21 using 'master'           |❌|✔|❌|✔|
-| Alpine Linux   | alpine      | Docker container based on Alpine 3.21 using latest release     |❌|✔|❌|✔|
-| Debian         | debian      | Docker container based on Debian Stable using latest release   |✔|✔|✔|✔|
-| Debian         | edge        | Docker container based on Debian Stable using 'master'         |✔|✔|✔|✔|
-| Debian         | edge-debian | Docker container based on Debian Stable using 'master'         |✔|✔|✔|✔|
-| Debian         | latest      | Docker container based on Debian Stable using latest release   |✔|✔|✔|✔|
-| Fedora         | edge-fedora | Docker container based on Fedora 42 using 'master'             |❌|✔|❌|✔|
-| Fedora         | fedora      | Docker container based on Fedora 42 using latest release       |❌|✔|❌|✔|
+| Alpine Linux   | edge-alpine | Docker container based on Alpine 3.23 using 'master'           |❌|✔|❌|✔|
+| Alpine Linux   | alpine      | Docker container based on Alpine 3.23 using latest release     |❌|✔|❌|✔|
+| Debian         | debian      | Docker container based on Debian 13 using latest release       |✔|✔|✔|✔|
+| Debian         | edge        | Docker container based on Debian 13 using 'master'             |✔|✔|✔|✔|
+| Debian         | edge-debian | Docker container based on Debian 13 using 'master'             |✔|✔|✔|✔|
+| Debian         | latest      | Docker container based on Debian 13 using latest release       |✔|✔|✔|✔|
+| Fedora         | edge-fedora | Docker container based on Fedora 43 using 'master'             |❌|✔|❌|✔|
+| Fedora         | fedora      | Docker container based on Fedora 43 using latest release       |❌|✔|❌|✔|
 
 These containers offer a simple monitoring-mode service for the OneDrive Client for Linux.
 

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -3,14 +3,14 @@ This client can be run as a Podman container, with 3 available container base op
 
 | Container Base | Docker Tag  | Description                                                    | i686 | x86_64 | ARMHF | AARCH64 |
 |----------------|-------------|----------------------------------------------------------------|:------:|:------:|:-----:|:-------:|
-| Alpine Linux   | edge-alpine | Podman container based on Alpine 3.21 using 'master'           |❌|✔|❌|✔|
-| Alpine Linux   | alpine      | Podman container based on Alpine 3.21 using latest release     |❌|✔|❌|✔|
-| Debian         | debian      | Podman container based on Debian Stable using latest release   |✔|✔|✔|✔|
-| Debian         | edge        | Podman container based on Debian Stable using 'master'         |✔|✔|✔|✔|
-| Debian         | edge-debian | Podman container based on Debian Stable using 'master'         |✔|✔|✔|✔|
-| Debian         | latest      | Podman container based on Debian Stable using latest release   |✔|✔|✔|✔|
-| Fedora         | edge-fedora | Podman container based on Fedora 42 using 'master'             |❌|✔|❌|✔|
-| Fedora         | fedora      | Podman container based on Fedora 42 using latest release       |❌|✔|❌|✔|
+| Alpine Linux   | edge-alpine | Podman container based on Alpine 3.23 using 'master'           |❌|✔|❌|✔|
+| Alpine Linux   | alpine      | Podman container based on Alpine 3.23 using latest release     |❌|✔|❌|✔|
+| Debian         | debian      | Podman container based on Debian 13 using latest release       |✔|✔|✔|✔|
+| Debian         | edge        | Podman container based on Debian 13 using 'master'             |✔|✔|✔|✔|
+| Debian         | edge-debian | Podman container based on Debian 13 using 'master'             |✔|✔|✔|✔|
+| Debian         | latest      | Podman container based on Debian 13 using latest release       |✔|✔|✔|✔|
+| Fedora         | edge-fedora | Podman container based on Fedora 43 using 'master'             |❌|✔|❌|✔|
+| Fedora         | fedora      | Podman container based on Fedora 43 using latest release       |❌|✔|❌|✔|
 
 These containers offer a simple monitoring-mode service for the OneDrive Client for Linux.
 


### PR DESCRIPTION
* Correct Docker documentation as to distribution versions being used for the Docker images. This should have been updated with the December 2025 update