### PR TITLE
Fix reserved Windows device name validation to block names with extensions (e.g. CON.txt, NUL.tar.gz)

### DIFF
--- a/src/util.d
+++ b/src/util.d
@@ -650,35 +650,61 @@ bool multiGlobMatch(const(char)[] path, const(char)[] pattern) {
     return false;
 }
 
+// Check if the provided item name is a reserved Microsoft / Windows device name
+// This must catch both:
+//   - exact reserved names, e.g. "CON"
+//   - reserved names followed by an extension, e.g. "CON.txt", "NUL.tar.gz"
+// Microsoft documents that reserved names remain invalid even when followed by an extension.
+bool isReservedMicrosoftName(string itemName, const(bool[string]) disallowedSet) {
+	// Ensure case-insensitive comparisons
+	string candidate = itemName.toLower();
+
+	// Exact match
+	if (disallowedSet.get(candidate, false)) {
+		return true;
+	}
+
+	// Reserved device names followed by an extension, e.g. "CON.txt"
+	auto firstDot = countUntil(candidate, ".");
+	if (firstDot > 0) {
+		string deviceRoot = candidate[0 .. firstDot];
+		if (disallowedSet.get(deviceRoot, false)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // Does the path pass the Microsoft restriction and limitations about naming files and folders
 bool isValidName(string path) {
 	// Restriction and limitations about windows naming files and folders
 	// https://msdn.microsoft.com/en-us/library/aa365247
 	// https://support.microsoft.com/en-us/help/3125202/restrictions-and-limitations-when-you-sync-files-and-folders
 	
-    if (path == ".") {
-        return true;
-    }
+	if (path == ".") {
+		return true;
+	}
 
-    string itemName = baseName(path).toLower(); // Ensure case-insensitivity
+	string itemName = baseName(path).toLower(); // Ensure case-insensitivity
 
-    // Check for explicitly disallowed names
+	// Check for explicitly disallowed names
 	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa?ui=en-us&rs=en-us&ad=us#invalidfilefoldernames
 	string[] disallowedNames = [
-        ".lock", "desktop.ini", "CON", "PRN", "AUX", "NUL",
-        "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-        "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
-    ];
+		".lock", "desktop.ini", "CON", "PRN", "AUX", "NUL",
+		"COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+	];
 
-    // Creating an associative array for faster lookup
-    bool[string] disallowedSet;
-    foreach (name; disallowedNames) {
-        disallowedSet[name.toLower()] = true; // Normalise to lowercase
-    }
+	// Creating an associative array for faster lookup
+	bool[string] disallowedSet;
+	foreach (name; disallowedNames) {
+		disallowedSet[name.toLower()] = true; // Normalise to lowercase
+	}
 
-    if (disallowedSet.get(itemName, false) || itemName.startsWith("~$") || canFind(itemName, "_vti_")) {
-        return false;
-    }
+	if (isReservedMicrosoftName(itemName, disallowedSet) || itemName.startsWith("~$") || canFind(itemName, "_vti_")) {
+		return false;
+	}
 
 	// Regular expression for invalid patterns
 	// https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa?ui=en-us&rs=en-us&ad=us#invalidcharacters
@@ -694,17 +720,17 @@ bool isValidName(string path) {
 	// - [<>:"\|\?*/\\] matches any single instance of the specified invalid characters: ", *, :, <, >, ?, /, \, |
 
 	auto matchResult = match(itemName, invalidNameReg);
-    if (!matchResult.empty) {
-        return false;
-    }
+	if (!matchResult.empty) {
+		return false;
+	}
 
-    // Determine if the path is at the root level, if yes, check that 'forms' is not the first folder
+	// Determine if the path is at the root level, if yes, check that 'forms' is not the first folder
 	auto segments = pathSplitter(path).array;
-    if (segments.length <= 2 && segments.back.toLower() == "forms") { // Check only the last segment, convert to lower as OneDrive is not POSIX compliant, easier to compare
-        return false;
-    }
+	if (segments.length <= 2 && segments.back.toLower() == "forms") { // Check only the last segment, convert to lower as OneDrive is not POSIX compliant, easier to compare
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 // Does the path contain any bad whitespace characters


### PR DESCRIPTION
Update the isValidName() validation logic to correctly reject Windows reserved device names when they are followed by an extension (e.g. CON.txt, NUL.log, COM1.dat). Previously, only exact matches such as CON or NUL were blocked locally, which allowed names like CON.txt to proceed to upload and fail with a Microsoft Graph 400 invalidRequest error. This change introduces isReservedMicrosoftName() to detect both exact reserved names and reserved names used as the filename root before an extension, preventing the client from attempting invalid uploads and aligning behaviour with Microsoft’s documented naming restrictions.