### PR TITLE
Fix Bug #3772: Fix hardcoded Microsoft Graph endpoint usage in SharePoint drive search handling

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1609,7 +1609,7 @@ class OneDriveApi {
 		auto odataSafe = path.replace("'", "''");
 		auto encoded   = encodeComponent(odataSafe);
 		string url;
-		url = "https://graph.microsoft.com/v1.0/drives/" ~ driveId ~ "/root/search(q='" ~ encoded ~ "')";
+		url = driveByIdUrl ~ driveId ~ "/root/search(q='" ~ encoded ~ "')";
 		return get(url);
 	}
 	


### PR DESCRIPTION


`searchDriveForPath()` was still constructing the drive search URL with the commercial Graph endpoint, `https://graph.microsoft.com/v1.0`, instead of using the configured Graph base URL. This caused GCC High / US Government tenants using `graph.microsoft.us` to incorrectly jump back to the commercial endpoint during local file or directory creation checks, resulting in `401 Unauthorized` responses. The fix changes the URL construction to use `driveByIdUrl`, ensuring the search request honours the configured national-cloud endpoint. ([GitHub][1])