### PR TITLE
Reduce forced garbage collection in synchronisation and CurlEngine cleanup paths

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -11,7 +11,6 @@ import std.format;
 import std.json;
 import std.stdio;
 import std.range;
-import core.memory;
 import core.sys.posix.signal;
 // Required for WebSocket Support
 import core.stdc.stdlib : getenv;
@@ -346,10 +345,6 @@ class CurlEngine {
 			curlEnginePool ~= this;
 			if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("CurlEngine curlEnginePool size after release: " ~ to!string(curlEnginePool.length), ["debug"]);}
 		}
-		// Perform Garbage Collection
-		GC.collect();
-		// Return free memory to the OS
-		GC.minimize();
 	}
 	
 	// Setup a specific SIGPIPE Signal handler due to curl bugs that ignore CurlOption.nosignal
@@ -704,10 +699,6 @@ class CurlEngine {
 			object.destroy(http); // Destroy, however we cant set to null
 			if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("Stopped HTTP instance shutdown and destroyed: " ~ to!string(internalThreadId), ["debug"]);}
 		}
-		// Perform Garbage Collection
-		GC.collect();
-		// Return free memory to the OS
-		GC.minimize();
 	}
 	
 	// Disable SSL certificate peer verification for libcurl operations.
@@ -842,8 +833,6 @@ void releaseAllCurlInstances() {
 				// It's safe to destroy the object here assuming no other references exist
 				object.destroy(curlEngineInstance); // Destroy, then set to null
 				curlEngineInstance = null;
-				// Perform Garbage Collection on this destroyed curl engine
-				GC.collect();
 				// Log release
 				if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("CurlEngine destroyed", ["debug"]);}
 			}
@@ -852,10 +841,6 @@ void releaseAllCurlInstances() {
 			curlEnginePool.length = 0; // More explicit than curlEnginePool = [];
 		}
 	}
-	// Perform Garbage Collection on the destroyed curl engines
-	GC.collect();
-	// Return free memory to the OS
-	GC.minimize();
 	// Log that all curl engines have been released
 	if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("CurlEngine releaseAllCurlInstances() completed", ["debug"]);}
 }

