### PR TITLE
Fix #3630 websocket trigger not leading to sync with --download-only

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1379,7 +1379,7 @@ int main(string[] cliArgs) {
 					auto sleepTime = nextCheckTime - currentTime;
 					if (debugLogging) {addLogEntry("Sleep for " ~ to!string(sleepTime), ["debug"]);}
 					
-					if (filesystemMonitor.initialised || webhookEnabled) {
+					if (filesystemMonitor.initialised || webhookEnabled || oneDriveSocketIo !is null) {
 
 						if (filesystemMonitor.initialised) {
 							// If local monitor is on and is waiting (previous event was not from webhook)


### PR DESCRIPTION
When using --download-only config options, changes in onedrive lead to a received notification, but no sync is triggered.

Cause: The WebSocket thread receives notifications from Microsoft and sends a signal to wake up the main sync loop. But in --download-only mode, the main loop is using a hard sleep (Thread.sleep) that can't be interrupted by messages, it only wakes up on a timer. So the signal sits ignored until the next scheduled sync.

