### PR TITLE
Fix single-tenant authentication redirect URI handling and add administrator consent support

### DIFF
--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -141,7 +141,7 @@ _**Valid Values:**_ USL4, USL5, DE, CN
 _**Config Example:**_ `azure_ad_endpoint = "DE"`
 
 ### azure_tenant_id
-_**Description:**_ This config option allows the locking of the client to a specific single tenant and will configure your client to use the specified tenant id in its Azure AD and Graph endpoint URIs, instead of "common". The tenant id may be the GUID Directory ID or the fully qualified tenant name.
+_**Description:**_ This configuration option restricts authentication and token acquisition to a specific Microsoft Entra ID tenant. When configured, the client will use the specified tenant identifier when constructing Microsoft Entra ID authentication endpoints and tenant-specific Microsoft Graph API requests, rather than using the multi-tenant `common` endpoint.
 
 _**Value Type:**_ String
 
@@ -150,7 +150,10 @@ _**Default Value:**_ *Empty* - not required for normal operation
 _**Config Example:**_ `azure_tenant_id = "example.onmicrosoft.us"` or `azure_tenant_id = "0c4be462-a1ab-499b-99e0-da08ce52a2cc"`
 
 > [!IMPORTANT]
-> Must be configured if 'azure_ad_endpoint' is configured.
+> This option must be configured when using `azure_ad_endpoint` or the `--display-admin-consent-url` CLI option.
+
+> [!NOTE]
+> This option is commonly used in Microsoft 365 Business, Enterprise, Education, Government, and other managed Microsoft Entra ID environments where authentication must be restricted to a specific tenant rather than using the multi-tenant `common` endpoint.
 
 ### bypass_data_preservation
 _**Description:**_ This config option allows the disabling of preserving local data by renaming the local file in the event of data conflict. If this is enabled, you will experience data loss on your local data as the local file will be over-written with data from OneDrive online. Use with care and caution.
@@ -1459,6 +1462,22 @@ _**Usage Example:**_ `onedrive --source-directory 'path/as/source/' --destinatio
 _**Description:**_ This CLI option displays a tenant-specific Microsoft Entra ID administrator consent URL for environments where administrator approval is required before users can authenticate and use the client.
 
 _**Usage Example:**_ `onedrive --display-admin-consent-url`
+
+> [!IMPORTANT]
+> This option does not authenticate the user and does not generate a refresh token.
+>
+> The generated URL must be opened by a Microsoft Entra ID administrator to grant tenant-wide consent for the application. Nothing from this process needs to be pasted back into the client.
+>
+> After administrator consent has been granted, users must complete the normal authentication process by running `onedrive` or `onedrive --reauth`.
+
+> [!IMPORTANT]
+> This option requires 'azure_tenant_id' to be configured.
+>
+> The tenant identifier is used only to generate the Microsoft Entra ID administrator consent endpoint. The OAuth native-client redirect URI must remain the registered application redirect URI:
+>
+> `https://login.microsoftonline.com/common/oauth2/nativeclient`
+>
+> Do not manually replace `common` in the redirect URI with the tenant ID unless you are using your own custom Microsoft Entra ID application registration and that exact redirect URI has been registered for that application.
 
 ### CLI Option: --display-config
 _**Description:**_ This CLI option will display the effective application configuration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -466,6 +466,18 @@ Open this URL as a Microsoft Entra ID administrator to grant tenant-wide consent
 After administrator consent has been granted, run the normal authentication process again.
 ```
 
+> [!IMPORTANT]
+> When using the default OneDrive Client for Linux application registration, the redirect URI remains:
+>
+> `https://login.microsoftonline.com/common/oauth2/nativeclient`
+>
+> even when `azure_tenant_id` is configured for a single Microsoft Entra ID tenant.
+>
+> This behaviour is required because the default application registration is configured with the Microsoft Identity Platform using the common native-client redirect URI.
+>
+> The `azure_tenant_id` value is used to scope authentication and token issuance to a specific tenant, but does not change the redirect URI used by the default application registration.
+
+
 Administrator consent is typically a one-time action for a Microsoft Entra ID tenant. Once consent has been granted, users can authenticate and reauthenticate normally, including when using `--reauth`.
 
 If you are uncertain whether administrator approval is required in your environment, contact your Microsoft 365 or Microsoft Entra ID administrator before attempting further authentication troubleshooting.
