### PR TITLE
Fix Bug #3675: Fix SIGSEGV during shutdown caused by logging subsystem teardown race condition

### DIFF
--- a/.github/gdb/smoke-monitor.gdb
+++ b/.github/gdb/smoke-monitor.gdb
@@ -1,0 +1,86 @@
+set pagination off
+set confirm off
+set print thread-events off
+set breakpoint pending on
+set backtrace limit 256
+
+# Ignore common runtime noise
+handle SIGPIPE nostop noprint pass
+handle SIGALRM nostop noprint pass
+handle SIGVTALRM nostop noprint pass
+handle SIGPROF nostop noprint pass
+
+# Ignore glibc/NPTL internal signals
+handle SIG32 nostop noprint pass
+handle SIG33 nostop noprint pass
+handle SIG34 nostop noprint pass
+handle SIG35 nostop noprint pass
+handle SIG36 nostop noprint pass
+handle SIG37 nostop noprint pass
+handle SIG38 nostop noprint pass
+handle SIG39 nostop noprint pass
+handle SIG40 nostop noprint pass
+handle SIG41 nostop noprint pass
+handle SIG42 nostop noprint pass
+handle SIG43 nostop noprint pass
+handle SIG44 nostop noprint pass
+handle SIG45 nostop noprint pass
+handle SIG46 nostop noprint pass
+handle SIG47 nostop noprint pass
+handle SIG48 nostop noprint pass
+handle SIG49 nostop noprint pass
+handle SIG50 nostop noprint pass
+handle SIG51 nostop noprint pass
+handle SIG52 nostop noprint pass
+handle SIG53 nostop noprint pass
+handle SIG54 nostop noprint pass
+handle SIG55 nostop noprint pass
+handle SIG56 nostop noprint pass
+handle SIG57 nostop noprint pass
+handle SIG58 nostop noprint pass
+handle SIG59 nostop noprint pass
+handle SIG60 nostop noprint pass
+handle SIG61 nostop noprint pass
+handle SIG62 nostop noprint pass
+handle SIG63 nostop noprint pass
+
+# Important crash signals
+handle SIGSEGV stop print pass
+handle SIGABRT stop print pass
+handle SIGILL stop print pass
+handle SIGFPE stop print pass
+
+# SIGINT should be delivered to the inferior, not treated as a debugger interrupt
+handle SIGINT nostop noprint pass
+
+# Breakpoints for this investigation
+break abort
+
+commands
+  silent
+  printf "\n===== breakpoint hit: abort =====\n"
+  info program
+  printf "\n===== thread apply all bt =====\n"
+  thread apply all bt
+  printf "\n===== thread apply all bt full =====\n"
+  thread apply all bt full
+  printf "\n===== registers =====\n"
+  info registers
+  printf "\n===== shared libraries =====\n"
+  info sharedlibrary
+  quit
+end
+
+run
+
+printf "\n===== inferior stopped =====\n"
+info program
+printf "\n===== thread apply all bt =====\n"
+thread apply all bt
+printf "\n===== thread apply all bt full =====\n"
+thread apply all bt full
+printf "\n===== registers =====\n"
+info registers
+printf "\n===== shared libraries =====\n"
+info sharedlibrary
+quit

--- a/.github/gdb/smoke-monitor.gdb
+++ b/.github/gdb/smoke-monitor.gdb
@@ -4,13 +4,13 @@ set print thread-events off
 set breakpoint pending on
 set backtrace limit 256
 
-# Ignore common runtime noise
+# Common noise
 handle SIGPIPE nostop noprint pass
 handle SIGALRM nostop noprint pass
 handle SIGVTALRM nostop noprint pass
 handle SIGPROF nostop noprint pass
 
-# Ignore glibc/NPTL internal signals
+# glibc / NPTL internal signals often seen on Linux
 handle SIG32 nostop noprint pass
 handle SIG33 nostop noprint pass
 handle SIG34 nostop noprint pass
@@ -44,21 +44,17 @@ handle SIG61 nostop noprint pass
 handle SIG62 nostop noprint pass
 handle SIG63 nostop noprint pass
 
-# Important crash signals
+# Crash signals
 handle SIGSEGV stop print pass
 handle SIGABRT stop print pass
-handle SIGILL stop print pass
-handle SIGFPE stop print pass
+handle SIGILL  stop print pass
+handle SIGFPE  stop print pass
 
-# SIGINT should be delivered to the inferior, not treated as a debugger interrupt
+# We want SIGINT delivered to the inferior, not to interrupt gdb itself
 handle SIGINT nostop noprint pass
 
-# Breakpoints for this investigation
-break abort
-
-commands
-  silent
-  printf "\n===== breakpoint hit: abort =====\n"
+define dump_state
+  printf "\n===== inferior stopped =====\n"
   info program
   printf "\n===== threads =====\n"
   info threads
@@ -70,21 +66,94 @@ commands
   info registers
   printf "\n===== shared libraries =====\n"
   info sharedlibrary
-  quit
+end
+
+break abort
+commands
+  silent
+  printf "\n===== breakpoint hit: abort =====\n"
+  dump_state
+  quit 1
+end
+
+catch signal SIGSEGV
+commands
+  silent
+  printf "\n===== caught SIGSEGV =====\n"
+  dump_state
+  quit 1
+end
+
+catch signal SIGABRT
+commands
+  silent
+  printf "\n===== caught SIGABRT =====\n"
+  dump_state
+  quit 1
+end
+
+catch signal SIGILL
+commands
+  silent
+  printf "\n===== caught SIGILL =====\n"
+  dump_state
+  quit 1
+end
+
+catch signal SIGFPE
+commands
+  silent
+  printf "\n===== caught SIGFPE =====\n"
+  dump_state
+  quit 1
+end
+
+python
+import gdb
+import os
+import time
+import signal
+import threading
+
+needle = "Sync with Microsoft OneDrive is complete"
+logfile = os.environ.get("SMOKE_GDB_MONITOR_LOG")
+timeout_s = int(os.environ.get("SMOKE_GDB_READY_TIMEOUT", "900"))
+poll_s = 1.0
+
+def controller():
+    deadline = time.time() + timeout_s
+    pid = None
+
+    while time.time() < deadline:
+        try:
+            inf = gdb.selected_inferior()
+            pid = inf.pid
+        except Exception:
+            pid = None
+
+        if pid and logfile:
+            try:
+                with open(logfile, "r", errors="replace") as fh:
+                    data = fh.read()
+                if needle in data:
+                    gdb.write("\\n===== controller: steady state detected =====\\n")
+                    gdb.write("===== controller: sending SIGINT to inferior pid %d =====\\n" % pid)
+                    os.kill(pid, signal.SIGINT)
+                    return
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                gdb.write("\\n===== controller: logfile read error: %s =====\\n" % exc)
+
+        time.sleep(poll_s)
+
+    gdb.write("\\n===== controller: timeout waiting for steady state; no SIGINT sent =====\\n")
+
+threading.Thread(target=controller, daemon=True).start()
 end
 
 run
 
-printf "\n===== inferior stopped =====\n"
+printf "\n===== inferior exited =====\n"
 info program
-printf "\n===== threads =====\n"
-info threads
-printf "\n===== thread apply all bt =====\n"
-thread apply all bt
-printf "\n===== thread apply all bt full =====\n"
-thread apply all bt full
-printf "\n===== registers =====\n"
-info registers
-printf "\n===== shared libraries =====\n"
-info sharedlibrary
-quit
+quit 0

