### PR TITLE
Fix Bug #3637: Fix internal crash when WebSocket initialisation fails in monitor mode

### DIFF
--- a/src/config.d
+++ b/src/config.d
@@ -1784,11 +1784,16 @@ class ApplicationConfig {
 			addLogEntry();
 			addLogEntry("--------------------DEVELOPER_OPTIONS----------------------------");
 			addLogEntry("Config option 'force_children_scan'          = " ~ to!string(getValueBool("force_children_scan")));
-			addLogEntry();
+			addLogEntry("Config option 'monitor_max_loop'             = " ~ to!string(getValueLong("monitor_max_loop")));
+			addLogEntry("Config option 'display_memory'               = " ~ to!string(getValueBool("display_memory")));
+			addLogEntry("Config option 'display_sync_options'         = " ~ to!string(getValueBool("display_sync_options")));
+			addLogEntry("Config option 'display_processing_time'      = " ~ to!string(getValueBool("display_processing_time")));
 		}
 		
+		// Close out config output
 		if (getValueBool("display_running_config")) {
 			addLogEntry("-----------------------------------------------------------------");
+			addLogEntry();
 		}
 	}
 	


### PR DESCRIPTION


This PR fixes an internal crash in --monitor mode when WebSocket (Socket.IO) initialisation fails (for example, when Microsoft Graph returns 400 notSupported).

Previously, a failed WebSocket initialisation could leave the internal oneDriveSocketIo object unset (null), while later monitor-loop logic still assumed it was available. This resulted in a null dereference and a SIGSEGV, causing the client to exit after the first monitor loop.