@@ -475,6 +487,36 @@ If you are uncertain whether administrator approval is required in your environm
 
 > [!IMPORTANT]
 > Some organisations prohibit users from granting consent to applications. In these environments, authentication will fail until approval has been granted by a Microsoft Entra ID administrator.
+
+> [!IMPORTANT]
+> **Handling a AADSTS50011 response**
+>
+> If authentication fails with:
+>
+> `AADSTS50011: The redirect URI specified in the request does not match the redirect URIs configured for the application`
+>
+> Microsoft Entra ID is rejecting the redirect URI supplied during authentication.
+>
+> **Common causes:**
+>
+> * Using a custom `application_id` where the configured redirect URI does not match the application registration
+> * Using an application registration that has not been configured as a Public Client Application
+> * Missing or incorrectly configured native client redirect URI within the Microsoft Entra ID application registration
+> * Application registration changes not yet replicated across Microsoft Entra ID
+>
+> **For users of the default OneDrive Client for Linux application registration:**
+>
+> The application uses:
+>
+> `https://login.microsoftonline.com/common/oauth2/nativeclient`
+>
+> as the redirect URI, regardless of whether `azure_tenant_id` is configured.
+>
+> If this error occurs while using the default application registration, please upgrade to the latest application release and re-run:
+>
+> ```
+> onedrive --reauth
+> ```
 
 
 #### Single Sign-On (SSO) via Intune using the Microsoft Identity Device Broker 

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -279,8 +279,23 @@ class OneDriveApi {
 				// Authentication
 				authUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/authorize";
 				deviceAuthUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/devicecode";
-				redirectUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/nativeclient";
 				tokenUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/v2.0/token";
+				
+				// Redirect URL
+				if (clientId == appConfig.defaultApplicationId) {
+					// application_id == default
+					// The default application registration uses the common native-client redirect URI.
+					// Do not tenant-substitute this URI when azure_tenant_id is configured.
+					if (debugLogging) {
+						addLogEntry("Global Azure AD Endpoint using default application_id, redirectUrl remains aligned to common nativeclient redirect URI", ["debug"]);
+					}
+					redirectUrl = appConfig.globalAuthEndpoint ~ "/common/oauth2/nativeclient";
+				} else {
+					// custom application_id
+					// Preserve existing behaviour for custom application registrations.
+					redirectUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/nativeclient";
+				}
+				
 				// WebSocket Endpoint
 				websocketEndpoint = appConfig.globalGraphEndpoint ~ websocketEndpointAPIEndpoint;
 				break;


### PR DESCRIPTION
Fix authentication URL generation when `azure_tenant_id` is configured and the default OneDrive Client for Linux application registration is being used.

Changes include:

* Fix redirect URI generation for single-tenant authentication when using the default application registration
* Retain the registered Microsoft Identity Platform native-client redirect URI: `https://login.microsoftonline.com/common/oauth2/nativeclient`
* Update the `--display-admin-consent-url` CLI option
* Generate tenant-specific Microsoft Entra ID administrator consent URLs
* Improve documentation for `azure_tenant_id`
* Add documentation covering Microsoft Entra ID administrator consent workflows and tenant-wide application approval

These changes resolve Microsoft Entra ID authentication failures reporting `AADSTS50011` when using `azure_tenant_id` with the default application registration and provide a documented workflow for administrator consent in managed Microsoft 365 and Microsoft Entra ID environments.