### PR TITLE
Fix Bug #3622: Fix OAuth authorisation code parsing and encoding during token redemption

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -795,14 +795,15 @@ class OneDriveApi {
 				}
 				
 				// match the authorisation code
-				auto c = matchFirst(response, r"(?:[?&]code=)([^&]+)");
+				auto c = matchFirst(strip(response), r"(?:[?&]code=)([^&]+)");
 				
 				if (c.empty) {
 					addLogEntry("An empty or invalid response uri was entered");
 					return false;
 				}
 				c.popFront(); // skip the whole match
-				redeemToken(c.front);
+				string authCode = decodeComponent(c.front);
+				redeemToken(authCode);
 				return true;
 			}
 		}
@@ -1253,7 +1254,7 @@ class OneDriveApi {
 		(*headers)["Prefer"] = "Include-Feature=AddToOneDrive";
 	}
 
-	private void redeemToken(char[] authCode) {
+	private void redeemToken(string authCode) {
 		string postData =
 			"client_id=" ~ clientId ~
 			"&redirect_uri=" ~ encodeComponent(redirectUrl) ~


### PR DESCRIPTION

Fix an issue where OAuth authorisation codes containing non-alphanumeric characters were truncated or incorrectly transmitted during token redemption.

The client now captures the full `code` query parameter from the redirect URI and ensures it is correctly form-encoded when posting to the token endpoint. Authorization codes are treated as opaque values and relayed exactly as returned by Microsoft, preventing AADSTS70000 errors caused by client-side parsing assumptions.