### PR TITLE
Fix Bug #3704: Fix 'sync_list' wildcard exclusion rules can incorrectly exclude ancestor directories

### DIFF
--- a/src/clientSideFiltering.d
+++ b/src/clientSideFiltering.d
@@ -27,6 +27,10 @@ class ClientSideFiltering {
 	bool skipDirStrictMatch = false;
 	bool skipDotfiles = false;
 	
+	// Define these at the class level
+	string wildcard = "*";
+	string globbing = "**";
+	
 	this(ApplicationConfig appConfig) {
 		// Configure the class variable to consume the application configuration
 		this.appConfig = appConfig;
@@ -378,9 +382,7 @@ class ClientSideFiltering {
 		bool wildcardRuleMatched = false; // will get updated if the 'wildcard' rule matches
 		bool excludeWildcardMatched = false; // will get updated if the 'wildcard' rule matches
 		int offset;
-		string wildcard = "*";
-		string globbing = "**";
-				
+						
 		// always allow the root
 		if (path == ".") return false;
 		
@@ -685,6 +687,46 @@ class ClientSideFiltering {
 				
 				// Does the parents of the input path and rule path match .. meaning we can actually evaluate this wildcard rule against the input path
 				if (matchFirstSegmentToPathFirstSegment(ruleSegments, pathSegments)) {
+
+					// A deeper wildcard/globbing exclusion rule must not exclude an ancestor path
+					// when the next unmatched rule segment is a named path component.
+					//
+					// Example:
+					//     input path: /SHARED_FOLDERS/SUB_FOLDER_1/CORE
+					//     exclusion:  !/SHARED_FOLDERS/SUB_FOLDER_1/CORE/nested/exclude/*
+					//
+					// The input path ends at CORE and the next rule segment is "nested",
+					// not "*" or "**". The exclusion targets a deeper named child path,
+					// not the CORE directory itself.
+					//
+					// Do not apply this guard when the next unmatched rule segment is "*" or "**",
+					// as those rules intentionally target the direct or recursive contents below
+					// the current input path.
+					if (thisIsAnExcludeRule && exclusionRuleTargetsNamedChildBeyondInputPath(ruleSegments, pathSegments)) {
+						if (debugLogging) {
+							addLogEntry("Evaluation against 'sync_list' rule result: exclusion wildcard|globbing rule targets a deeper named child path; ancestor input path must not be excluded", ["debug"]);
+						}
+						continue;
+					}
+
+					// A child-only exclusion rule must not exclude the container itself when
+					// there is an explicit include rule for that same container.
+					//
+					// Example:
+					//     exclusion: !/SHARED_FOLDERS/SUB_FOLDER_2/WIDE_*_15/*
+					//     inclusion:  /SHARED_FOLDERS/SUB_FOLDER_2/WIDE_*/
+					//     input:      /SHARED_FOLDERS/SUB_FOLDER_2/WIDE_SET_15
+					//
+					// The exclusion applies to children below WIDE_SET_15, not to the
+					// WIDE_SET_15 container itself. This is intentionally guarded by the
+					// presence of a same-depth include rule so ordinary deeper exclusions
+					// such as !/Projects/Code*/JOBXYZ/Exports/* are not weakened.
+					if (thisIsAnExcludeRule && childWildcardExclusionHasSpecificIncludeForCurrentPath(ruleSegments, pathSegments)) {
+						if (debugLogging) {
+							addLogEntry("Evaluation against 'sync_list' rule result: child-only wildcard exclusion targets contents below an explicitly included container; container input path must not be excluded", ["debug"]);
+						}
+						continue;
+					}
 					
 					// Is this a globbing rule (**) or just a single wildcard (*) entries
 					if (globbingRule) {
@@ -728,6 +770,24 @@ class ClientSideFiltering {
 						}
 					}
 					
+
+					// If this is an include rule that targets a descendant path, allow the
+					// current input path as a traversal container even before the final
+					// descendant exists in the evaluation path.
+					//
+					// Example:
+					//     include: /SHARED_FOLDERS/SUB_FOLDER_2/TREE/**/tree.txt
+					//     input:   /SHARED_FOLDERS/SUB_FOLDER_2/TREE
+					//
+					// TREE itself does not directly match tree.txt, but it must be
+					// traversed so that A/B/C/tree.txt can be discovered and included.
+					if (!thisIsAnExcludeRule && !wildcardRuleMatched && inclusionWildcardRuleCanMatchDescendant(ruleSegments, pathSegments)) {
+						wildcardRuleMatched = true;
+						if (debugLogging) {
+							addLogEntry("Evaluation against 'sync_list' rule result: wildcard|globbing inclusion rule requires traversal of this container path", ["debug"]);
+						}
+					}
+
 					// Was the rule matched?
 					if (wildcardRuleMatched) {
 						// Is this an exclude rule?
@@ -741,7 +801,8 @@ class ClientSideFiltering {
 							// include rule
 							if (debugLogging) {addLogEntry("Evaluation against 'sync_list' rule result: wildcard|globbing pattern matched and must be included", ["debug"]);}
 							finalResult = false;
-							excludeWildcardMatched = false;
+							// Do not clear excludeWildcardMatched here.
+							// A prior wildcard/globbing exclusion rule must retain precedence over a later wildcard/globbing inclusion rule for the same path.
 						}
 					} else {
 						if (debugLogging) {addLogEntry("Evaluation against 'sync_list' rule result: No match to 'sync_list' wildcard|globbing rule", ["debug"]);}
@@ -816,6 +877,168 @@ class ClientSideFiltering {
 		return !match(pathSegment, pattern).empty;
 	}
 	
+
+	// Function to determine if an exclusion wildcard/globbing rule targets a deeper named child path beyond the current input path.
+	//
+	// This prevents a deeper exclusion such as:
+	//     !/SHARED_FOLDERS/SUB_FOLDER_1/CORE/nested/exclude/*
+	// from incorrectly excluding the ancestor path:
+	//     /SHARED_FOLDERS/SUB_FOLDER_1/CORE
+	//
+	// This helper is intentionally used only for exclusion wildcard/globbing rules so that
+	// existing include traversal behaviour is not altered.
+	//
+	// The guard is intentionally narrow:
+	// - If the input path is not a prefix of the rule, do not guard.
+	// - If the rule is not deeper than the input path, do not guard.
+	// - If the next unmatched rule segment is "*" or "**", do not guard because
+	//   the rule intentionally targets the contents below the input path.
+	// - If the next unmatched rule segment is a named segment, guard because the rule
+	//   targets a deeper child path and must not exclude the ancestor.
+	bool exclusionRuleTargetsNamedChildBeyondInputPath(string[] ruleSegments, string[] pathSegments) {
+		// If the rule is not deeper than the input path, there is no deeper named child path to guard
+		if (ruleSegments.length <= pathSegments.length) {
+			return false;
+		}
+
+		// Compare the input path against the equivalent prefix of the rule path
+		foreach (index, pathSegment; pathSegments) {
+			if (!matchSegment(ruleSegments[index], pathSegment)) {
+				return false;
+			}
+		}
+
+		// The input path is a prefix of the rule. Inspect the next unmatched rule segment.
+		string nextRuleSegment = ruleSegments[pathSegments.length];
+
+		// If the next segment is a wildcard/globbing segment, the rule is intentionally targeting
+		// contents immediately below the input path, so allow normal exclusion evaluation.
+		if ((nextRuleSegment == wildcard) || (nextRuleSegment == globbing)) {
+			return false;
+		}
+
+		// The next segment is a named child path, so this exclusion rule must not exclude the ancestor.
+		return true;
+	}
+
+	// Function to determine if an exclusion rule of the form:
+	//     /path/to/container/*
+	// is being evaluated against the container itself, and that same container
+	// is explicitly included by an include rule at the same path depth.
+	//
+	// This preserves child-only exclusion semantics without weakening broader
+	// exclusion precedence. The same-depth include requirement is important:
+	// it prevents a broad include such as /Projects/Code* from re-including a
+	// deeper excluded container such as /Projects/Code/JOBXYZ/Exports.
+	bool childWildcardExclusionHasSpecificIncludeForCurrentPath(string[] ruleSegments, string[] pathSegments) {
+		// This helper only applies to direct child wildcard exclusions where the
+		// rule is exactly one segment deeper than the current input path.
+		if (ruleSegments.length != pathSegments.length + 1) {
+			return false;
+		}
+
+		// Only direct child wildcard exclusions are handled here. Globbing exclusions
+		// are intentionally left to the normal exclusion logic.
+		if (ruleSegments[$ - 1] != wildcard) {
+			return false;
+		}
+
+		// The current input path must match the exclusion rule's container prefix.
+		foreach (index, pathSegment; pathSegments) {
+			if (!matchSegment(ruleSegments[index], pathSegment)) {
+				return false;
+			}
+		}
+
+		// The same container must be explicitly included at the same path depth.
+		foreach (includeRule; syncListIncludePathsOnly) {
+			if (includeRule.empty) continue;
+
+			string candidate = includeRule;
+			if (candidate.endsWith("/*")) {
+				candidate = candidate[0 .. $ - 2];
+			}
+			if (candidate.length > 1 && candidate[$ - 1] == '/') {
+				candidate = candidate[0 .. $ - 1];
+			}
+
+			string[] includeSegments = candidate.strip.split("/").filter!(s => !s.empty).array;
+			if (includeSegments.length != pathSegments.length) {
+				continue;
+			}
+
+			bool includeMatchesCurrentPath = true;
+			foreach (index, pathSegment; pathSegments) {
+				if (!matchSegment(includeSegments[index], pathSegment)) {
+					includeMatchesCurrentPath = false;
+					break;
+				}
+			}
+
+			if (includeMatchesCurrentPath) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	// Function to determine if an include wildcard/globbing rule can match a
+	// descendant of the current input path. This allows directory/container
+	// traversal for rules that target deeper file descendants, for example:
+	//     /SHARED_FOLDERS/SUB_FOLDER_2/TREE/**/tree.txt
+	// when evaluating:
+	//     /SHARED_FOLDERS/SUB_FOLDER_2/TREE
+	//
+	// This must not be used as a broad include for every container below a
+	// globbing segment. For example, this rule:
+	//     /ZZ_E2E_SYNC_LIST/Programming/Projects/**/src/
+	// must include matching src directories only. It must not include sibling
+	// containers such as build, .gradle, .next, node_modules or __pycache__
+	// merely because they are below Programming/Projects.
+	bool inclusionWildcardRuleCanMatchDescendant(string[] ruleSegments, string[] pathSegments) {
+		if (pathSegments.empty || ruleSegments.empty) {
+			return false;
+		}
+
+		// This helper exists to allow traversal for descendant file targets such
+		// as **/tree.txt. Directory include rules such as **/src/ are handled by
+		// normal segment matching and must not cause unrelated sibling containers
+		// to be included. Because sync_list normalisation removes the trailing
+		// slash, use a conservative file-target heuristic here.
+		string terminalRuleSegment = ruleSegments[$ - 1];
+		if (terminalRuleSegment == wildcard || terminalRuleSegment == globbing || !canFind(terminalRuleSegment, ".")) {
+			return false;
+		}
+
+		size_t ruleIndex = 0;
+		size_t pathIndex = 0;
+
+		while (pathIndex < pathSegments.length) {
+			if (ruleIndex >= ruleSegments.length) {
+				return false;
+			}
+
+			if (ruleSegments[ruleIndex] == globbing) {
+				// A globbing segment may consume the current path segment only for
+				// the conservative descendant-file traversal case guarded above.
+				return true;
+			}
+
+			if (!matchSegment(ruleSegments[ruleIndex], pathSegments[pathIndex])) {
+				return false;
+			}
+
+			pathIndex++;
+			ruleIndex++;
+		}
+
+		// The full input path matched the leading portion of the include rule and
+		// the rule still has unmatched segments. Therefore a descendant of the
+		// current input path can match this include rule.
+		return ruleIndex < ruleSegments.length;
+	}
+
 	// Function to handle path matching when using globbing (**)
 	bool matchPathAgainstRule(string path, string rule) {
 		// Split both the path and rule into segments

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -1013,10 +1013,44 @@ final class ItemDatabase {
 						// Move up one level (within the same drive)
 						id = item.parentId;
 
-						// Check for relocation and handle the relocation
+						// Check for relocation and handle the relocation.
+						//
+						// For Personal Shared Folders, a single remote drive root can be represented
+						// locally by multiple shared-folder shortcut mount points. In that case the
+						// root row's relocDriveId/relocParentId is not specific enough: it can point
+						// at a sibling shortcut location and cause computePath() to reconstruct the
+						// child path under the wrong logical parent.
+						//
+						// Prefer resolving via the highest non-root remote item we saw before the
+						// root. This maps the remote shared-folder root back to the exact local
+						// shortcut row. If no such mount point exists, fall back to the legacy root
+						// relocation fields.
 						if (item.type == ItemType.root && item.relocDriveId !is null && item.relocParentId !is null) {
-							driveId = item.relocDriveId;
-							id = item.relocParentId;
+							bool relocatedViaRemoteAnchor = false;
+
+							if (anchorCandidateItemId.length) {
+								s2.bind(1, anchorCandidateDriveId);
+								s2.bind(2, anchorCandidateItemId);
+								auto r2 = s2.exec();
+
+								if (!r2.empty) {
+									// Jump into the drive that contains the exact shared-folder mount point
+									// for the remote item that anchored this generated path.
+									driveId = r2.front[0].dup;
+									id      = r2.front[1].dup;
+									relocatedViaRemoteAnchor = true;
+
+									// Avoid reusing the remote-drive anchor after crossing back into the
+									// local logical hierarchy.
+									anchorCandidateDriveId = "";
+									anchorCandidateItemId = "";
+								}
+							}
+
+							if (!relocatedViaRemoteAnchor) {
+								driveId = item.relocDriveId;
+								id = item.relocParentId;
+							}
 						}
 					} else {
 						// We fell off the top (id == null). Try to jump to the anchor (mount point).

--- a/src/sync.d
+++ b/src/sync.d
@@ -214,6 +214,7 @@ class SyncEngine {
 	// Shared Folder Flags for 'sync_list' processing
 	bool sharedFolderDeltaGeneration = false;
 	string currentSharedFolderName = "";
+	string currentSharedFolderLogicalPath = "";
 	
 	// Directory excluded by 'sync_list flag so that when scanning that directory, if it is excluded, 
 	// can be scanned for new data which may be included by other include rule, but parent is excluded
@@ -879,13 +880,13 @@ class SyncEngine {
 					}
 					
 					// Directory name is not excluded or skip_dir is not populated
+					// So that we represent correctly where this shared folder is, calculate the path
+					string sharedFolderLogicalPath = computeItemPath(remoteItem.driveId, remoteItem.id);
 					if (!appConfig.suppressLoggingOutput) {
-						// So that we represent correctly where this shared folder is, calculate the path
-						string sharedFolderLogicalPath = computeItemPath(remoteItem.driveId, remoteItem.id);
 						addLogEntry("Syncing this OneDrive Personal Shared Folder: " ~ ensureStartsWithDotSlash(sharedFolderLogicalPath));
 					}
 					// Check this OneDrive Personal Shared Folder for changes
-					fetchOneDriveDeltaAPIResponse(remoteItem.remoteDriveId, remoteItem.remoteId, remoteItem.name);
+					fetchOneDriveDeltaAPIResponse(remoteItem.remoteDriveId, remoteItem.remoteId, remoteItem.name, sharedFolderLogicalPath);
 					
 					// Process any download activities or cleanup actions for this OneDrive Personal Shared Folder
 					processDownloadActivities();
@@ -919,9 +920,9 @@ class SyncEngine {
 							}
 							
 							// Directory name is not excluded or skip_dir is not populated
+							// So that we represent correctly where this shared folder is, calculate the path
+							string sharedFolderLogicalPath = computeItemPath(remoteItem.driveId, remoteItem.id);
 							if (!appConfig.suppressLoggingOutput) {
-								// So that we represent correctly where this shared folder is, calculate the path
-								string sharedFolderLogicalPath = computeItemPath(remoteItem.driveId, remoteItem.id);
 								addLogEntry("Syncing this OneDrive Business Shared Folder: " ~ sharedFolderLogicalPath);
 							}
 							
@@ -933,7 +934,7 @@ class SyncEngine {
 							}
 							
 							// Check this OneDrive Business Shared Folder for changes
-							fetchOneDriveDeltaAPIResponse(remoteItem.remoteDriveId, remoteItem.remoteId, remoteItem.name);
+							fetchOneDriveDeltaAPIResponse(remoteItem.remoteDriveId, remoteItem.remoteId, remoteItem.name, sharedFolderLogicalPath);
 							
 							// Process any download activities or cleanup actions for this OneDrive Business Shared Folder
 							processDownloadActivities();
@@ -1156,7 +1157,7 @@ class SyncEngine {
 	}
 	
 	// Query OneDrive API for /delta changes and iterate through items online
-	void fetchOneDriveDeltaAPIResponse(string driveIdToQuery = null, string itemIdToQuery = null, string sharedFolderName = null) {
+	void fetchOneDriveDeltaAPIResponse(string driveIdToQuery = null, string itemIdToQuery = null, string sharedFolderName = null, string sharedFolderLogicalPath = null) {
 		// Function Start Time
 		SysTime functionStartTime;
 		string logKey;
@@ -1186,6 +1187,7 @@ class SyncEngine {
 		// Reset Shared Folder Flags for 'sync_list' processing
 		sharedFolderDeltaGeneration = false;
 		currentSharedFolderName = "";
+		currentSharedFolderLogicalPath = "";
 		
 		// Was a driveId provided as an input
 		if (strip(driveIdToQuery).empty) {
@@ -1234,6 +1236,8 @@ class SyncEngine {
 			// When using 'sync_list' we need to do this
 			sharedFolderDeltaGeneration = true;
 			currentSharedFolderName = sharedFolderName;
+			currentSharedFolderLogicalPath = sharedFolderLogicalPath.empty ? sharedFolderName : sharedFolderLogicalPath;
+			if (debugLogging) {addLogEntry("Current shared-folder logical path for generated delta processing: " ~ currentSharedFolderLogicalPath, ["debug"]);}
 			generatedSimulatedDeltaResponse = true;
 		}
 		
@@ -2207,6 +2211,14 @@ class SyncEngine {
 					newItemPath = computedItemPath ~ "/" ~ thisItemName;
 				}
 				
+				string generatedSharedFolderItemPath = computeGeneratedSharedFolderDeltaPath(onedriveJSONItem);
+				if (!generatedSharedFolderItemPath.empty) {
+					if (debugLogging) {
+						addLogEntry("Overriding JSON Item calculated full path using active shared-folder generated-delta logical path = " ~ generatedSharedFolderItemPath, ["debug"]);
+					}
+					newItemPath = generatedSharedFolderItemPath;
+				}
+
 				// debug logging of what was calculated
 				if (debugLogging) {addLogEntry("JSON Item calculated full path is: " ~ newItemPath, ["debug"]);}
 			} else {
@@ -4661,6 +4673,96 @@ class SyncEngine {
 		}
 	}
 	
+	// Compute a Shared Folder path
+	string computeGeneratedSharedFolderDeltaPath(JSONValue onedriveJSONItem, bool parentOnly = false) {
+		// This helper is intentionally limited to self-generated /delta responses for Shared Folders.
+		// In that mode Microsoft Graph returns paths from the owner drive, but the client must
+		// evaluate and materialise paths under the selected local Shared Folder shortcut.
+		if ((!sharedFolderDeltaGeneration) || (currentSharedFolderLogicalPath.empty)) {
+			return "";
+		}
+		if (!hasParentReference(onedriveJSONItem)) {
+			return "";
+		}
+		if (("path" in onedriveJSONItem["parentReference"]) == null) {
+			return "";
+		}
+
+		string parentPath = onedriveJSONItem["parentReference"]["path"].str;
+		string itemName = onedriveJSONItem["name"].str;
+		string logicalAnchorPath = currentSharedFolderLogicalPath;
+
+		// Convert Graph parentReference path from /drives/<id>/root:/A/B/C to /A/B/C.
+		auto splitIndex = parentPath.indexOf(":");
+		if (splitIndex != -1) {
+			parentPath = parentPath[splitIndex + 1 .. $];
+		}
+		parentPath = buildNormalizedPath(parentPath);
+		if (parentPath == ".") {
+			parentPath = "";
+		}
+		if ((!parentPath.empty) && (parentPath[$ - 1] == '/')) {
+			parentPath = parentPath[0 .. $ - 1];
+		}
+
+		logicalAnchorPath = processPathToRemoveRootReference(logicalAnchorPath);
+		if (startsWith(logicalAnchorPath, "./")) {
+			logicalAnchorPath = logicalAnchorPath[2 .. $];
+		}
+		if (startsWith(logicalAnchorPath, "/")) {
+			logicalAnchorPath = logicalAnchorPath[1 .. $];
+		}
+		if ((!logicalAnchorPath.empty) && (logicalAnchorPath[$ - 1] == '/')) {
+			logicalAnchorPath = logicalAnchorPath[0 .. $ - 1];
+		}
+		if (logicalAnchorPath.empty) {
+			return "";
+		}
+
+		string calculatedParentPath;
+
+		// The generated delta can include the shared-folder anchor item itself. Its owner-drive
+		// parent is outside the selected shortcut, so use the local parent of the shortcut.
+		if (itemName == currentSharedFolderName) {
+			calculatedParentPath = dirName(logicalAnchorPath);
+			if (calculatedParentPath == ".") {
+				calculatedParentPath = "";
+			}
+		} else {
+			string anchorNeedle = "/" ~ currentSharedFolderName;
+			auto anchorIndex = lastIndexOf(parentPath, anchorNeedle);
+			if (anchorIndex < 0) {
+				if (parentPath == currentSharedFolderName) {
+					anchorIndex = 0;
+					anchorNeedle = currentSharedFolderName;
+				} else {
+					return "";
+				}
+			}
+
+			string suffix = "";
+			auto suffixStart = cast(size_t)(anchorIndex + anchorNeedle.length);
+			if (suffixStart < parentPath.length) {
+				suffix = parentPath[suffixStart .. $];
+			}
+			calculatedParentPath = logicalAnchorPath ~ suffix;
+		}
+
+		calculatedParentPath = buildNormalizedPath(calculatedParentPath);
+		if (calculatedParentPath == ".") {
+			calculatedParentPath = "";
+		}
+
+		if (parentOnly) {
+			return calculatedParentPath;
+		}
+
+		if (calculatedParentPath.empty) {
+			return itemName;
+		}
+		return buildNormalizedPath(calculatedParentPath ~ "/" ~ itemName);
+	}
+
 	// Query itemdb.computePath() and catch potential assert when DB consistency issue occurs
 	// This function returns what that local physical path should be on the local disk
 	string computeItemPath(string thisDriveId, string thisItemId) {
@@ -6027,6 +6129,14 @@ class SyncEngine {
 			if (debugLogging) {addLogEntry("Parent path details are in DB - computing 'calculatedParentalPath' using computeItemPath()", ["debug"]);}
 			calculatedParentalPath = computeItemPath(thisItemDriveId, thisItemParentId);
 			if (debugLogging) {addLogEntry("Resulting 'calculatedParentalPath' using computeItemPath() = " ~ calculatedParentalPath, ["debug"]);}
+
+			string generatedSharedFolderParentalPath = computeGeneratedSharedFolderDeltaPath(onedriveJSONItem, true);
+			if (!generatedSharedFolderParentalPath.empty) {
+				if (debugLogging) {
+					addLogEntry("Overriding calculatedParentalPath using active shared-folder generated-delta logical path = " ~ generatedSharedFolderParentalPath, ["debug"]);
+				}
+				calculatedParentalPath = generatedSharedFolderParentalPath;
+			}
 		}
 		
 		// Check if this is excluded by config option: skip_dir 
@@ -6456,19 +6566,14 @@ class SyncEngine {
 						// Directory included due to 'sync_list' match
 						if (verboseLogging) {addLogEntry("Including path - included by sync_list config: " ~ newItemPath, ["verbose"]);}
 						
-						// When using 'sync_list', an included directory must be represented
-						// consistently in both the local filesystem and the database.
+						// When using 'sync_list', an included directory must be represented consistently in both the local filesystem and the database.
 						//
-						// Previously this branch could save the directory JSON directly to
-						// the database when the parent was already present, without also
-						// creating the local directory. This was particularly visible for
-						// included empty directories in OneDrive Personal Shared Folders:
-						// the DB record existed, but no local directory existed, so the
-						// later database consistency check incorrectly reported:
+						// Previously this branch could save the directory JSON directly to the database when the parent was already present, without also
+						// creating the local directory. This was particularly visible for included empty directories in OneDrive Personal Shared Folders:
+						// the DB record existed, but no local directory existed, so the later database consistency check incorrectly reported:
 						//     The directory has been deleted locally
 						//
-						// Avoid inserting an included directory into the database without
-						// also ensuring that the local directory exists.
+						// Avoid inserting an included directory into the database without also ensuring that the local directory exists.
 						if (!parentInDatabase) {
 							// Parental database and local path structure needs to be created
 							// before this included directory can be materialised locally.


### PR DESCRIPTION


Fix 'sync_list' wildcard exclusion rules can incorrectly exclude ancestor directories