--- a/src/main.d
+++ b/src/main.d
@@ -1384,6 +1384,8 @@ int main(string[] cliArgs) {
 					releaseAllCurlInstances(); // Release all CurlEngine instances
 					if (debugLogging) {addLogEntry("CurlEngine Pool Size POST Cleanup: " ~ to!string(curlEnginePoolLength()) , ["debug"]);}
 					
+					
+					
 					// Display memory details before garbage collection
 					if (displayMemoryUsage) {
 						addLogEntry("Monitor Loop Count:   " ~ to!string(monitorLoopFullCount));
@@ -1395,11 +1397,13 @@ int main(string[] cliArgs) {
 						displayMemoryUsagePreGC();
 					}
 					// Perform Garbage Collection
-					GC.collect();
+					//GC.collect();
 					// Return free memory to the OS
-					GC.minimize();
+					//GC.minimize();
 					// Display memory details after garbage collection
 					if (displayMemoryUsage) displayMemoryUsagePostGC();
+					
+					
 					
 					// Log that this loop is complete
 					if (debugLogging) {addLogEntry(loopStopOutputMessage, ["debug"]);}

--- a/src/main.d
+++ b/src/main.d
@@ -1413,7 +1413,6 @@ int main(string[] cliArgs) {
 							GC.minimize(); // Return free memory to the operating system
 							// Update time gate
 							lastMonitorGcCleanup = monitorGcCleanupTime;
-							addLogEntry("lastMonitorGcCleanup set to = " ~ to!string(lastMonitorGcCleanup));
 						}
 					}
 					

--- a/src/main.d
+++ b/src/main.d
@@ -1200,6 +1200,7 @@ int main(string[] cliArgs) {
 			ulong monitorLogOutputLoopCount = 0;
 			MonoTime lastCheckTime = MonoTime.currTime();
 			MonoTime lastGitHubCheckTime = MonoTime.currTime();
+			SysTime lastMonitorGcCleanup = Clock.currTime();
 			
 			while (performFileSystemMonitoring) {
 				if (shutdownRequested()) {
@@ -1384,26 +1385,37 @@ int main(string[] cliArgs) {
 					releaseAllCurlInstances(); // Release all CurlEngine instances
 					if (debugLogging) {addLogEntry("CurlEngine Pool Size POST Cleanup: " ~ to!string(curlEnginePoolLength()) , ["debug"]);}
 					
-					
-					
-					// Display memory details before garbage collection
+					// Display monitor loop memory details
 					if (displayMemoryUsage) {
 						addLogEntry("Monitor Loop Count:   " ~ to!string(monitorLoopFullCount));
+
 						// Get the current time in the local timezone
 						auto timeStamp = leftJustify(Clock.currTime().toString(), 28, '0');
 						addLogEntry("Timestamp:            " ~ to!string(timeStamp));
 						addLogEntry("Application Run Time: " ~ to!string(elapsedTime));
-						// Display memory stats before GC cleanup
-						displayMemoryUsagePreGC();
+						
+						// Display memory consumption details
+						displayMemoryUsageDetails();
 					}
-					// Perform Garbage Collection
-					//GC.collect();
-					// Return free memory to the OS
-					//GC.minimize();
-					// Display memory details after garbage collection
-					if (displayMemoryUsage) displayMemoryUsagePostGC();
 					
-					
+					// Perform coarse GC cleanup for long-running monitor processes.
+					// This is intentionally time-gated and only runs at most once every 24 hours,
+					// after sync processing has completed and the client is idle.
+					auto monitorGcCleanupTime = Clock.currTime();
+					if (lastMonitorGcCleanup == SysTime.min || (monitorGcCleanupTime - lastMonitorGcCleanup) >= dur!"hours"(24)) {
+						// Avoid running this during initial startup; only run after the application
+						// has been active for at least 24 hours.
+						if (elapsedTime >= dur!"hours"(24)) {
+							// Log what we are doing
+							addLogEntry("Performing scheduled monitor-mode memory cleanup after 24 hours of runtime");
+							// Perform GC actions
+							GC.collect();  // Perform Garbage Collection
+							GC.minimize(); // Return free memory to the operating system
+							// Update time gate
+							lastMonitorGcCleanup = monitorGcCleanupTime;
+							addLogEntry("lastMonitorGcCleanup set to = " ~ to!string(lastMonitorGcCleanup));
+						}
+					}
 					
 					// Log that this loop is complete
 					if (debugLogging) {addLogEntry(loopStopOutputMessage, ["debug"]);}

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -526,8 +526,6 @@ class OneDriveApi {
 		}
 		// Release the response
 		response = null;
-		// Perform Garbage Collection
-		GC.collect();
 	}
 
 	// Authenticate this client against Microsoft OneDrive API using one of the 3 authentication methods this client supports

--- a/src/sync.d
+++ b/src/sync.d
@@ -2,7 +2,6 @@
 module syncEngine;
 
 // What does this module require to function?
-import core.memory;
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.thread;
 import core.time;
@@ -1105,8 +1104,7 @@ class SyncEngine {
 		databaseItemsToDeleteOnline = [];
 		pathsRetained = [];
 		
-		// Perform Garbage Collection on this destroyed curl engine
-		GC.collect();
+		// Log completion of cleanup
 		if (debugLogging) {addLogEntry("Cleaning of internal arrays complete", ["debug"]);}
 		
 		// Display function processing time if configured to do so
@@ -1360,12 +1358,6 @@ class SyncEngine {
 			getDeltaDataOneDriveApiInstance = new OneDriveApi(appConfig);
 			getDeltaDataOneDriveApiInstance.initialise();
 
-			// Throttle forced garbage collection during native /delta enumeration.
-			// jsonItemsToProcess grows during enumeration and remains live until later
-			// processing, so forcing a full GC for every response bundle causes repeated
-			// scans of an increasingly large live heap.
-			enum long deltaEnumerationGcInterval = 100;
-
 			// Get the /delta changes via the OneDrive API
 			// To handle SIGINT (CTRL-C) and SIGTERM (kill) events we need this while loop
 			while (true) {
@@ -1510,11 +1502,6 @@ class SyncEngine {
 				
 				// Cleanup deltaChanges as this is no longer needed
 				deltaChanges = null;
-				
-				// Perform throttled garbage collection during large native /delta enumeration
-				if ((responseBundleCount % deltaEnumerationGcInterval) == 0) {
-					GC.collect();
-				}
 				
 				// Sleep for a while to avoid busy-waiting
 				Thread.sleep(dur!"msecs"(100)); // Adjust the sleep duration as needed

--- a/src/sync.d
+++ b/src/sync.d
@@ -700,9 +700,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		getDefaultDriveApiInstance.releaseCurlEngine();
 		getDefaultDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -776,9 +774,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		getDefaultRootApiInstance.releaseCurlEngine();
 		getDefaultRootApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -1319,9 +1315,7 @@ class SyncEngine {
 		deltaLinkCache.driveId = null;
 		deltaLinkCache.itemId = null;
 		deltaLinkCache.latestDeltaLink = null;
-		// Perform Garbage Collection
-		GC.collect();
-				
+						
 		// What /delta query do we use?
 		if (!generatedSimulatedDeltaResponse) {
 			// This should be the majority default pathway application use
@@ -1529,9 +1523,7 @@ class SyncEngine {
 			// Terminate getDeltaDataOneDriveApiInstance here
 			getDeltaDataOneDriveApiInstance.releaseCurlEngine();
 			getDeltaDataOneDriveApiInstance = null;
-			// Perform Garbage Collection on this destroyed curl engine
-			GC.collect();
-			
+						
 			// To finish off the JSON processing items, this is needed to reflect this in the log
 			if (debugLogging) {addLogEntry(debugLogBreakType1, ["debug"]);}
 			
@@ -1553,8 +1545,6 @@ class SyncEngine {
 			
 			// Cleanup deltaChanges as this is no longer needed
 			deltaChanges = null;
-			// Perform Garbage Collection
-			GC.collect();
 		} else {
 			// Why are we generating a /delta response
 			if (debugLogging) {
@@ -1645,16 +1635,11 @@ class SyncEngine {
 			
 			// Cleanup deltaChanges as this is no longer needed
 			deltaChanges = null;
-			
-			// Perform Garbage Collection
-			GC.collect();
 		}
 		
 		// Cleanup deltaChanges as this is no longer needed
 		deltaChanges = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// We have JSON items received from the OneDrive API
 		if (debugLogging) {
 			addLogEntry("Number of JSON Objects received from OneDrive API:                 " ~ to!string(jsonItemsReceived), ["debug"]);
@@ -1727,9 +1712,6 @@ class SyncEngine {
 			
 			// Free up memory and items processed as it is pointless now having this data around
 			jsonItemsToProcess = [];
-			
-			// Perform Garbage Collection on this destroyed curl engine
-			GC.collect();
 		} else {
 			if (!appConfig.suppressLoggingOutput) {
 				addLogEntry("No changes or items that can be applied were discovered while processing the data received from Microsoft OneDrive");
@@ -3487,9 +3469,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				onlineParentOneDriveApiInstance.releaseCurlEngine();
 				onlineParentOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -3506,9 +3486,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				onlineParentOneDriveApiInstance.releaseCurlEngine();
 				onlineParentOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -3628,9 +3606,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		onlineParentOneDriveApiInstance.releaseCurlEngine();
 		onlineParentOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -4141,12 +4117,12 @@ class SyncEngine {
 							}
 						}
 						
-						// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
+						// OneDrive API Instance Cleanup - Shutdown API and free curl object.
+						// Do not force GC collection here: downloadFileItem() runs once per file
+						// inside the parallel download worker pool, and forcing a full GC after
+						// every downloaded file causes repeated stop-the-world mark scans.
 						downloadFileOneDriveApiInstance.releaseCurlEngine();
 						downloadFileOneDriveApiInstance = null;
-						// Perform Garbage Collection
-						GC.collect();
-						
 					} catch (OneDriveException exception) {
 						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset); generated a OneDriveException", ["debug"]);}
 						
@@ -4731,8 +4707,6 @@ class SyncEngine {
 				addLogEntry("CODING TO DO: Hitting this failure error output after getting a httpStatusCode != 410 when the API responded the deltaLink was invalid");
 				displayOneDriveErrorMessage(exception.msg, thisFunctionName);
 				deltaChangesBundle = null;
-				// Perform Garbage Collection
-				GC.collect();
 			}
 		}
 		
@@ -5355,9 +5329,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			uploadLastModifiedTimeApiInstance.releaseCurlEngine();
 			uploadLastModifiedTimeApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// Do we actually save the response?
 			// Special case here .. if the DB record item (originItem) is a remote object, thus, if we save the 'response' we will have a DB FOREIGN KEY constraint failed problem
 			//  Update 'originItem.mtime' with the correct timestamp
@@ -5411,8 +5383,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			uploadLastModifiedTimeApiInstance.releaseCurlEngine();
 			uploadLastModifiedTimeApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
 		}
 		
 		// Display function processing time if configured to do so
@@ -6931,8 +6901,6 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		onlinePathOneDriveApiInstance.releaseCurlEngine();
 		onlinePathOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
 		
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
@@ -7090,9 +7058,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			checkFileOneDriveApiInstance.releaseCurlEngine();
 			checkFileOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// Turn 'fileDetailsFromOneDrive' into a DB item
 			if (fileDetailsFromOneDrive.type() == JSONType.object) {
 				// Yes
@@ -7706,9 +7672,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		uploadFileOneDriveApiInstance.releaseCurlEngine();
 		uploadFileOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -7776,9 +7740,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			getCurrentDriveQuotaApiInstance.releaseCurlEngine();
 			getCurrentDriveQuotaApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
 		} catch (OneDriveException e) {
 			if (debugLogging) {addLogEntry("currentDriveQuota = onedrive.getDriveQuota(driveId) generated a OneDriveException", ["debug"]);}
 			// If an exception occurs, it's unclear if quota is restricted, but quota details are not available
@@ -7789,8 +7750,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			getCurrentDriveQuotaApiInstance.releaseCurlEngine();
 			getCurrentDriveQuotaApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
 			return result;
 		}
 		
@@ -9262,8 +9221,6 @@ class SyncEngine {
 							createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 							// Free object and memory
 							createDirectoryOnlineOneDriveApiInstance = null;
-							// Perform Garbage Collection
-							GC.collect();
 						} else {
 							// some other error from OneDrive was returned - display what it is
 							addLogEntry("OneDrive generated an error when creating this path: " ~ thisNewPathToCreate);
@@ -9272,8 +9229,6 @@ class SyncEngine {
 							createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 							// Free object and memory
 							createDirectoryOnlineOneDriveApiInstance = null;
-							// Perform Garbage Collection
-							GC.collect();
 						}
 						
 						// Display function processing time if configured to do so
@@ -9298,9 +9253,7 @@ class SyncEngine {
 				createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 				// Free object and memory
 				createDirectoryOnlineOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -9393,9 +9346,7 @@ class SyncEngine {
 							// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 							createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 							createDirectoryOnlineOneDriveApiInstance = null;
-							// Perform Garbage Collection
-							GC.collect();
-							
+														
 							// Display function processing time if configured to do so
 							if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 								// Combine module name & running Function
@@ -9421,9 +9372,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 				createDirectoryOnlineOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -9445,9 +9394,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 				createDirectoryOnlineOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -9465,9 +9412,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			createDirectoryOnlineOneDriveApiInstance.releaseCurlEngine();
 			createDirectoryOnlineOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// Display function processing time if configured to do so
 			if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 				// Combine module name & running Function
@@ -9574,9 +9519,7 @@ class SyncEngine {
 		raceConditionResolutionOneDriveApiInstance.releaseCurlEngine();
 		// Free object and memory
 		raceConditionResolutionOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -9960,9 +9903,7 @@ class SyncEngine {
 								// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 								checkFileOneDriveApiInstance.releaseCurlEngine();
 								checkFileOneDriveApiInstance = null;
-								// Perform Garbage Collection
-								GC.collect();
-								
+																
 								// No 404 which means a file was found with the path we are trying to upload to
 								if (debugLogging) {addLogEntry("fileDetailsFromOneDrive JSON data after exist online check: " ~ to!string(fileDetailsFromOneDrive), ["debug"]);}
 																
@@ -10042,9 +9983,7 @@ class SyncEngine {
 								// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 								checkFileOneDriveApiInstance.releaseCurlEngine();
 								checkFileOneDriveApiInstance = null;
-								// Perform Garbage Collection
-								GC.collect();
-								
+																
 								// If we get a 404 .. the file is not online .. this is what we want .. file does not exist online
 								if (exception.httpStatusCode == 404) {
 									// The file has been checked, client side filtering checked, does not exist online - we need to upload it
@@ -10196,9 +10135,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					uploadFileOneDriveApiInstance.releaseCurlEngine();
 					uploadFileOneDriveApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
-					
 				} catch (OneDriveException exception) {
 					// An error was responded with - what was it
 					// Default operation if not 408,429,503,504 errors
@@ -10209,10 +10145,7 @@ class SyncEngine {
 					
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					uploadFileOneDriveApiInstance.releaseCurlEngine();
-					uploadFileOneDriveApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
-					
+					uploadFileOneDriveApiInstance = null;				
 				} catch (FileException e) {
 					// display the error message
 					addLogEntry("Uploading new file: " ~ fileToUpload ~ " ... failed!", ["info", "notify"]);
@@ -10221,8 +10154,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					uploadFileOneDriveApiInstance.releaseCurlEngine();
 					uploadFileOneDriveApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
 				}
 			} else {
 				// Initialise API for session upload
@@ -10318,8 +10249,6 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				uploadFileOneDriveApiInstance.releaseCurlEngine();
 				uploadFileOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
 			}
 		} else {
 			// We are in a --dry-run scenario
@@ -10980,9 +10909,6 @@ class SyncEngine {
 						// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 						uploadDeletedItemOneDriveApiInstance.releaseCurlEngine();
 						uploadDeletedItemOneDriveApiInstance = null;
-						// Perform Garbage Collection
-						GC.collect();
-					
 					} catch (OneDriveException e) {
 						if (e.httpStatusCode == 404) {
 							// item.id, item.eTag could not be found on the specified driveId
@@ -10992,8 +10918,6 @@ class SyncEngine {
 						// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 						uploadDeletedItemOneDriveApiInstance.releaseCurlEngine();
 						uploadDeletedItemOneDriveApiInstance = null;
-						// Perform Garbage Collection
-						GC.collect();
 					}
 					
 					// Delete the reference in the local database - use the original input
@@ -11079,9 +11003,6 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				uploadDeletedItemOneDriveApiInstance.releaseCurlEngine();
 				uploadDeletedItemOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-			
 			} catch (OneDriveException e) {
 				if (e.httpStatusCode == 404) {
 					// item.id, item.eTag could not be found on the specified driveId
@@ -11091,8 +11012,6 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				uploadDeletedItemOneDriveApiInstance.releaseCurlEngine();
 				uploadDeletedItemOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
 			}
 		} else {
 			// log that this is a dry-run activity
@@ -11191,8 +11110,6 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		performReverseDeletionOneDriveApiInstance.releaseCurlEngine();
 		performReverseDeletionOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
 		
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
@@ -11613,9 +11530,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		fetchDriveDetailsOneDriveApiInstance.releaseCurlEngine();
 		fetchDriveDetailsOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Do we have details we can use?
 		if (hasParentReferenceDriveId(remoteDriveDetails)) {
 			// We have a [parentReference][driveId] reference driveId to use
@@ -11782,9 +11697,6 @@ class SyncEngine {
 				generateDeltaResponseOneDriveApiInstance.releaseCurlEngine();
 				generateDeltaResponseOneDriveApiInstance = null;
 				
-				// Perform Garbage Collection
-				GC.collect();
-				
 				// Must force exit here, allow logging to be done
 				forceExit();
 			}
@@ -11847,9 +11759,7 @@ class SyncEngine {
 				generateDeltaResponseOneDriveApiInstance.releaseCurlEngine();
 				// Free object and memory
 				generateDeltaResponseOneDriveApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Return the generated JSON response
 				return selfGeneratedDeltaResponse;
 			} else {
@@ -11909,9 +11819,7 @@ class SyncEngine {
 			generateDeltaResponseOneDriveApiInstance.releaseCurlEngine();
 			// Free object and memory
 			generateDeltaResponseOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// Must force exit here, allow logging to be done
 			forceExit();
 		}
@@ -12041,9 +11949,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		generateDeltaResponseOneDriveApiInstance.releaseCurlEngine();
 		generateDeltaResponseOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -12183,9 +12089,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		queryChildrenOneDriveApiInstance.releaseCurlEngine();
 		queryChildrenOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -12525,9 +12429,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		queryOneDriveForSpecificPath.releaseCurlEngine();
 		queryOneDriveForSpecificPath = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Output our search results
 		if (debugLogging) {addLogEntry("queryOneDriveForSpecificPathAndCreateIfMissing.getPathDetailsAPIResponse = " ~ to!string(getPathDetailsAPIResponse), ["debug"]);}
 		
@@ -12649,9 +12551,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			deleteByPathNoSyncAPIInstance.releaseCurlEngine();
 			deleteByPathNoSyncAPIInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-		
+					
 			// Log that an error was generated
 			if (debugLogging) {addLogEntry("deleteByPathNoSyncAPIInstance.getPathDetails(path) generated a OneDriveException", ["debug"]);}
 			if (exception.httpStatusCode == 404) {
@@ -12700,9 +12600,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		deleteByPathNoSyncAPIInstance.releaseCurlEngine();
 		deleteByPathNoSyncAPIInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -12867,9 +12765,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				movePathOnlineApiInstance.releaseCurlEngine();
 				movePathOnlineApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Save the move response from OneDrive in the database
 				if (isMoveSuccess && response.type() == JSONType.object) {
 					saveItem(response);
@@ -13068,8 +12964,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					querySharePointLibraryNameApiInstance.releaseCurlEngine();
 					querySharePointLibraryNameApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
 					return;
 				}
 				
@@ -13088,8 +12982,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					querySharePointLibraryNameApiInstance.releaseCurlEngine();
 					querySharePointLibraryNameApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
 					return;
 				}
 				
@@ -13101,8 +12993,6 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				querySharePointLibraryNameApiInstance.releaseCurlEngine();
 				querySharePointLibraryNameApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
 				return;
 			}
 			
@@ -13134,8 +13024,6 @@ class SyncEngine {
 									// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 									querySharePointLibraryNameApiInstance.releaseCurlEngine();
 									querySharePointLibraryNameApiInstance = null;
-									// Perform Garbage Collection
-									GC.collect();
 									return;
 								}
 								
@@ -13175,8 +13063,6 @@ class SyncEngine {
 									// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 									querySharePointLibraryNameApiInstance.releaseCurlEngine();
 									querySharePointLibraryNameApiInstance = null;
-									// Perform Garbage Collection
-									GC.collect();
 									return;
 								}
 							}
@@ -13233,8 +13119,6 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				querySharePointLibraryNameApiInstance.releaseCurlEngine();
 				querySharePointLibraryNameApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
 				return;
 			}
 			
@@ -13270,9 +13154,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		querySharePointLibraryNameApiInstance.releaseCurlEngine();
 		querySharePointLibraryNameApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -13409,9 +13291,7 @@ class SyncEngine {
 		// Terminate getDeltaDataOneDriveApiInstance here
 		getDeltaDataOneDriveApiInstance.releaseCurlEngine();
 		getDeltaDataOneDriveApiInstance = null;
-		// Perform Garbage Collection on this destroyed curl engine
-		GC.collect();
-		
+				
 		// Needed after printing out '....' when fetching changes from OneDrive API
 		if (appConfig.verbosityCount == 0) {
 			completeProcessingDots();
@@ -13539,8 +13419,6 @@ class SyncEngine {
 						// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 						queryOneDriveForFileDetailsApiInstance.releaseCurlEngine();
 						queryOneDriveForFileDetailsApiInstance = null;
-						// Perform Garbage Collection
-						GC.collect();
 						return;
 					}
 					
@@ -13627,8 +13505,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					queryOneDriveForFileDetailsApiInstance.releaseCurlEngine();
 					queryOneDriveForFileDetailsApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
 				}
 			}
 			
@@ -13683,16 +13559,11 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			getCurrentDriveQuotaApiInstance.releaseCurlEngine();
 			getCurrentDriveQuotaApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
 		} catch (OneDriveException e) {
 			if (debugLogging) {addLogEntry("currentDriveQuota = onedrive.getDriveQuota(driveId) generated a OneDriveException", ["debug"]);}
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			getCurrentDriveQuotaApiInstance.releaseCurlEngine();
 			getCurrentDriveQuotaApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
 		}
 		
 		// validate that currentDriveQuota is a JSON value
@@ -14207,11 +14078,8 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				validateUploadSessionFileDataApiInstance.releaseCurlEngine();
 				validateUploadSessionFileDataApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
 				
 				// no error .. potentially all still valid
-				
 			} catch (OneDriveException e) {
 				// handle any onedrive error response as invalid
 				if (debugLogging) {addLogEntry("SESSION-RESUME: Invalid response when using uploadUrl in: " ~ sessionFilePath, ["debug"]);}
@@ -14219,9 +14087,7 @@ class SyncEngine {
 				// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 				validateUploadSessionFileDataApiInstance.releaseCurlEngine();
 				validateUploadSessionFileDataApiInstance = null;
-				// Perform Garbage Collection
-				GC.collect();
-				
+								
 				// Display function processing time if configured to do so
 				if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 					// Combine module name & running Function
@@ -14480,9 +14346,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			validateResumableDownloadFileDataApiInstance.releaseCurlEngine();
 			validateResumableDownloadFileDataApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// no error .. potentially all still valid
 		} catch (OneDriveException e) {
 			// handle any onedrive error response as invalid
@@ -14491,9 +14355,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			validateResumableDownloadFileDataApiInstance.releaseCurlEngine();
 			validateResumableDownloadFileDataApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
+						
 			// Display function processing time if configured to do so
 			if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 				// Combine module name & running Function
@@ -14592,9 +14454,7 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			uploadFileOneDriveApiInstance.releaseCurlEngine();
 			uploadFileOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-						
+									
 			// Was the response from the OneDrive API a valid JSON item?
 			if (uploadResponse.type() == JSONType.object) {
 				// A valid JSON object was returned - session resumption upload successful
@@ -14875,9 +14735,7 @@ class SyncEngine {
 						// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 						checkFileOneDriveApiInstance.releaseCurlEngine();
 						checkFileOneDriveApiInstance = null;
-						// Perform Garbage Collection
-						GC.collect();
-						
+												
 						// Display function processing time if configured to do so
 						if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 							// Combine module name & running Function
@@ -14909,9 +14767,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		checkFileOneDriveApiInstance.releaseCurlEngine();
 		checkFileOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -15178,9 +15034,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					getPathDetailsApiInstance.releaseCurlEngine();
 					getPathDetailsApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
-			
 				} catch (OneDriveException e) {
 					// Display error message
 					displayOneDriveErrorMessage(e.msg, thisFunctionName);
@@ -15188,8 +15041,6 @@ class SyncEngine {
 					// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 					getPathDetailsApiInstance.releaseCurlEngine();
 					getPathDetailsApiInstance = null;
-					// Perform Garbage Collection
-					GC.collect();
 					return;
 				}
 			}
@@ -15235,9 +15086,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			sharedWithMeOneDriveApiInstance.releaseCurlEngine();
 			sharedWithMeOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
-			
 		} catch (OneDriveException e) {
 			// Display error message
 			displayOneDriveErrorMessage(e.msg, thisFunctionName);
@@ -15245,8 +15093,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			sharedWithMeOneDriveApiInstance.releaseCurlEngine();
 			sharedWithMeOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
 			return;
 		}
 		
@@ -15360,8 +15206,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			sharedWithMeOneDriveApiInstance.releaseCurlEngine();
 			sharedWithMeOneDriveApiInstance = null;
-			// Perform Garbage Collection
-			GC.collect();
 			return;
 		}
 		
@@ -15583,9 +15427,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		sharedWithMeOneDriveApiInstance.releaseCurlEngine();
 		sharedWithMeOneDriveApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -16152,9 +15994,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		queryWebsocketURLApiInstance.releaseCurlEngine();
 		queryWebsocketURLApiInstance = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function
@@ -16207,8 +16047,6 @@ class SyncEngine {
 			// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 			queryPathDetailsOnline.releaseCurlEngine();
 			queryPathDetailsOnline = null;
-			// Perform Garbage Collection
-			GC.collect();
 			
 			// Return .. nothing to do
 			return;
@@ -16237,9 +16075,7 @@ class SyncEngine {
 		// OneDrive API Instance Cleanup - Shutdown API, free curl object and memory
 		queryPathDetailsOnline.releaseCurlEngine();
 		queryPathDetailsOnline = null;
-		// Perform Garbage Collection
-		GC.collect();
-		
+				
 		// Display function processing time if configured to do so
 		if (appConfig.getValueBool("display_processing_time") && debugLogging) {
 			// Combine module name & running Function

--- a/src/util.d
+++ b/src/util.d
@@ -1825,58 +1825,47 @@ string generateAlphanumericString(size_t length = 16) {
     return to!string(randomString);
 }
 
-// Display internal memory stats pre garbage collection
-void displayMemoryUsagePreGC() {
-	// Display memory usage
+// Display internal memory stats and RSS details
+void displayMemoryUsageDetails() {
+	// The Resident Set Size (RSS) represents the amount of physical memory currently
+	// mapped into the process address space. RSS includes application data, runtime
+	// allocations, thread stacks, shared libraries, memory-mapped files, allocator
+	// arenas, and other memory retained by the process.
+	//
+	// RSS does not directly indicate active memory usage. Memory that has been
+	// allocated and retained for future reuse may continue to contribute to RSS even
+	// when it is no longer actively being used by the application.
+	//
+	// Long-running applications may experience changes in RSS as workload patterns
+	// change, internal caches grow or shrink, and the runtime adjusts heap capacity.
+	// As such, RSS should be observed as a trend over time rather than interpreted as
+	// an indication of current memory demand or the presence of a memory leak.
+	
 	addLogEntry();
-	addLogEntry("Memory Usage PRE Garbage Collection (KB)");
+	addLogEntry("Memory Usage (KB)");
 	addLogEntry("-----------------------------------------------------");
-	writeMemoryStats();
-	addLogEntry();
-}
-
-// Display internal memory stats post garbage collection + RSS (actual memory being used)
-void displayMemoryUsagePostGC() {
-    // Display memory usage title
-    addLogEntry("Memory Usage POST Garbage Collection (KB)");
-    addLogEntry("-----------------------------------------------------");
-    writeMemoryStats();  // Assuming this function logs memory stats correctly
-
-    // Query the actual Resident Set Size (RSS) for the PID
-    pid_t pid = getCurrentPID();
-    ulong rss = getRSS(pid);
-
-    // Check and log the previous RSS value
-    if (previousRSS != 0) {
-        addLogEntry("previous Resident Set Size (RSS)         = " ~ to!string(previousRSS) ~ " KB");
-        
-        // Calculate and log the difference in RSS
-        long difference = rss - previousRSS;  // 'difference' can be negative, use 'long' to handle it
-        string sign = difference > 0 ? "+" : (difference < 0 ? "" : "");  // Determine the sign for display, no sign for zero
-        addLogEntry("difference in Resident Set Size (RSS)    = " ~ sign ~ to!string(difference) ~ " KB");
-    }
-    
-    // Update previous RSS with the new value
-    previousRSS = rss;
-    
-    // Closeout
-	addLogEntry();
-}
-
-// Write internal memory stats
-void writeMemoryStats() {
-	addLogEntry("current memory usedSize                  = " ~ to!string((GC.stats.usedSize/1024))); // number of used bytes on the GC heap (might only get updated after a collection)
-	addLogEntry("current memory freeSize                  = " ~ to!string((GC.stats.freeSize/1024))); // number of free bytes on the GC heap (might only get updated after a collection)
-	addLogEntry("current memory allocatedInCurrentThread  = " ~ to!string((GC.stats.allocatedInCurrentThread/1024))); // number of bytes allocated for current thread since program start
+	addLogEntry("current memory usedSize                  = " ~ to!string((GC.stats.usedSize/1024))); // Amount of GC-managed heap memory currently occupied by live objects
+	addLogEntry("current memory freeSize                  = " ~ to!string((GC.stats.freeSize/1024))); // Amount of GC-managed heap memory currently reserved and available for future allocations
+	addLogEntry("current memory allocatedInCurrentThread  = " ~ to!string((GC.stats.allocatedInCurrentThread/1024))); // Running total of memory allocated by this thread; this value is cumulative and does not indicate current memory usage
 	
 	// Query the actual Resident Set Size (RSS) for the PID
 	pid_t pid = getCurrentPID();
-	ulong rss = getRSS(pid);
-	// The RSS includes all memory that is currently marked as occupied by the process. 
-	// Over time, the heap can become fragmented. Even after garbage collection, fragmented memory blocks may not be contiguous enough to be returned to the OS, leading to an increase in the reported memory usage despite having free space.
-	// This includes memory that might not be actively used but has not been returned to the system. 
-	// The GC.minimize() function can sometimes cause an increase in RSS due to how memory pages are managed and freed.
-	addLogEntry("current Resident Set Size (RSS)          = " ~ to!string(rss)  ~ " KB"); // actual memory in RAM used by the process at this point in time
+	ulong currentRSS = getRSS(pid);
+	addLogEntry("current Resident Set Size (RSS)          = " ~ to!string(currentRSS) ~ " KB");
+	
+	// Calculate difference
+	if (previousRSS != 0) {
+		addLogEntry("previous Resident Set Size (RSS)         = " ~ to!string(previousRSS) ~ " KB");
+		// Delta between current and previous RSS
+		long rssDifference = cast(long) currentRSS - cast(long) previousRSS;
+		string sign = rssDifference > 0 ? "+" : (rssDifference < 0 ? "" : "");
+		addLogEntry("difference in Resident Set Size (RSS)    = " ~ sign ~ to!string(rssDifference) ~ " KB");
+	}
+	
+	// Update the previous RSS value
+	previousRSS = currentRSS;
+	addLogEntry("-----------------------------------------------------");
+	addLogEntry();
 }
 
 // Return the username of the UID running the 'onedrive' process

--- a/src/util.d
+++ b/src/util.d
@@ -1299,10 +1299,6 @@ JSONValue fetchOnlineURLContent(string url) {
 		// Shut http down and destroy
 		http.shutdown();
 		object.destroy(http);
-		// Perform Garbage Collection
-		GC.collect();
-		// Return free memory to the OS
-		GC.minimize();
 	}
 	
 	// Configure the URL to access


### PR DESCRIPTION


Remove explicit GC.collect() and GC.minimize() calls from hot execution paths associated with synchronisation and CurlEngine lifecycle management.

This reduces unnecessary garbage collection overhead during normal operation while preserving existing functionality.