--- a/.github/gdb/smoke-monitor.gdb
+++ b/.github/gdb/smoke-monitor.gdb
@@ -1,16 +1,21 @@
 set pagination off
 set confirm off
 set print thread-events off
+set print pretty on
+set print frame-arguments all
 set breakpoint pending on
 set backtrace limit 256
+set debuginfod enabled on
 
-# Common noise
+# Ignore common runtime noise
 handle SIGPIPE nostop noprint pass
 handle SIGALRM nostop noprint pass
 handle SIGVTALRM nostop noprint pass
 handle SIGPROF nostop noprint pass
+handle SIGUSR1 nostop noprint pass
+handle SIGUSR2 nostop noprint pass
 
-# glibc / NPTL internal signals often seen on Linux
+# Ignore glibc/NPTL internal signals
 handle SIG32 nostop noprint pass
 handle SIG33 nostop noprint pass
 handle SIG34 nostop noprint pass
@@ -44,26 +49,37 @@ handle SIG61 nostop noprint pass
 handle SIG62 nostop noprint pass
 handle SIG63 nostop noprint pass
 
-# Crash signals
+# Important crash signals
 handle SIGSEGV stop print pass
 handle SIGABRT stop print pass
-handle SIGILL  stop print pass
-handle SIGFPE  stop print pass
+handle SIGILL stop print pass
+handle SIGFPE stop print pass
 
-# We want SIGINT delivered to the inferior, not to interrupt gdb itself
+# SIGINT should go to the inferior, not stop gdb itself
 handle SIGINT nostop noprint pass
 
 define dump_state
   printf "\n===== inferior stopped =====\n"
   info program
+
+  printf "\n===== bt =====\n"
+  bt
+
+  printf "\n===== bt full =====\n"
+  bt full
+
   printf "\n===== threads =====\n"
   info threads
+
   printf "\n===== thread apply all bt =====\n"
   thread apply all bt
+
   printf "\n===== thread apply all bt full =====\n"
   thread apply all bt full
+
   printf "\n===== registers =====\n"
   info registers
+
   printf "\n===== shared libraries =====\n"
   info sharedlibrary
 end
@@ -136,18 +152,18 @@ def controller():
                 with open(logfile, "r", errors="replace") as fh:
                     data = fh.read()
                 if needle in data:
-                    gdb.write("\\n===== controller: steady state detected =====\\n")
-                    gdb.write("===== controller: sending SIGINT to inferior pid %d =====\\n" % pid)
+                    gdb.write("\n===== controller: steady state detected =====\n")
+                    gdb.write("===== controller: sending SIGINT to inferior pid %d =====\n" % pid)
                     os.kill(pid, signal.SIGINT)
                     return
             except FileNotFoundError:
                 pass
             except Exception as exc:
-                gdb.write("\\n===== controller: logfile read error: %s =====\\n" % exc)
+                gdb.write("\n===== controller: logfile read error: %s =====\n" % exc)
 
         time.sleep(poll_s)
 
-    gdb.write("\\n===== controller: timeout waiting for steady state; no SIGINT sent =====\\n")
+    gdb.write("\n===== controller: timeout waiting for steady state; no SIGINT sent =====\n")
 
 threading.Thread(target=controller, daemon=True).start()
 end

--- a/.github/gdb/smoke-monitor.gdb
+++ b/.github/gdb/smoke-monitor.gdb
@@ -60,6 +60,8 @@ commands
   silent
   printf "\n===== breakpoint hit: abort =====\n"
   info program
+  printf "\n===== threads =====\n"
+  info threads
   printf "\n===== thread apply all bt =====\n"
   thread apply all bt
   printf "\n===== thread apply all bt full =====\n"
@@ -75,6 +77,8 @@ run
 
 printf "\n===== inferior stopped =====\n"
 info program
+printf "\n===== threads =====\n"
+info threads
 printf "\n===== thread apply all bt =====\n"
 thread apply all bt
 printf "\n===== thread apply all bt full =====\n"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -13,9 +13,10 @@ permissions:
 
 jobs:
   ubuntu-monitor-exit:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Ubuntu ${{ matrix.ubuntu }} monitor clean exit
     runs-on: ${{ matrix.ubuntu }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment:
       name: smoke-test
       deployment: false
@@ -28,6 +29,7 @@ jobs:
 
     env:
       SMOKE_REFRESH_TOKEN: ${{ secrets.SMOKE_PERSONAL_REFRESH_TOKEN }}
+      TESTROOT: ${{ runner.temp }}/onedrive-smoke
 
     steps:
       - name: Checkout repository with full history and tags
@@ -56,10 +58,12 @@ jobs:
             git \
             curl \
             ldc \
+            gdb \
             libcurl4-openssl-dev \
             libsqlite3-dev \
             libsystemd-dev \
-            libdbus-1-dev
+            libdbus-1-dev \
+            procps
 
       - name: Build client
         shell: bash
@@ -73,7 +77,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
+          rm -rf "$TESTROOT"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -86,13 +90,15 @@ jobs:
           chmod 600 "$TESTROOT/config/refresh_token"
 
       - name: Run monitor smoke test
+        id: smoke_test
         shell: bash
         run: |
           set -euo pipefail
 
-          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
           BIN="$GITHUB_WORKSPACE/onedrive"
+
+          : > "$LOGFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -107,10 +113,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "Early exit code: $RC"
-              echo "----- monitor.log -----"
-              cat "$LOGFILE" || true
-              exit 1
+              echo "status=unclean" >> "$GITHUB_OUTPUT"
+              echo "reason=early_exit" >> "$GITHUB_OUTPUT"
+              echo "rc=$RC" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
             if grep -Fq "Sync with Microsoft OneDrive is complete" "$LOGFILE"; then
@@ -128,13 +134,16 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
+            RC=$?
             set -e
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=timeout_waiting_for_monitor_idle" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "Steady state reached; sending SIGINT"
+          ps -o pid,ppid,pgid,sid,stat,cmd -p "$PID" || true
           kill -INT "$PID"
 
           set +e
@@ -145,40 +154,109 @@ jobs:
           echo "Exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
-            echo "Fatal shutdown pattern detected"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=fatal_pattern_in_log" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          elif [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=unexpected_exit_code" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            echo "reason=clean_exit" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "$RC" -eq 139 ]; then
-            echo "SIGSEGV exit detected"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+      - name: Run gdb diagnostics on unclean exit
+        if: steps.smoke_test.outputs.status != 'clean'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BIN="$GITHUB_WORKSPACE/onedrive"
+          GDBLOG="$TESTROOT/gdb.log"
+          GDB_MONITOR_LOG="$TESTROOT/monitor-gdb.log"
+          GDB_WRAPPER="$TESTROOT/run-under-gdb.sh"
+
+          rm -f "$GDBLOG" "$GDB_MONITOR_LOG" "$GDB_WRAPPER"
+
+          cat > "$GDB_WRAPPER" <<EOF
+          #!/usr/bin/env bash
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$GDB_MONITOR_LOG" 2>&1
+          EOF
+          chmod +x "$GDB_WRAPPER"
+
+          echo "Starting gdb diagnostic rerun"
+          gdb -q -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" --args /usr/bin/env bash "$GDB_WRAPPER" >"$GDBLOG" 2>&1 &
+          GDBPID=$!
+
+          echo "Started gdb PID: $GDBPID"
+
+          READY=0
+          for _ in $(seq 1 180); do
+            if ! kill -0 "$GDBPID" 2>/dev/null; then
+              echo "gdb exited before reaching steady state"
+              break
+            fi
+
+            if [ -f "$GDB_MONITOR_LOG" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDB_MONITOR_LOG"; then
+              READY=1
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ "$READY" -eq 1 ]; then
+            INFERIOR_PID="$(pgrep -f "$BIN --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
+            if [ -n "$INFERIOR_PID" ]; then
+              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
+              ps -o pid,ppid,pgid,sid,stat,cmd -p "$INFERIOR_PID" || true
+              kill -INT "$INFERIOR_PID" || true
+            else
+              echo "Unable to determine inferior PID during gdb rerun"
+            fi
+          else
+            echo "gdb rerun did not reach steady state before timeout"
           fi
 
