### PR TITLE
Fix Bug #3677: Fix SIGSEGV on shutdown, implement signal-safe termination handling, and preserve itemdb thread safety

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -455,6 +455,7 @@ scgi
 scl
 sdlang
 Searchmonkey
+segv
 semanage
 sendfd
 setsebool
@@ -535,6 +536,7 @@ verifypeer
 vsid
 vti
 wal
+Wds
 websockets
 webtemplate
 weburl

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -11,7 +11,6 @@ import std.algorithm.searching;
 import core.stdc.stdlib;
 import std.json;
 import std.conv;
-import core.sync.mutex;
 
 // What other modules that we have created do we need to import?
 import sqlite;
@@ -241,11 +240,11 @@ final class ItemDatabase {
 	string selectRemoteTypeByRemoteDriveIdStmt;
 	string deleteItemByIdStmt;
 	bool databaseInitialised = false;
-	private Mutex databaseLock;
+	private Object databaseLock;
 	
 	this(string filename) {
-		// Initialise the mutex
-		databaseLock = new Mutex();
+		// Initialise the database monitor used to serialise all database access
+		databaseLock = new Object();
 		
 		db = Database(filename);
 		int dbVersion;

--- a/src/log.d
+++ b/src/log.d
@@ -67,14 +67,17 @@ class LogBuffer {
 	
 	// Terminate Logging
 	void terminateLogging() {
-		synchronized(bufferLock) {
+		// lock
+		bufferLock.lock();
+		try {
 			if (!isRunning) {
 				return; // Prevent multiple shutdowns
 			}
-
 			// flag that we are no longer running due to shutting down
 			isRunning = false;
 			condReady.notifyAll(); // Wake up all waiting threads
+		} finally {
+			bufferLock.unlock();
 		}
 
 		// Wait for the flush thread to finish outside of the lock to avoid deadlocks
@@ -89,8 +92,7 @@ class LogBuffer {
 		condReady = null;
 		flushThread = null;
 	}
-	
-	
+		
 	// Flush the logging buffer
 	private void flushBuffer() {
 		while (true) {
@@ -100,13 +102,14 @@ class LogBuffer {
 		}
 		stdout.flush();
 	}
-	
+
 	// Add the message received to the buffer for logging
 	void logThisMessage(string message, string[] levels = ["info"]) {
 		// Generate the timestamp for this log entry
 		auto timeStamp = leftJustify(Clock.currTime().toString(), 28, '0');
 		
-		synchronized(bufferLock) {
+		bufferLock.lock();
+		try {
 			// Do not accept new log messages once shutdown has started
 			if (!isRunning) {
 				return;
@@ -137,6 +140,8 @@ class LogBuffer {
 			}
 			// Notify thread to wake up
 			condReady.notify();
+		} finally {
+			bufferLock.unlock();
 		}
 	}
 		
@@ -157,7 +162,9 @@ class LogBuffer {
 	// Flush the logging buffer
 	private bool flush() {
 		string[3][] messages;
-		synchronized(bufferLock) {
+
+		bufferLock.lock();
+		try {
 			while (buffer.empty && isRunning) { // buffer is empty and logging is still active
 				condReady.wait();
 			}
@@ -169,6 +176,8 @@ class LogBuffer {
 
 			messages = buffer;
 			buffer.length = 0;
+		} finally {
+			bufferLock.unlock();
 		}
 
 		// Are there messages to process?
@@ -216,16 +225,24 @@ void initialiseLogging(bool verboseLogging = false, bool debugLogging = false) {
 void shutdownLogging() {
 	if (logBuffer !is null) {
 		// Terminate logging in a safe manner
-		logBuffer.terminateLogging();
+		auto lb = logBuffer;
+		lb.terminateLogging();
 		logBuffer = null;
 	}
 }
 
 // Function to add a log entry with multiple levels
 void addLogEntry(string message = "", string[] levels = ["info"]) {
-	// we can only add a log line if we are running ... 
-	if (isRunning) {
-		logBuffer.logThisMessage(message, levels);
+	auto lb = logBuffer;
+	// we can only add a log line if we are running ...
+	if ((lb !is null) && isRunning) {
+		lb.logThisMessage(message, levels);
+	} else {
+		// log that we tried to add a log message but it was dropped
+		stderr.writeln("TRACE log.d: addLogEntry dropped message; lb=", cast(void*) lb,
+			" isRunning=", isRunning,
+			" thread=", Thread.getThis(),
+			" msg=", message);
 	}
 }
 

--- a/src/main.d
+++ b/src/main.d
@@ -3,8 +3,9 @@ module main;
 
 // What does this module require to function?
 import core.memory;
-import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit, _Exit;
+import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.sys.posix.signal;
+import core.sys.posix.unistd : write, _exit, STDERR_FILENO;
 import core.thread;
 import core.time;
 import std.algorithm;
@@ -62,6 +63,9 @@ bool performFileSystemMonitoring = false;
 bool performDatabaseVacuum = true;
 // Flag if SIGTERM is used
 bool sigtermHandlerTriggered = false;
+// Preserve the signal that initiated shutdown so the final process exit code is correct
+int terminationSignal = 0;
+int requestedExitCode = EXIT_SUCCESS;
 
 int main(string[] cliArgs) {
 	// Application Start Time - used during monitor loop to detail how long it has been running for
@@ -108,6 +112,10 @@ int main(string[] cliArgs) {
 		performSynchronisedExitProcess("exitScope");
 		// Setup signal handling for the exit scope
 		setupExitScopeSignalHandler();
+		// Preserve signal-driven exit semantics after orderly shutdown completes
+		if (shutdownRequested()) {
+			exit(requestedExitCode);
+		}
 	}
 	
 	scope(failure) {
@@ -117,6 +125,10 @@ int main(string[] cliArgs) {
 		performSynchronisedExitProcess("failureScope");
 		// Setup signal handling for the exit scope
 		setupExitScopeSignalHandler();
+		// Preserve signal-driven exit semantics after orderly shutdown completes
+		if (shutdownRequested()) {
+			exit(requestedExitCode);
+		}
 	}
 	
 	// Read in application options as passed in
@@ -1179,6 +1191,11 @@ int main(string[] cliArgs) {
 			MonoTime lastGitHubCheckTime = MonoTime.currTime();
 			
 			while (performFileSystemMonitoring) {
+				if (shutdownRequested()) {
+					addShutdownTelemetry("monitor loop detected shutdown request before processing new work");
+					performFileSystemMonitoring = false;
+					break;
+				}
 				// Do we need to validate the runtimeSyncDirectory to check for the presence of a '.nosync' file - the disk may have been ejected ..
 				checkForNoMountScenario();
 			
@@ -1394,7 +1411,10 @@ int main(string[] cliArgs) {
 							// Not only is this really bad application behaviour, for this client, this means the application is constantly writing to disk, thus attempting to upload file changes.
 							// Unfortunately Obsidian on Linux does not provide a built-in way to disable atomic saves or switch to a backup-copy method via configuration.
 							if (appConfig.getValueBool("delay_inotify_processing")) {
-								Thread.sleep(dur!("seconds")(to!int(appConfig.getValueLong("inotify_delay"))));
+								if (sleepInterruptibly(dur!("seconds")(to!int(appConfig.getValueLong("inotify_delay"))), "delay_inotify_processing sleep")) {
+									performFileSystemMonitoring = false;
+									break;
+								}
 							}
 							
 							// Start the filesystem monitor (inotify) worker and wait for inotify event
@@ -1418,11 +1438,13 @@ int main(string[] cliArgs) {
 						// ALWAYS wait for FS worker, but only track webhook/websocket if NOT '--upload-only'
 						int res = 1;
 						bool onlineSignal = false;
+						bool shutdownDetectedDuringWait = false;
 
-						if (appConfig.getValueBool("upload_only")) {
-							receiveTimeout(sleepTime, (int msg) { res = msg; });
-						} else {
-							receiveTimeout(sleepTime, (int msg) { res = msg; }, (ulong _) { onlineSignal = true; });
+						shutdownDetectedDuringWait = waitForMonitorEventsInterruptibly(sleepTime, appConfig.getValueBool("upload_only"), res, onlineSignal);
+						if (shutdownDetectedDuringWait) {
+							performFileSystemMonitoring = false;
+							addShutdownTelemetry("monitor wait exited early due to shutdown request");
+							break;
 						}
 
 						// Debug logging of worker status
@@ -1493,7 +1515,11 @@ int main(string[] cliArgs) {
 						}
 					} else {
 						// no hooks available, nothing to check
-						Thread.sleep(sleepTime);
+						if (sleepInterruptibly(sleepTime, "monitor idle sleep")) {
+							performFileSystemMonitoring = false;
+							addShutdownTelemetry("monitor idle sleep exited early due to shutdown request");
+							break;
+						}
 					}
 				}
 			}
@@ -1854,60 +1880,117 @@ void setupSignalHandler() {
 
 // Catch SIGINT (CTRL-C), SIGTERM (kill) and SIGSEGV (invalid memory access), handle rapid repeat CTRL-C presses
 extern(C) nothrow @nogc @system void exitViaSignalHandler(int signo) {
+	enum firstSignalMsg = "
+Received termination signal, attempting to cleanly shutdown application
+";
+	enum repeatSignalMsg = "
+Termination signal received again, forcing immediate exit
+";
+	enum segvMsg = "
+FATAL: Segmentation fault (SIGSEGV). The application encountered an internal error and will now exit in an unclean manner.
+";
 
 	// Update global exitHandlerTriggered flag so that objects that depend on this know we are shutting down
 	exitHandlerTriggered = true;
-	
-	// Catch the generation of SIGSEV post SIGINT or SIGTERM event
-    if (signo == SIGSEGV) {
-		// Was SIGTERM used?
-		if (!sigtermHandlerTriggered) {
-			// No .. so most likely SIGINT (CTRL-C) - lets check
-			if (signo == SIGINT) {
-				// Yes - SIGINT was used
-				printf("Due to a termination signal, internal processing stopped abruptly. The application will now exit in a unclean manner.\n");
-				_Exit(130);
-			} else {
-				// Confirmed as SIGSEGV, but not SIGINT and SIGTERM not used
-				printf("FATAL: Segmentation fault (SIGSEGV). The application encountered an internal error and will now exit in a unclean manner.\n");
-				_Exit(139);
-			}
-		} else {
-			// High probability of being shutdown by systemd, for example: systemctl --user stop onedrive
-			// Exit in a manner that does not trigger an exit failure in systemd
-			_Exit(0);
-		}
-	}
-	
+	performFileSystemMonitoring = false;
+	terminationSignal = signo;
+
 	if (signo == SIGTERM) {
 		// systemd will use SIGTERM to terminate a running process
 		sigtermHandlerTriggered = true;
+		requestedExitCode = 0;
+	} else if (signo == SIGINT) {
+		requestedExitCode = 130;
+	} else {
+		requestedExitCode = 128 + signo;
+	}
+
+	// SIGSEGV is fatal - do not attempt a complex shutdown path from the signal handler
+	if (signo == SIGSEGV) {
+		requestedExitCode = 139;
+		write(STDERR_FILENO, segvMsg.ptr, segvMsg.length);
+		_exit(requestedExitCode);
 	}
 
 	if (shutdownInProgress) {
-		return;  // Ignore subsequent presses
-	} else {
-		// Disable logging suppression
-		appConfig.suppressLoggingOutput = false;
-		// Flag we are shutting down
-		shutdownInProgress = true;
-		
-		try {
-			assumeNoGC ( () {
-				// Log that a termination signal was caught
-				addLogEntry("\nReceived termination signal, attempting to cleanly shutdown application");
-				// Try and shutdown in a safe and synchronised manner
-				performSynchronisedExitProcess("SIGINT-SIGTERM-HANDLER");
-			})();
-		} catch (Exception e) {
-			// Any output here will cause a GC allocation
-			// - Error: `@nogc` function `main.exitHandler` cannot call non-@nogc function `std.stdio.writeln!string.writeln`
-			// - Error: cannot use operator `~` in `@nogc` function `main.exitHandler`
-			// writeln("Exception during shutdown: " ~ e.msg);
-		}
-		// Exit the process with the provided exit code
-		_Exit(signo);
+		write(STDERR_FILENO, repeatSignalMsg.ptr, repeatSignalMsg.length);
+		_exit(requestedExitCode);
 	}
+
+	shutdownInProgress = true;
+	write(STDERR_FILENO, firstSignalMsg.ptr, firstSignalMsg.length);
+}
+
+bool shutdownRequested() {
+	return shutdownInProgress || exitHandlerTriggered;
+}
+
+void addShutdownTelemetry(string message) {
+	addLogEntry("SHUTDOWN TRACE: " ~ message, ["debug"]);
+}
+
+bool sleepInterruptibly(Duration totalSleep, string reason) {
+	immutable auto sleepPollInterval = dur!"seconds"(1);
+	auto remaining = totalSleep;
+
+	while (remaining > Duration.zero) {
+		if (shutdownRequested()) {
+			addShutdownTelemetry(reason ~ " interrupted due to shutdown request");
+			return true;
+		}
+
+		auto sleepSlice = (remaining > sleepPollInterval) ? sleepPollInterval : remaining;
+		Thread.sleep(sleepSlice);
+		remaining -= sleepSlice;
+	}
+
+	return shutdownRequested();
+}
+
+bool waitForMonitorEventsInterruptibly(Duration totalWait, bool uploadOnly, ref int workerStatus, ref bool onlineSignal) {
+	immutable auto waitPollInterval  = dur!"seconds"(1);
+	auto remaining = totalWait;
+
+	while (remaining > Duration.zero) {
+		if (shutdownRequested()) {
+			addShutdownTelemetry("receiveTimeout wait interrupted due to shutdown request");
+			return true;
+		}
+
+		auto waitSlice = (remaining > waitPollInterval) ? waitPollInterval : remaining;
+		bool workerMessageReceived = false;
+		bool onlineSignalReceived = false;
+
+		if (uploadOnly) {
+			receiveTimeout(waitSlice, (int msg) {
+				workerStatus = msg;
+				workerMessageReceived = true;
+			});
+		} else {
+			receiveTimeout(waitSlice,
+				(int msg) {
+					workerStatus = msg;
+					workerMessageReceived = true;
+				},
+				(ulong _) {
+					onlineSignal = true;
+					onlineSignalReceived = true;
+				}
+			);
+		}
+
+		if (workerMessageReceived || onlineSignalReceived) {
+			return false;
+		}
+		remaining -= waitSlice;
+	}
+
+	if (shutdownRequested()) {
+		addShutdownTelemetry("receiveTimeout wait completed with shutdown request pending");
+		return true;
+	}
+
+	return false;
 }
 
 // Handle application exit
@@ -1917,6 +2000,8 @@ void performSynchronisedExitProcess(string scopeCaller = null) {
 		try {
 			// Log who called this function
 			if (debugLogging) {addLogEntry("performSynchronisedExitProcess called by: " ~ scopeCaller, ["debug"]);}
+			addShutdownTelemetry("performSynchronisedExitProcess entered by scope: " ~ (scopeCaller.length ? scopeCaller : "unknown"));
+			addShutdownTelemetry("planned final exit code: " ~ to!string(requestedExitCode) ~ ", termination signal: " ~ to!string(terminationSignal));
 			// Remove Desktop integration
 			if(performFileSystemMonitoring) {
 				// Was desktop integration enabled?
@@ -1925,6 +2010,7 @@ void performSynchronisedExitProcess(string scopeCaller = null) {
 					attemptFileManagerIntegrationRemoval();
 				}
 			}
+			
 			// Shutdown the OneDrive Webhook instance
 			shutdownOneDriveWebhook();
 			// Shutdown the OneDrive WebSocket instance
@@ -1932,10 +2018,8 @@ void performSynchronisedExitProcess(string scopeCaller = null) {
 			// Shutdown any local filesystem monitoring
 			shutdownFilesystemMonitor();
 			// Shutdown the sync engine
-			if (scopeCaller == "SIGINT-SIGTERM-HANDLER") {
-				// Wait for all parallel jobs that depend on the database being available to complete
-				addLogEntry("Waiting for any existing upload|download process to complete");
-			}
+			// Wait for all parallel jobs that depend on the database being available to complete
+			addLogEntry("Waiting for any existing upload|download process to complete");
 			shutdownSyncEngine();
 			// Release all CurlEngine instances
 			releaseAllCurlInstances();

--- a/src/monitor.d
+++ b/src/monitor.d
@@ -30,15 +30,15 @@ import clientSideFiltering;
 
 // Relevant inotify events
 version(FreeBSD) {
-     private immutable uint32_t mask = IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVE;
+	 private immutable uint32_t mask = IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVE;
 } else {
-     private immutable uint32_t mask = IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVE | IN_IGNORED | IN_Q_OVERFLOW;
+	 private immutable uint32_t mask = IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVE | IN_IGNORED | IN_Q_OVERFLOW;
 }
 
 class MonitorException: ErrnoException {
-    @safe this(string msg, string file = __FILE__, size_t line = __LINE__) {
-        super(msg, file, line);
-    }
+	@safe this(string msg, string file = __FILE__, size_t line = __LINE__) {
+		super(msg, file, line);
+	}
 }
 
 class MonitorBackgroundWorker {
@@ -160,7 +160,7 @@ class MonitorBackgroundWorker {
 
 void startMonitorJob(shared(MonitorBackgroundWorker) worker, Tid callerTid) {
 	try {
-    	worker.watch(callerTid);
+		worker.watch(callerTid);
 	} catch (OwnerTerminated error) {
 		// caller is terminated
 		worker.shutdown();
@@ -349,16 +349,22 @@ final class Monitor {
 		if(!initialised)
 			return;
 		initialised = false;
-		// Release all resources
-		synchronized(inotifyMutex) {
-			// Interrupt the worker to allow removal of inotify watch descriptors
-			worker.interrupt();
-			// Remove all the inotify watch descriptors
-			removeAll();
-			// Notify the worker that the monitor has been shutdown
-			worker.interrupt();
-			send(false);
+
+		// Interrupt the worker to allow removal of inotify watch descriptors
+		worker.interrupt();
+
+		// Remove all the inotify watch descriptors
+		removeAll();
+
+		// Notify the worker that the monitor has been shutdown
+		worker.interrupt();
+		send(false);
+
+		inotifyMutex.lock();
+		try {
 			wdToDirName = null;
+		} finally {
+			inotifyMutex.unlock();
 		}
 	}
 
@@ -449,7 +455,12 @@ final class Monitor {
 			if (debugLogging) {addLogEntry("Calling worker.addInotifyWatch() for this dirname: " ~ dirname, ["debug"]);}
 			int wd = worker.addInotifyWatch(dirname);
 			if (wd > 0) {
-				wdToDirName[wd] = buildNormalizedPath(dirname) ~ "/";
+				inotifyMutex.lock();
+				try {
+					wdToDirName[wd] = buildNormalizedPath(dirname) ~ "/";
+				} finally {
+					inotifyMutex.unlock();
+				}
 			}
 			
 			// if this is a directory, recursively add this path
@@ -509,8 +520,12 @@ final class Monitor {
 	// Remove a watch descriptor
 	private void removeAll() {
 		string[int] copy;
-		synchronized(inotifyMutex) {
+
+		inotifyMutex.lock();
+		try {
 			copy = wdToDirName.dup; // Make a thread-safe copy
+		} finally {
+			inotifyMutex.unlock();
 		}
 
 		// Loop through the watch descriptors and remove
@@ -520,32 +535,68 @@ final class Monitor {
 	}
 
 	private void remove(int wd) {
-		assert(wd in wdToDirName);
-		
-		synchronized(inotifyMutex) {
-			int ret = worker.removeInotifyWatch(wd);
+		string dirname;
+		int ret;
+
+		inotifyMutex.lock();
+		try {
+			assert(wd in wdToDirName);
+			dirname = wdToDirName[wd];
+			ret = worker.removeInotifyWatch(wd);
 			if (ret < 0) throw new MonitorException("inotify_rm_watch failed");
-			if (verboseLogging) {addLogEntry("Stopped monitoring directory (inotify watch removed): " ~ to!string(wdToDirName[wd]), ["verbose"]);}
 			wdToDirName.remove(wd);
+		} finally {
+			inotifyMutex.unlock();
 		}
+
+		if (verboseLogging) {addLogEntry("Stopped monitoring directory (inotify watch removed): " ~ dirname, ["verbose"]);}
 	}
 
 	// Remove the watch descriptors associated to the given path
 	private void remove(const(char)[] path) {
+		string[] matchingPaths;
+		int[] matchingWds;
+
 		path ~= "/";
-		foreach (wd, dirname; wdToDirName) {
-			if (dirname.startsWith(path)) {
-				int ret = worker.removeInotifyWatch(wd);
-				if (ret < 0) throw new MonitorException("inotify_rm_watch failed");
-				wdToDirName.remove(wd);
-				if (verboseLogging) {addLogEntry("Stopped monitoring directory (inotify watch removed): " ~ dirname, ["verbose"]);}
+
+		inotifyMutex.lock();
+		try {
+			foreach (wd, dirname; wdToDirName) {
+				if (dirname.startsWith(path)) {
+					matchingWds ~= wd;
+					matchingPaths ~= dirname;
+				}
 			}
+		} finally {
+			inotifyMutex.unlock();
+		}
+
+		foreach (idx, wd; matchingWds) {
+			int ret = worker.removeInotifyWatch(wd);
+			if (ret < 0) throw new MonitorException("inotify_rm_watch failed");
+
+			inotifyMutex.lock();
+			try {
+				wdToDirName.remove(wd);
+			} finally {
+				inotifyMutex.unlock();
+			}
+
+			if (verboseLogging) {addLogEntry("Stopped monitoring directory (inotify watch removed): " ~ matchingPaths[idx], ["verbose"]);}
 		}
 	}
 
 	// Return the file path from an inotify event
 	private string getPath(const(inotify_event)* event) {
-		string path = wdToDirName[event.wd];
+		string path;
+
+		inotifyMutex.lock();
+		try {
+			path = wdToDirName[event.wd];
+		} finally {
+			inotifyMutex.unlock();
+		}
+
 		if (event.len > 0) path ~= fromStringz(event.name.ptr);
 		if (debugLogging) {addLogEntry("inotify path event for: " ~ path, ["debug"]);}
 		return path;
@@ -618,7 +669,12 @@ final class Monitor {
 					// skip events that need to be ignored
 					if (event.mask & IN_IGNORED) {
 						// forget the directory associated to the watch descriptor
-						wdToDirName.remove(event.wd);
+						inotifyMutex.lock();
+						try {
+							wdToDirName.remove(event.wd);
+						} finally {
+							inotifyMutex.unlock();
+						}
 						goto skip;
 					} else if (event.mask & IN_Q_OVERFLOW) {
 						throw new MonitorException("inotify queue overflow: some events may be lost");


### PR DESCRIPTION
This PR resolves a long-standing issue where the application could crash with a SIGSEGV during shutdown, and improves overall shutdown behaviour, signal handling, and thread safety.

The changes ensure that:

* A single CTRL-C (SIGINT) results in a clean, synchronised shutdown
* The application no longer crashes during shutdown due to unsafe signal handling
* Exit codes correctly reflect the termination signal
* Database access remains safely serialised across multiple worker threads