-          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
-            echo "Unexpected exit code: $RC"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+          set +e
+          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
+          WAIT_RC=$?
+          set -e
+
+          echo "GDB wait result: $WAIT_RC"
+
+          if kill -0 "$GDBPID" 2>/dev/null; then
+            echo "gdb still running; terminating"
+            kill -TERM "$GDBPID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "$GDBPID" 2>/dev/null || true
           fi
 
-          echo "Clean shutdown verified"
-
-      - name: Upload logs
-        if: always()
+      - name: Upload failure diagnostics
+        if: always() && steps.smoke_test.outputs.status != 'clean'
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-monitor-${{ matrix.ubuntu }}-logs
+          name: smoke-monitor-ubuntu-${{ matrix.ubuntu }}-diagnostics
           path: ${{ runner.temp }}/onedrive-smoke/
           if-no-files-found: warn
 
+      - name: Fail job on unclean shutdown
+        if: steps.smoke_test.outputs.status != 'clean'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Smoke test failed with status: ${{ steps.smoke_test.outputs.status }}"
+          echo "Reason: ${{ steps.smoke_test.outputs.reason }}"
+          echo "Exit code: ${{ steps.smoke_test.outputs.rc }}"
+          exit 1
+
   fedora-monitor-exit:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Fedora ${{ matrix.fedora }} monitor clean exit
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment:
       name: smoke-test
       deployment: false
@@ -194,6 +272,7 @@ jobs:
 
     env:
       SMOKE_REFRESH_TOKEN: ${{ secrets.SMOKE_PERSONAL_REFRESH_TOKEN }}
+      TESTROOT: /tmp/onedrive-smoke
 
     steps:
       - name: Checkout repository with full history and tags
@@ -221,6 +300,7 @@ jobs:
             git \
             curl \
             ldc \
+            gdb \
             libcurl-devel \
             sqlite-devel \
             dbus-devel \
@@ -239,7 +319,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TESTROOT="/tmp/onedrive-smoke"
+          rm -rf "$TESTROOT"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -252,13 +332,15 @@ jobs:
           chmod 600 "$TESTROOT/config/refresh_token"
 
       - name: Run monitor smoke test
+        id: smoke_test
         shell: bash
         run: |
           set -euo pipefail
 
-          TESTROOT="/tmp/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
           BIN="$GITHUB_WORKSPACE/onedrive"
+
+          : > "$LOGFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -273,10 +355,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "Early exit code: $RC"
-              echo "----- monitor.log -----"
-              cat "$LOGFILE" || true
-              exit 1
+              echo "status=unclean" >> "$GITHUB_OUTPUT"
+              echo "reason=early_exit" >> "$GITHUB_OUTPUT"
+              echo "rc=$RC" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
             if grep -Fq "Sync with Microsoft OneDrive is complete" "$LOGFILE"; then
@@ -294,13 +376,16 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
+            RC=$?
             set -e
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=timeout_waiting_for_monitor_idle" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "Steady state reached; sending SIGINT"
+          ps -o pid,ppid,pgid,sid,stat,cmd -p "$PID" || true
           kill -INT "$PID"
 
           set +e
@@ -311,32 +396,100 @@ jobs:
           echo "Exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
-            echo "Fatal shutdown pattern detected"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=fatal_pattern_in_log" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          elif [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+            echo "status=unclean" >> "$GITHUB_OUTPUT"
+            echo "reason=unexpected_exit_code" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            echo "reason=clean_exit" >> "$GITHUB_OUTPUT"
+            echo "rc=$RC" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "$RC" -eq 139 ]; then
-            echo "SIGSEGV exit detected"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+      - name: Run gdb diagnostics on unclean exit
+        if: steps.smoke_test.outputs.status != 'clean'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BIN="$GITHUB_WORKSPACE/onedrive"
+          GDBLOG="$TESTROOT/gdb.log"
+          GDB_MONITOR_LOG="$TESTROOT/monitor-gdb.log"
+          GDB_WRAPPER="$TESTROOT/run-under-gdb.sh"
+
+          rm -f "$GDBLOG" "$GDB_MONITOR_LOG" "$GDB_WRAPPER"
+
+          cat > "$GDB_WRAPPER" <<EOF
+          #!/usr/bin/env bash
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$GDB_MONITOR_LOG" 2>&1
+          EOF
+          chmod +x "$GDB_WRAPPER"
+
+          echo "Starting gdb diagnostic rerun"
+          gdb -q -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" --args /usr/bin/env bash "$GDB_WRAPPER" >"$GDBLOG" 2>&1 &
+          GDBPID=$!
+
+          echo "Started gdb PID: $GDBPID"
+
+          READY=0
+          for _ in $(seq 1 180); do
+            if ! kill -0 "$GDBPID" 2>/dev/null; then
+              echo "gdb exited before reaching steady state"
+              break
+            fi
+
+            if [ -f "$GDB_MONITOR_LOG" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDB_MONITOR_LOG"; then
+              READY=1
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ "$READY" -eq 1 ]; then
+            INFERIOR_PID="$(pgrep -f "$BIN --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
+            if [ -n "$INFERIOR_PID" ]; then
+              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
+              ps -o pid,ppid,pgid,sid,stat,cmd -p "$INFERIOR_PID" || true
+              kill -INT "$INFERIOR_PID" || true
+            else
+              echo "Unable to determine inferior PID during gdb rerun"
+            fi
+          else
+            echo "gdb rerun did not reach steady state before timeout"
           fi
 
-          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
-            echo "Unexpected exit code: $RC"
-            echo "----- monitor.log -----"
-            cat "$LOGFILE" || true
-            exit 1
+          set +e
+          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
+          WAIT_RC=$?
+          set -e
+
+          echo "GDB wait result: $WAIT_RC"
+
+          if kill -0 "$GDBPID" 2>/dev/null; then
+            echo "gdb still running; terminating"
+            kill -TERM "$GDBPID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "$GDBPID" 2>/dev/null || true
           fi
 
-          echo "Clean shutdown verified"
-
-      - name: Upload logs
-        if: always()
+      - name: Upload failure diagnostics
+        if: always() && steps.smoke_test.outputs.status != 'clean'
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-monitor-fedora-${{ matrix.fedora }}-logs
+          name: smoke-monitor-fedora-${{ matrix.fedora }}-diagnostics
           path: /tmp/onedrive-smoke/
           if-no-files-found: warn
+
+      - name: Fail job on unclean shutdown
+        if: steps.smoke_test.outputs.status != 'clean'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Smoke test failed with status: ${{ steps.smoke_test.outputs.status }}"
+          echo "Reason: ${{ steps.smoke_test.outputs.reason }}"
+          echo "Exit code: ${{ steps.smoke_test.outputs.rc }}"
+          exit 1

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   ubuntu-monitor-exit:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Ubuntu ${{ matrix.ubuntu }} monitor clean exit
     runs-on: ${{ matrix.ubuntu }}
     timeout-minutes: 45
@@ -253,7 +252,6 @@ jobs:
           exit 1
 
   fedora-monitor-exit:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Fedora ${{ matrix.fedora }} monitor clean exit
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -15,7 +15,7 @@ jobs:
   ubuntu-monitor-exit:
     name: Ubuntu ${{ matrix.ubuntu }} monitor clean exit
     runs-on: ${{ matrix.ubuntu }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     environment:
       name: smoke-test
       deployment: false
@@ -28,7 +28,6 @@ jobs:
 
     env:
       SMOKE_REFRESH_TOKEN: ${{ secrets.SMOKE_PERSONAL_REFRESH_TOKEN }}
-      TESTROOT: ${{ runner.temp }}/onedrive-smoke
 
     steps:
       - name: Checkout repository with full history and tags
@@ -57,12 +56,10 @@ jobs:
             git \
             curl \
             ldc \
-            gdb \
             libcurl4-openssl-dev \
             libsqlite3-dev \
             libsystemd-dev \
-            libdbus-1-dev \
-            procps
+            libdbus-1-dev
 
       - name: Build client
         shell: bash
@@ -76,7 +73,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          rm -rf "$TESTROOT"
+          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -89,15 +86,13 @@ jobs:
           chmod 600 "$TESTROOT/config/refresh_token"
 
       - name: Run monitor smoke test
-        id: smoke_test
         shell: bash
         run: |
           set -euo pipefail
 
+          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
           BIN="$GITHUB_WORKSPACE/onedrive"
-
-          : > "$LOGFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -112,10 +107,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "status=unclean" >> "$GITHUB_OUTPUT"
-              echo "reason=early_exit" >> "$GITHUB_OUTPUT"
-              echo "rc=$RC" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "Early exit code: $RC"
+              echo "----- monitor.log -----"
+              cat "$LOGFILE" || true
+              exit 1
             fi
 
             if grep -Fq "Sync with Microsoft OneDrive is complete" "$LOGFILE"; then
@@ -133,16 +128,13 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
-            RC=$?
             set -e
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=timeout_waiting_for_monitor_idle" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
           echo "Steady state reached; sending SIGINT"
-          ps -o pid,ppid,pgid,sid,stat,cmd -p "$PID" || true
           kill -INT "$PID"
 
           set +e
@@ -153,108 +145,40 @@ jobs:
           echo "Exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=fatal_pattern_in_log" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-          elif [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=unexpected_exit_code" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=clean" >> "$GITHUB_OUTPUT"
-            echo "reason=clean_exit" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+            echo "Fatal shutdown pattern detected"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-      - name: Run gdb diagnostics on unclean exit
-        if: steps.smoke_test.outputs.status != 'clean'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          BIN="$GITHUB_WORKSPACE/onedrive"
-          GDBLOG="$TESTROOT/gdb.log"
-          GDB_MONITOR_LOG="$TESTROOT/monitor-gdb.log"
-          GDB_WRAPPER="$TESTROOT/run-under-gdb.sh"
-
-          rm -f "$GDBLOG" "$GDB_MONITOR_LOG" "$GDB_WRAPPER"
-
-          cat > "$GDB_WRAPPER" <<EOF
-          #!/usr/bin/env bash
-          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$GDB_MONITOR_LOG" 2>&1
-          EOF
-          chmod +x "$GDB_WRAPPER"
-
-          echo "Starting gdb diagnostic rerun"
-          gdb -q -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" --args /usr/bin/env bash "$GDB_WRAPPER" >"$GDBLOG" 2>&1 &
-          GDBPID=$!
-
-          echo "Started gdb PID: $GDBPID"
-
-          READY=0
-          for _ in $(seq 1 180); do
-            if ! kill -0 "$GDBPID" 2>/dev/null; then
-              echo "gdb exited before reaching steady state"
-              break
-            fi
-
-            if [ -f "$GDB_MONITOR_LOG" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDB_MONITOR_LOG"; then
-              READY=1
-              break
-            fi
-
-            sleep 5
-          done
-
-          if [ "$READY" -eq 1 ]; then
-            INFERIOR_PID="$(pgrep -f "$BIN --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
-            if [ -n "$INFERIOR_PID" ]; then
-              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
-              ps -o pid,ppid,pgid,sid,stat,cmd -p "$INFERIOR_PID" || true
-              kill -INT "$INFERIOR_PID" || true
-            else
-              echo "Unable to determine inferior PID during gdb rerun"
-            fi
-          else
-            echo "gdb rerun did not reach steady state before timeout"
+          if [ "$RC" -eq 139 ]; then
+            echo "SIGSEGV exit detected"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-          set +e
-          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
-          WAIT_RC=$?
-          set -e
-
-          echo "GDB wait result: $WAIT_RC"
-
-          if kill -0 "$GDBPID" 2>/dev/null; then
-            echo "gdb still running; terminating"
-            kill -TERM "$GDBPID" 2>/dev/null || true
-            sleep 5
-            kill -KILL "$GDBPID" 2>/dev/null || true
+          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+            echo "Unexpected exit code: $RC"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-      - name: Upload failure diagnostics
-        if: always() && steps.smoke_test.outputs.status != 'clean'
+          echo "Clean shutdown verified"
+
+      - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-monitor-ubuntu-${{ matrix.ubuntu }}-diagnostics
+          name: smoke-monitor-${{ matrix.ubuntu }}-logs
           path: ${{ runner.temp }}/onedrive-smoke/
           if-no-files-found: warn
-
-      - name: Fail job on unclean shutdown
-        if: steps.smoke_test.outputs.status != 'clean'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Smoke test failed with status: ${{ steps.smoke_test.outputs.status }}"
-          echo "Reason: ${{ steps.smoke_test.outputs.reason }}"
-          echo "Exit code: ${{ steps.smoke_test.outputs.rc }}"
-          exit 1
 
   fedora-monitor-exit:
     name: Fedora ${{ matrix.fedora }} monitor clean exit
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 30
     environment:
       name: smoke-test
       deployment: false
@@ -270,7 +194,6 @@ jobs:
 
     env:
       SMOKE_REFRESH_TOKEN: ${{ secrets.SMOKE_PERSONAL_REFRESH_TOKEN }}
-      TESTROOT: /tmp/onedrive-smoke
 
     steps:
       - name: Checkout repository with full history and tags
@@ -298,7 +221,6 @@ jobs:
             git \
             curl \
             ldc \
-            gdb \
             libcurl-devel \
             sqlite-devel \
             dbus-devel \
@@ -317,7 +239,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          rm -rf "$TESTROOT"
+          TESTROOT="/tmp/onedrive-smoke"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -330,15 +252,13 @@ jobs:
           chmod 600 "$TESTROOT/config/refresh_token"
 
       - name: Run monitor smoke test
-        id: smoke_test
         shell: bash
         run: |
           set -euo pipefail
 
+          TESTROOT="/tmp/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
           BIN="$GITHUB_WORKSPACE/onedrive"
-
-          : > "$LOGFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -353,10 +273,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "status=unclean" >> "$GITHUB_OUTPUT"
-              echo "reason=early_exit" >> "$GITHUB_OUTPUT"
-              echo "rc=$RC" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "Early exit code: $RC"
+              echo "----- monitor.log -----"
+              cat "$LOGFILE" || true
+              exit 1
             fi
 
             if grep -Fq "Sync with Microsoft OneDrive is complete" "$LOGFILE"; then
@@ -374,16 +294,13 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
-            RC=$?
             set -e
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=timeout_waiting_for_monitor_idle" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
           echo "Steady state reached; sending SIGINT"
-          ps -o pid,ppid,pgid,sid,stat,cmd -p "$PID" || true
           kill -INT "$PID"
 
           set +e
@@ -394,100 +311,32 @@ jobs:
           echo "Exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=fatal_pattern_in_log" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-          elif [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
-            echo "status=unclean" >> "$GITHUB_OUTPUT"
-            echo "reason=unexpected_exit_code" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=clean" >> "$GITHUB_OUTPUT"
-            echo "reason=clean_exit" >> "$GITHUB_OUTPUT"
-            echo "rc=$RC" >> "$GITHUB_OUTPUT"
+            echo "Fatal shutdown pattern detected"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-      - name: Run gdb diagnostics on unclean exit
-        if: steps.smoke_test.outputs.status != 'clean'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          BIN="$GITHUB_WORKSPACE/onedrive"
-          GDBLOG="$TESTROOT/gdb.log"
-          GDB_MONITOR_LOG="$TESTROOT/monitor-gdb.log"
-          GDB_WRAPPER="$TESTROOT/run-under-gdb.sh"
-
-          rm -f "$GDBLOG" "$GDB_MONITOR_LOG" "$GDB_WRAPPER"
-
-          cat > "$GDB_WRAPPER" <<EOF
-          #!/usr/bin/env bash
-          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$GDB_MONITOR_LOG" 2>&1
-          EOF
-          chmod +x "$GDB_WRAPPER"
-
-          echo "Starting gdb diagnostic rerun"
-          gdb -q -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" --args /usr/bin/env bash "$GDB_WRAPPER" >"$GDBLOG" 2>&1 &
-          GDBPID=$!
-
-          echo "Started gdb PID: $GDBPID"
-
-          READY=0
-          for _ in $(seq 1 180); do
-            if ! kill -0 "$GDBPID" 2>/dev/null; then
-              echo "gdb exited before reaching steady state"
-              break
-            fi
-
-            if [ -f "$GDB_MONITOR_LOG" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDB_MONITOR_LOG"; then
-              READY=1
-              break
-            fi
-
-            sleep 5
-          done
-
-          if [ "$READY" -eq 1 ]; then
-            INFERIOR_PID="$(pgrep -f "$BIN --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
-            if [ -n "$INFERIOR_PID" ]; then
-              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
-              ps -o pid,ppid,pgid,sid,stat,cmd -p "$INFERIOR_PID" || true
-              kill -INT "$INFERIOR_PID" || true
-            else
-              echo "Unable to determine inferior PID during gdb rerun"
-            fi
-          else
-            echo "gdb rerun did not reach steady state before timeout"
+          if [ "$RC" -eq 139 ]; then
+            echo "SIGSEGV exit detected"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-          set +e
-          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
-          WAIT_RC=$?
-          set -e
-
-          echo "GDB wait result: $WAIT_RC"
-
-          if kill -0 "$GDBPID" 2>/dev/null; then
-            echo "gdb still running; terminating"
-            kill -TERM "$GDBPID" 2>/dev/null || true
-            sleep 5
-            kill -KILL "$GDBPID" 2>/dev/null || true
+          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+            echo "Unexpected exit code: $RC"
+            echo "----- monitor.log -----"
+            cat "$LOGFILE" || true
+            exit 1
           fi
 
-      - name: Upload failure diagnostics
-        if: always() && steps.smoke_test.outputs.status != 'clean'
+          echo "Clean shutdown verified"
+
+      - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-monitor-fedora-${{ matrix.fedora }}-diagnostics
+          name: smoke-monitor-fedora-${{ matrix.fedora }}-logs
           path: /tmp/onedrive-smoke/
           if-no-files-found: warn
-
-      - name: Fail job on unclean shutdown
-        if: steps.smoke_test.outputs.status != 'clean'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Smoke test failed with status: ${{ steps.smoke_test.outputs.status }}"
-          echo "Reason: ${{ steps.smoke_test.outputs.reason }}"
-          echo "Exit code: ${{ steps.smoke_test.outputs.rc }}"
-          exit 1

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -62,6 +62,12 @@ jobs:
             libsystemd-dev \
             libdbus-1-dev
 
+      - name: Enable debuginfod for gdb
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'DEBUGINFOD_URLS=https://debuginfod.ubuntu.com' >> "$GITHUB_ENV"
+
       - name: Build client
         shell: bash
         run: |
@@ -97,7 +103,7 @@ jobs:
 
           cat > "$TESTROOT/run-under-gdb.sh" <<EOF
           #!/usr/bin/env bash
-          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
           EOF
 
           chmod +x "$TESTROOT/run-under-gdb.sh"
@@ -299,7 +305,14 @@ jobs:
             sqlite-devel \
             dbus-devel \
             which \
-            procps-ng
+            procps-ng \
+            dnf-plugins-core
+
+      - name: Install core debuginfo packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          dnf -y debuginfo-install glibc libcurl sqlite systemd || true
 
       - name: Build client
         shell: bash
@@ -336,7 +349,7 @@ jobs:
 
           cat > "$TESTROOT/run-under-gdb.sh" <<EOF
           #!/usr/bin/env bash
-          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
           EOF
 
           chmod +x "$TESTROOT/run-under-gdb.sh"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -15,7 +15,7 @@ jobs:
   ubuntu-monitor-exit:
     name: Ubuntu ${{ matrix.ubuntu }} monitor clean exit
     runs-on: ${{ matrix.ubuntu }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment:
       name: smoke-test
       deployment: false
@@ -56,6 +56,7 @@ jobs:
             git \
             curl \
             ldc \
+            gdb \
             libcurl4-openssl-dev \
             libsqlite3-dev \
             libsystemd-dev \
@@ -74,6 +75,7 @@ jobs:
           set -euo pipefail
 
           TESTROOT="$RUNNER_TEMP/onedrive-smoke"
+          rm -rf "$TESTROOT"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -85,14 +87,33 @@ jobs:
           printf '%s' "$SMOKE_REFRESH_TOKEN" > "$TESTROOT/config/refresh_token"
           chmod 600 "$TESTROOT/config/refresh_token"
 
+      - name: Prepare gdb wrapper
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
+          BIN="$GITHUB_WORKSPACE/onedrive"
+
+          cat > "$TESTROOT/run-under-gdb.sh" <<EOF
+          #!/usr/bin/env bash
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
+          EOF
+
+          chmod +x "$TESTROOT/run-under-gdb.sh"
+
       - name: Run monitor smoke test
+        id: smoke
         shell: bash
         run: |
           set -euo pipefail
 
           TESTROOT="$RUNNER_TEMP/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
+          RESULTFILE="$TESTROOT/smoke-result.env"
           BIN="$GITHUB_WORKSPACE/onedrive"
+
+          rm -f "$RESULTFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -107,9 +128,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "Early exit code: $RC"
-              echo "----- monitor.log -----"
-              cat "$LOGFILE" || true
+              echo "STATUS=unclean" > "$RESULTFILE"
+              echo "REASON=early_exit" >> "$RESULTFILE"
+              echo "RC=$RC" >> "$RESULTFILE"
+              echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
               exit 1
             fi
 
@@ -128,9 +150,14 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
+            RC=$?
             set -e
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=timeout_waiting_for_monitor_idle" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -146,26 +173,107 @@ jobs:
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
             echo "Fatal shutdown pattern detected"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=fatal_pattern_in_log" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           if [ "$RC" -eq 139 ]; then
             echo "SIGSEGV exit detected"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=sigsegv_exit_code" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
             echo "Unexpected exit code: $RC"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=unexpected_exit_code" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
+          echo "STATUS=clean" > "$RESULTFILE"
+          echo "REASON=clean_exit" >> "$RESULTFILE"
+          echo "RC=$RC" >> "$RESULTFILE"
           echo "Clean shutdown verified"
+          echo "smoke_status=clean" >> "$GITHUB_OUTPUT"
+
+      - name: Run gdb diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TESTROOT="$RUNNER_TEMP/onedrive-smoke"
+          GDBLOG="$TESTROOT/gdb.log"
+          GDBCONSOLE="$TESTROOT/gdb-console.log"
+          GDBMONITOR="$TESTROOT/monitor-gdb.log"
+          GDBWRAPPER="$TESTROOT/run-under-gdb.sh"
+
+          rm -f "$GDBLOG" "$GDBCONSOLE" "$GDBMONITOR"
+
+          echo "Starting gdb diagnostic rerun"
+
+          gdb -q \
+            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
+            --args /usr/bin/env bash "$GDBWRAPPER" \
+            >"$GDBCONSOLE" 2>&1 &
+          GDBPID=$!
+
+          echo "Started gdb PID: $GDBPID"
+
+          READY=0
+          for _ in $(seq 1 180); do
+            if ! kill -0 "$GDBPID" 2>/dev/null; then
+              echo "gdb exited before reaching steady state"
+              break
+            fi
+
+            if [ -f "$GDBMONITOR" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDBMONITOR"; then
+              READY=1
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ "$READY" -eq 1 ]; then
+            INFERIOR_PID="$(pgrep -f "$GITHUB_WORKSPACE/onedrive --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
+            if [ -n "$INFERIOR_PID" ]; then
+              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
+              kill -INT "$INFERIOR_PID" || true
+            else
+              echo "Unable to determine inferior PID during gdb rerun"
+            fi
+          else
+            echo "gdb rerun did not reach steady state before timeout"
+          fi
+
+          set +e
+          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
+          WAIT_RC=$?
+          set -e
+
+          echo "GDB wait result: $WAIT_RC"
+
+          if kill -0 "$GDBPID" 2>/dev/null; then
+            echo "gdb still running; terminating"
+            kill -TERM "$GDBPID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "$GDBPID" 2>/dev/null || true
+          fi
 
       - name: Upload logs
         if: always()
@@ -178,7 +286,7 @@ jobs:
   fedora-monitor-exit:
     name: Fedora ${{ matrix.fedora }} monitor clean exit
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment:
       name: smoke-test
       deployment: false
@@ -221,6 +329,7 @@ jobs:
             git \
             curl \
             ldc \
+            gdb \
             libcurl-devel \
             sqlite-devel \
             dbus-devel \
@@ -240,6 +349,7 @@ jobs:
           set -euo pipefail
 
           TESTROOT="/tmp/onedrive-smoke"
+          rm -rf "$TESTROOT"
           mkdir -p "$TESTROOT/config" "$TESTROOT/syncdir"
 
           cat > "$TESTROOT/config/config" <<EOF
@@ -251,14 +361,33 @@ jobs:
           printf '%s' "$SMOKE_REFRESH_TOKEN" > "$TESTROOT/config/refresh_token"
           chmod 600 "$TESTROOT/config/refresh_token"
 
+      - name: Prepare gdb wrapper
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TESTROOT="/tmp/onedrive-smoke"
+          BIN="$GITHUB_WORKSPACE/onedrive"
+
+          cat > "$TESTROOT/run-under-gdb.sh" <<EOF
+          #!/usr/bin/env bash
+          exec "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$TESTROOT/monitor-gdb.log" 2>&1
+          EOF
+
+          chmod +x "$TESTROOT/run-under-gdb.sh"
+
       - name: Run monitor smoke test
+        id: smoke
         shell: bash
         run: |
           set -euo pipefail
 
           TESTROOT="/tmp/onedrive-smoke"
           LOGFILE="$TESTROOT/monitor.log"
+          RESULTFILE="$TESTROOT/smoke-result.env"
           BIN="$GITHUB_WORKSPACE/onedrive"
+
+          rm -f "$RESULTFILE"
 
           "$BIN" --confdir="$TESTROOT/config" --monitor --verbose >"$LOGFILE" 2>&1 &
           PID=$!
@@ -273,9 +402,10 @@ jobs:
               wait "$PID"
               RC=$?
               set -e
-              echo "Early exit code: $RC"
-              echo "----- monitor.log -----"
-              cat "$LOGFILE" || true
+              echo "STATUS=unclean" > "$RESULTFILE"
+              echo "REASON=early_exit" >> "$RESULTFILE"
+              echo "RC=$RC" >> "$RESULTFILE"
+              echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
               exit 1
             fi
 
@@ -294,9 +424,14 @@ jobs:
             kill -KILL "$PID" 2>/dev/null || true
             set +e
             wait "$PID"
+            RC=$?
             set -e
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=timeout_waiting_for_monitor_idle" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -312,26 +447,107 @@ jobs:
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
             echo "Fatal shutdown pattern detected"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=fatal_pattern_in_log" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           if [ "$RC" -eq 139 ]; then
             echo "SIGSEGV exit detected"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=sigsegv_exit_code" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
             echo "Unexpected exit code: $RC"
+            echo "STATUS=unclean" > "$RESULTFILE"
+            echo "REASON=unexpected_exit_code" >> "$RESULTFILE"
+            echo "RC=$RC" >> "$RESULTFILE"
             echo "----- monitor.log -----"
             cat "$LOGFILE" || true
+            echo "smoke_status=unclean" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
+          echo "STATUS=clean" > "$RESULTFILE"
+          echo "REASON=clean_exit" >> "$RESULTFILE"
+          echo "RC=$RC" >> "$RESULTFILE"
           echo "Clean shutdown verified"
+          echo "smoke_status=clean" >> "$GITHUB_OUTPUT"
+
+      - name: Run gdb diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TESTROOT="/tmp/onedrive-smoke"
+          GDBLOG="$TESTROOT/gdb.log"
+          GDBCONSOLE="$TESTROOT/gdb-console.log"
+          GDBMONITOR="$TESTROOT/monitor-gdb.log"
+          GDBWRAPPER="$TESTROOT/run-under-gdb.sh"
+
+          rm -f "$GDBLOG" "$GDBCONSOLE" "$GDBMONITOR"
+
+          echo "Starting gdb diagnostic rerun"
+
+          gdb -q \
+            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
+            --args /usr/bin/env bash "$GDBWRAPPER" \
+            >"$GDBCONSOLE" 2>&1 &
+          GDBPID=$!
+
+          echo "Started gdb PID: $GDBPID"
+
+          READY=0
+          for _ in $(seq 1 180); do
+            if ! kill -0 "$GDBPID" 2>/dev/null; then
+              echo "gdb exited before reaching steady state"
+              break
+            fi
+
+            if [ -f "$GDBMONITOR" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDBMONITOR"; then
+              READY=1
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ "$READY" -eq 1 ]; then
+            INFERIOR_PID="$(pgrep -f "$GITHUB_WORKSPACE/onedrive --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
+            if [ -n "$INFERIOR_PID" ]; then
+              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
+              kill -INT "$INFERIOR_PID" || true
+            else
+              echo "Unable to determine inferior PID during gdb rerun"
+            fi
+          else
+            echo "gdb rerun did not reach steady state before timeout"
+          fi
+
+          set +e
+          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
+          WAIT_RC=$?
+          set -e
+
+          echo "GDB wait result: $WAIT_RC"
+
+          if kill -0 "$GDBPID" 2>/dev/null; then
+            echo "gdb still running; terminating"
+            kill -TERM "$GDBPID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "$GDBPID" 2>/dev/null || true
+          fi
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./configure
+          ./configure --enable-debug
           make -j"$(nproc)"
 
       - name: Prepare smoke configuration
@@ -217,63 +217,28 @@ jobs:
           set -euo pipefail
 
           TESTROOT="$RUNNER_TEMP/onedrive-smoke"
-          GDBLOG="$TESTROOT/gdb.log"
           GDBCONSOLE="$TESTROOT/gdb-console.log"
           GDBMONITOR="$TESTROOT/monitor-gdb.log"
           GDBWRAPPER="$TESTROOT/run-under-gdb.sh"
 
-          rm -f "$GDBLOG" "$GDBCONSOLE" "$GDBMONITOR"
+          rm -f "$GDBCONSOLE" "$GDBMONITOR"
 
           echo "Starting gdb diagnostic rerun"
 
-          gdb -q \
-            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
-            --args /usr/bin/env bash "$GDBWRAPPER" \
-            >"$GDBCONSOLE" 2>&1 &
-          GDBPID=$!
-
-          echo "Started gdb PID: $GDBPID"
-
-          READY=0
-          for _ in $(seq 1 180); do
-            if ! kill -0 "$GDBPID" 2>/dev/null; then
-              echo "gdb exited before reaching steady state"
-              break
-            fi
-
-            if [ -f "$GDBMONITOR" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDBMONITOR"; then
-              READY=1
-              break
-            fi
-
-            sleep 5
-          done
-
-          if [ "$READY" -eq 1 ]; then
-            INFERIOR_PID="$(pgrep -f "$GITHUB_WORKSPACE/onedrive --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
-            if [ -n "$INFERIOR_PID" ]; then
-              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
-              kill -INT "$INFERIOR_PID" || true
-            else
-              echo "Unable to determine inferior PID during gdb rerun"
-            fi
-          else
-            echo "gdb rerun did not reach steady state before timeout"
-          fi
+          export SMOKE_GDB_MONITOR_LOG="$GDBMONITOR"
+          export SMOKE_GDB_READY_TIMEOUT="900"
 
           set +e
-          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
-          WAIT_RC=$?
+          gdb -q -batch \
+            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
+            --args /usr/bin/env bash "$GDBWRAPPER" \
+            >"$GDBCONSOLE" 2>&1
+          GDBRC=$?
           set -e
 
-          echo "GDB wait result: $WAIT_RC"
-
-          if kill -0 "$GDBPID" 2>/dev/null; then
-            echo "gdb still running; terminating"
-            kill -TERM "$GDBPID" 2>/dev/null || true
-            sleep 5
-            kill -KILL "$GDBPID" 2>/dev/null || true
-          fi
+          echo "gdb exit code: $GDBRC"
+          echo "----- gdb-console.log -----"
+          cat "$GDBCONSOLE" || true
 
       - name: Upload logs
         if: always()
@@ -340,7 +305,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./configure
+          ./configure --enable-debug
           make -j"$(nproc)"
 
       - name: Prepare smoke configuration
@@ -491,63 +456,28 @@ jobs:
           set -euo pipefail
 
           TESTROOT="/tmp/onedrive-smoke"
-          GDBLOG="$TESTROOT/gdb.log"
           GDBCONSOLE="$TESTROOT/gdb-console.log"
           GDBMONITOR="$TESTROOT/monitor-gdb.log"
           GDBWRAPPER="$TESTROOT/run-under-gdb.sh"
 
-          rm -f "$GDBLOG" "$GDBCONSOLE" "$GDBMONITOR"
+          rm -f "$GDBCONSOLE" "$GDBMONITOR"
 
           echo "Starting gdb diagnostic rerun"
 
-          gdb -q \
-            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
-            --args /usr/bin/env bash "$GDBWRAPPER" \
-            >"$GDBCONSOLE" 2>&1 &
-          GDBPID=$!
-
-          echo "Started gdb PID: $GDBPID"
-
-          READY=0
-          for _ in $(seq 1 180); do
-            if ! kill -0 "$GDBPID" 2>/dev/null; then
-              echo "gdb exited before reaching steady state"
-              break
-            fi
-
-            if [ -f "$GDBMONITOR" ] && grep -Fq "Sync with Microsoft OneDrive is complete" "$GDBMONITOR"; then
-              READY=1
-              break
-            fi
-
-            sleep 5
-          done
-
-          if [ "$READY" -eq 1 ]; then
-            INFERIOR_PID="$(pgrep -f "$GITHUB_WORKSPACE/onedrive --confdir=$TESTROOT/config --monitor --verbose" | head -n1 || true)"
-            if [ -n "$INFERIOR_PID" ]; then
-              echo "Sending SIGINT to inferior PID $INFERIOR_PID"
-              kill -INT "$INFERIOR_PID" || true
-            else
-              echo "Unable to determine inferior PID during gdb rerun"
-            fi
-          else
-            echo "gdb rerun did not reach steady state before timeout"
-          fi
+          export SMOKE_GDB_MONITOR_LOG="$GDBMONITOR"
+          export SMOKE_GDB_READY_TIMEOUT="900"
 
           set +e
-          timeout 180s bash -c 'while kill -0 '"$GDBPID"' 2>/dev/null; do sleep 1; done'
-          WAIT_RC=$?
+          gdb -q -batch \
+            -x "$GITHUB_WORKSPACE/.github/gdb/smoke-monitor.gdb" \
+            --args /usr/bin/env bash "$GDBWRAPPER" \
+            >"$GDBCONSOLE" 2>&1
+          GDBRC=$?
           set -e
 
-          echo "GDB wait result: $WAIT_RC"
-
-          if kill -0 "$GDBPID" 2>/dev/null; then
-            echo "gdb still running; terminating"
-            kill -TERM "$GDBPID" 2>/dev/null || true
-            sleep 5
-            kill -KILL "$GDBPID" 2>/dev/null || true
-          fi
+          echo "gdb exit code: $GDBRC"
+          echo "----- gdb-console.log -----"
+          cat "$GDBCONSOLE" || true
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -175,7 +175,7 @@ jobs:
           RC=$?
           set -e
 
-          echo "Exit code: $RC"
+          echo "wait() captured child exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
             echo "Fatal shutdown pattern detected"
@@ -199,7 +199,7 @@ jobs:
             exit 1
           fi
 
-          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+          if [ "$RC" -ne 0 ] && [ "$RC" -ne 2 ] && [ "$RC" -ne 130 ]; then
             echo "Unexpected exit code: $RC"
             echo "STATUS=unclean" > "$RESULTFILE"
             echo "REASON=unexpected_exit_code" >> "$RESULTFILE"
@@ -421,7 +421,7 @@ jobs:
           RC=$?
           set -e
 
-          echo "Exit code: $RC"
+          echo "wait() captured child exit code: $RC"
 
           if grep -Eqi 'sigsegv|segmentation fault|aborting|pthread_mutex_destroy failed' "$LOGFILE"; then
             echo "Fatal shutdown pattern detected"
@@ -445,7 +445,7 @@ jobs:
             exit 1
           fi
 
-          if [ "$RC" -ne 0 ] && [ "$RC" -ne 130 ]; then
+          if [ "$RC" -ne 0 ] && [ "$RC" -ne 2 ] && [ "$RC" -ne 130 ]; then
             echo "Unexpected exit code: $RC"
             echo "STATUS=unclean" > "$RESULTFILE"
             echo "REASON=unexpected_exit_code" >> "$RESULTFILE"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # OneDrive Client for Linux
 [![Version](https://img.shields.io/github/v/release/abraunegg/onedrive)](https://github.com/abraunegg/onedrive/releases)
 [![Release Date](https://img.shields.io/github/release-date/abraunegg/onedrive)](https://github.com/abraunegg/onedrive/releases)
+
 [![Test Build](https://github.com/abraunegg/onedrive/actions/workflows/testbuild.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/testbuild.yaml)
+[![Smoke Test](https://github.com/abraunegg/onedrive/actions/workflows/smoke-test.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/smoke-test.yaml)
+
 [![Build Docker Images](https://github.com/abraunegg/onedrive/actions/workflows/docker.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/docker.yaml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/driveone/onedrive)](https://hub.docker.com/r/driveone/onedrive)
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,6 @@
 
 [![Test Build](https://github.com/abraunegg/onedrive/actions/workflows/testbuild.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/testbuild.yaml)
 [![Smoke Test](https://github.com/abraunegg/onedrive/actions/workflows/smoke-test.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/smoke-test.yaml)
-
 [![Build Docker Images](https://github.com/abraunegg/onedrive/actions/workflows/docker.yaml/badge.svg)](https://github.com/abraunegg/onedrive/actions/workflows/docker.yaml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/driveone/onedrive)](https://hub.docker.com/r/driveone/onedrive)
 

--- a/src/log.d
+++ b/src/log.d
@@ -85,7 +85,7 @@ class LogBuffer {
 		// Final flush of stdout only
 		stdout.flush();
 
-		// Release references only - do not destroy the mutex during shutdown
+		// Release references only
 		condReady = null;
 		flushThread = null;
 	}
@@ -93,8 +93,10 @@ class LogBuffer {
 	
 	// Flush the logging buffer
 	private void flushBuffer() {
-		while (isRunning) {
-			flush();
+		while (true) {
+			if (!flush()) {
+				break;
+			}
 		}
 		stdout.flush();
 	}
@@ -105,6 +107,11 @@ class LogBuffer {
 		auto timeStamp = leftJustify(Clock.currTime().toString(), 28, '0');
 		
 		synchronized(bufferLock) {
+			// Do not accept new log messages once shutdown has started
+			if (!isRunning) {
+				return;
+			}
+
 			foreach (level; levels) {
 				// Normal application output
 				if (!debugLogging) {
@@ -148,16 +155,20 @@ class LogBuffer {
 	}
 
 	// Flush the logging buffer
-	private void flush() {
+	private bool flush() {
 		string[3][] messages;
 		synchronized(bufferLock) {
-			if (isRunning) {
-				while (buffer.empty && isRunning) { // buffer is empty and logging is still active
-					condReady.wait();
-				}
-				messages = buffer;
-				buffer.length = 0;
+			while (buffer.empty && isRunning) { // buffer is empty and logging is still active
+				condReady.wait();
 			}
+
+			// If shutdown has started and there is nothing left to write, exit the flush thread
+			if (buffer.empty && !isRunning) {
+				return false;
+			}
+
+			messages = buffer;
+			buffer.length = 0;
 		}
 
 		// Are there messages to process?
@@ -190,6 +201,8 @@ class LogBuffer {
 			// Clear Messages
 			messages.length = 0;
 		}
+
+		return true;
 	}
 }
 

--- a/src/log.d
+++ b/src/log.d
@@ -65,69 +65,31 @@ class LogBuffer {
 		this.flushThread.start();
 	}
 	
-	~this() {
-		if (!isRunning) {		
-			if (exitHandlerTriggered) {
-				bufferLock.unlock();	
-			}
-		}
-	}
-		
 	// Terminate Logging
 	void terminateLogging() {
-		synchronized {
-			// join all threads
-			thread_joinAll();
-			
+		synchronized(bufferLock) {
 			if (!isRunning) {
 				return; // Prevent multiple shutdowns
 			}
-			
+
 			// flag that we are no longer running due to shutting down
 			isRunning = false;
 			condReady.notifyAll(); // Wake up all waiting threads
 		}
 
-		// Wait for the flush thread to finish outside of the synchronized block to avoid deadlocks
-		if (flushThread.isRunning()) {
+		// Wait for the flush thread to finish outside of the lock to avoid deadlocks
+		if ((flushThread !is null) && flushThread.isRunning()) {
 			flushThread.join(true);
 		}
-		
-		// Flush any remaining logs
-		flushBuffer();
-		
-		// Sleep for a while to avoid busy-waiting
-		Thread.sleep(dur!"msecs"(100)); // Adjust the sleep duration as needed
-		
-		// Exit scopes
-		scope(exit) {
-			if (bufferLock !is null) {
-				bufferLock.lock();
-			}
-			
-			scope(exit) {
-				if (bufferLock !is null) {
-					bufferLock.unlock();
-					object.destroy(bufferLock);
-					bufferLock = null;
-				}
-			}
-		}
 
-		scope(failure) {
-			if (bufferLock !is null) {
-				bufferLock.lock();	
-			}
-			
-			scope(exit) {
-				if (bufferLock !is null) {
-					bufferLock.unlock();
-					object.destroy(bufferLock);
-					bufferLock = null;
-				}
-			}
-		}
+		// Final flush of stdout only
+		stdout.flush();
+
+		// Release references only - do not destroy the mutex during shutdown
+		condReady = null;
+		flushThread = null;
 	}
+	
 	
 	// Flush the logging buffer
 	private void flushBuffer() {

--- a/src/main.d
+++ b/src/main.d
@@ -3,7 +3,7 @@ module main;
 
 // What does this module require to function?
 import core.memory;
-import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
+import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit, _Exit;
 import core.sys.posix.signal;
 import core.thread;
 import core.time;
@@ -1862,16 +1862,16 @@ extern(C) nothrow @nogc @system void exitViaSignalHandler(int signo) {
 			if (signo == SIGINT) {
 				// Yes - SIGINT was used
 				printf("Due to a termination signal, internal processing stopped abruptly. The application will now exit in a unclean manner.\n");
-				exit(130);
+				_Exit(130);
 			} else {
 				// Confirmed as SIGSEGV, but not SIGINT and SIGTERM not used
 				printf("FATAL: Segmentation fault (SIGSEGV). The application encountered an internal error and will now exit in a unclean manner.\n");
-				exit(139);
+				_Exit(139);
 			}
 		} else {
 			// High probability of being shutdown by systemd, for example: systemctl --user stop onedrive
 			// Exit in a manner that does not trigger an exit failure in systemd
-			exit(0);
+			_Exit(0);
 		}
 	}
 	
@@ -1902,7 +1902,7 @@ extern(C) nothrow @nogc @system void exitViaSignalHandler(int signo) {
 			// writeln("Exception during shutdown: " ~ e.msg);
 		}
 		// Exit the process with the provided exit code
-		exit(signo);
+		_Exit(signo);
 	}
 }
 


### PR DESCRIPTION
This PR resolves a segmentation fault (SIGSEGV) that occurs during application shutdown, specifically within the logging subsystem.

Under signal-triggered termination (e.g. SIGINT via CTRL-C), the application could crash while tearing down logging resources. The failure was traced to unsafe destructor ordering and concurrent access to logging internals during shutdown.