### PR TITLE
Bound peak memory during /delta enumeration on very large accounts (stream-process instead of accumulating the whole drive)

### DIFF
--- a/config
+++ b/config
@@ -204,6 +204,11 @@
 ## Number of threads to use for upload/download.
 #threads = "8"
 
+## Number of items to accumulate during /delta enumeration before processing and
+## clearing them, to bound peak memory usage on very large accounts. 0 disables
+## streaming (accumulate the entire /delta response before processing).
+#stream_flush_threshold = "5000"
+
 ## File transfer ordering between client and OneDrive.
 #transfer_order = "default"
 

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -1097,6 +1097,20 @@ _**Config Example:**_ `space_reservation = "100"`
 
 _**CLI Option Use:**_ `--space-reservation '100'`
 
+### stream_flush_threshold
+_**Description:**_ This configuration option controls how many items are accumulated during native `/delta` enumeration before they are processed and cleared. Processing at each bundle boundary once this threshold is reached keeps peak memory usage bounded to approximately the threshold size, rather than growing to the size of the entire drive. This is relevant for very large accounts where accumulating the whole `/delta` response before processing would otherwise exhaust available memory.
+
+_**Value Type:**_ Integer
+
+_**Default Value:**_ 5000
+
+_**Config Example:**_ `stream_flush_threshold = "5000"`
+
+_**CLI Option Use:**_ *None - this is a config file option only*
+
+> [!NOTE]
+> A value of `0` disables streaming and restores the previous behaviour of accumulating the entire `/delta` response before processing. Increasing this value raises peak memory usage with no material throughput benefit; decreasing it lowers peak memory usage at the cost of more frequent database checkpoints.
+
 ### sync_business_shared_items
 _**Description:**_ This configuration option controls whether OneDrive Business | Office 365 Shared Folders, when added as a 'shortcut' to your 'My Files', will be synced to your local system.
 

--- a/src/config.d
+++ b/src/config.d
@@ -348,7 +348,14 @@ class ApplicationConfig {
 		
 		// Number of concurrent threads
 		longValues["threads"] = defaultConcurrentThreads; // Default is 8, user can increase to max of 16 or decrease
-		
+
+		// Streaming flush threshold: during /delta enumeration, process & clear the accumulated
+		// jsonItemsToProcess once it reaches this many items (at a bundle boundary) to keep peak
+		// memory ~O(threshold) instead of O(drive). Higher = fewer flushes (less checkpoint/GC
+		// overhead, faster) but more peak RAM; lower = tighter RAM at the cost of more flushes.
+		// 0 disables streaming (accumulate the whole drive, original upstream behaviour).
+		longValues["stream_flush_threshold"] = 5000;
+
 		// Do we wish to upload only?
 		boolValues["upload_only"] = false;
 		// Do we need to check for the .nomount file on the mount point?

--- a/src/sync.d
+++ b/src/sync.d
@@ -104,7 +104,9 @@ class SyncEngine {
 	// Streaming flush threshold: when jsonItemsToProcess reaches this many items during /delta
 	// enumeration, process & clear it (at a bundle boundary) to keep peak memory ~O(threshold)
 	// instead of O(drive) and avoid the O(n^2) GC re-mark that stalled large first syncs.
-	enum size_t streamFlushThreshold = 5000;
+	// Runtime-tunable via the 'stream_flush_threshold' config option (0 disables streaming).
+	// Cached once at enumeration start so it cannot change mid-run.
+	size_t streamFlushThreshold = 5000;
 	// Array of JSON items which are files that are not 'root', skipped or to be deleted, that need to be downloaded
 	JSONValue[] fileJSONItemsToDownload;
 	// Array of paths that failed to download
@@ -1236,7 +1238,10 @@ class SyncEngine {
 		// Reset jsonItemsToProcess & processedCount
 		jsonItemsToProcess = [];
 		processedCount = 0;
-		
+
+		// Cache the streaming flush threshold once for this enumeration (0 = streaming disabled)
+		streamFlushThreshold = cast(size_t) max(0, appConfig.getValueLong("stream_flush_threshold"));
+
 		// Reset generatedSimulatedDeltaResponse
 		addLogEntry("Reset generatedSimulatedDeltaResponse as 'false'", ["debug"]);
 		generatedSimulatedDeltaResponse = false;
@@ -1498,7 +1503,8 @@ class SyncEngine {
 				// Streaming: once this bundle pushed the accumulator past the threshold, process and
 				// clear it now. Done at a bundle boundary so API parent-before-child ordering is never
 				// broken; keeps peak memory bounded instead of growing to the size of the whole drive.
-				if (jsonItemsToProcess.length >= streamFlushThreshold) {
+				// A threshold of 0 disables streaming (accumulate the whole drive, as upstream does).
+				if ((streamFlushThreshold > 0) && (jsonItemsToProcess.length >= streamFlushThreshold)) {
 					flushAccumulatedJSONItems();
 				}
 

--- a/src/sync.d
+++ b/src/sync.d
@@ -4,7 +4,7 @@ module syncEngine;
 // What does this module require to function?
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.stdc.errno : ENOENT, ENOTDIR;
-import core.memory : GC;   // streamfix: explicit GC.collect() at each flush boundary (heap is already small there)
+import core.memory : GC;   // explicit GC.collect() at each flush boundary (heap is already small there)
 import core.thread;
 import core.time;
 import std.algorithm;
@@ -2809,7 +2809,7 @@ class SyncEngine {
 	
 	// Stream-process the currently-accumulated jsonItemsToProcess through the existing 500-item
 	// chunked processor, then clear it. Safe to call repeatedly DURING /delta enumeration: the
-	// OneDrive API delivers parents before children, and each batch upserts items into
+	// OneDrive API delivers parents before children, and each batch inserts/updates items in
 	// items.sqlite3 before the next batch's children are looked up, so moving the chunk boundary
 	// earlier (streaming) preserves ordering while bounding peak memory to ~O(batch) instead of
 	// O(drive). This removes the O(n^2) GC re-mark that stalled large first syncs.

--- a/src/sync.d
+++ b/src/sync.d
@@ -4,6 +4,7 @@ module syncEngine;
 // What does this module require to function?
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.stdc.errno : ENOENT, ENOTDIR;
+import core.memory : GC;   // streamfix: explicit GC.collect() at each flush boundary (heap is already small there)
 import core.thread;
 import core.time;
 import std.algorithm;
@@ -100,6 +101,10 @@ class SyncEngine {
 	string[3][] idsToDelete;
 	// Array of JSON items which are files or directories that are not 'root', skipped or to be deleted, that need to be processed
 	JSONValue[] jsonItemsToProcess;
+	// Streaming flush threshold: when jsonItemsToProcess reaches this many items during /delta
+	// enumeration, process & clear it (at a bundle boundary) to keep peak memory ~O(threshold)
+	// instead of O(drive) and avoid the O(n^2) GC re-mark that stalled large first syncs.
+	enum size_t streamFlushThreshold = 5000;
 	// Array of JSON items which are files that are not 'root', skipped or to be deleted, that need to be downloaded
 	JSONValue[] fileJSONItemsToDownload;
 	// Array of paths that failed to download
@@ -1489,7 +1494,14 @@ class SyncEngine {
 					// This will determine its initial applicability and perform some initial processing on the JSON if required
 					processDeltaJSONItem(onedriveJSONItem, nrChanges, changeCount, responseBundleCount, singleDirectoryScope);
 				}
-				
+
+				// Streaming: once this bundle pushed the accumulator past the threshold, process and
+				// clear it now. Done at a bundle boundary so API parent-before-child ordering is never
+				// broken; keeps peak memory bounded instead of growing to the size of the whole drive.
+				if (jsonItemsToProcess.length >= streamFlushThreshold) {
+					flushAccumulatedJSONItems();
+				}
+
 				// Clear up this data
 				jsonArrayToProcess = null;
 				
@@ -1637,42 +1649,16 @@ class SyncEngine {
 			addLogEntry("Number of JSON items submitted for further processing is: " ~ to!string(jsonItemsToProcess.length), ["debug"]);
 		}
 		
-		// Are there items to process?
+		// Flush any residual accumulated items. The bulk were already streamed during enumeration
+		// (flushAccumulatedJSONItems() at each bundle threshold) to keep peak memory bounded; this
+		// processes the tail left after the final bundle.
 		if (jsonItemsToProcess.length > 0) {
-			// Lets deal with the JSON items in a batch process
-			size_t batchSize = 500;
-			long batchCount = (jsonItemsToProcess.length + batchSize - 1) / batchSize;
-			long batchesProcessed = 0;
-			
 			// Dynamic output for a non-verbose run so that the user knows something is happening
 			if (!appConfig.suppressLoggingOutput) {
 				addProcessingLogHeaderEntry("Processing " ~ to!string(jsonItemsToProcess.length) ~ " applicable JSON items received from Microsoft OneDrive", appConfig.verbosityCount);
 			}
-			
-			// For each batch, process the JSON items that need to be now processed.
-			// 'root' and deleted objects have already been handled
-			foreach (batchOfJSONItems; jsonItemsToProcess.chunks(batchSize)) {
-				// Chunk the total items to process into 500 lot items
-				batchesProcessed++;
-				if (appConfig.verbosityCount == 0) {
-					// Dynamic output for a non-verbose run so that the user knows something is happening
-					if (!appConfig.suppressLoggingOutput) {
-						addProcessingDotEntry();
-					}
-				} else {
-					if (verboseLogging) {addLogEntry("Processing OneDrive JSON item batch [" ~ to!string(batchesProcessed) ~ "/" ~ to!string(batchCount) ~ "] to ensure consistent local state", ["verbose"]);}
-				}	
-					
-				// Process the batch
-				processJSONItemsInBatch(batchOfJSONItems, batchesProcessed, batchCount);
-				
-				// To finish off the JSON processing items, this is needed to reflect this in the log
-				if (debugLogging) {addLogEntry(debugLogBreakType1, ["debug"]);}
-				
-				// For this set of items, perform a DB PASSIVE checkpoint
-				itemDB.performCheckpoint("PASSIVE");
-			}
-			
+			// Process & clear the residual window (also drains any remaining download JSON)
+			flushAccumulatedJSONItems();
 			if (appConfig.verbosityCount == 0) {
 				// close off '.' output
 				if (!appConfig.suppressLoggingOutput) {
@@ -1680,31 +1666,35 @@ class SyncEngine {
 					completeProcessingDots();
 				}
 			}
-			
-			// Debug output - what was processed
-			if (debugLogging) {
-				addLogEntry("Number of JSON items to process is: " ~ to!string(jsonItemsToProcess.length), ["debug"]);
-				addLogEntry("Number of JSON items processed was: " ~ to!string(processedCount), ["debug"]);
-				addLogEntry("", ["debug"]);
-				string jsonProcessingCompleteLineEntry = format("Processing of JSON items from driveId %s and itemId %s is complete", driveIdToQuery, itemIdToQuery);
-				addLogEntry(jsonProcessingCompleteLineEntry, ["debug"]);
-				addLogEntry("", ["debug"]);
-			}
-			
-			// Notification to user regarding number of objects received from OneDrive API
-			if (jsonItemsReceived >= 300000) {
-				// 'driveIdToQuery' should be the drive where the JSON responses came from
-				string objectsExceedLimitWarning = format("WARNING: The number of objects stored online in '%s' exceeds Microsoft OneDrive's recommended limit. This may cause unreliable application behaviour due to inconsistent or incomplete API responses. Immediate action is strongly advised to avoid data integrity issues.", driveIdToQuery);
-				addLogEntry(objectsExceedLimitWarning, ["info", "notify"]);
-			}
-			
-			// Free up memory and items processed as it is pointless now having this data around
-			jsonItemsToProcess = [];
-		} else {
+		}
+
+		// Debug output - total processed across all streamed + residual batches
+		if (debugLogging) {
+			addLogEntry("Number of JSON items processed was: " ~ to!string(processedCount), ["debug"]);
+			addLogEntry("", ["debug"]);
+			string jsonProcessingCompleteLineEntry = format("Processing of JSON items from driveId %s and itemId %s is complete", driveIdToQuery, itemIdToQuery);
+			addLogEntry(jsonProcessingCompleteLineEntry, ["debug"]);
+			addLogEntry("", ["debug"]);
+		}
+
+		// Notification to user regarding number of objects received from OneDrive API
+		if (jsonItemsReceived >= 300000) {
+			// 'driveIdToQuery' should be the drive where the JSON responses came from
+			string objectsExceedLimitWarning = format("WARNING: The number of objects stored online in '%s' exceeds Microsoft OneDrive's recommended limit. This may cause unreliable application behaviour due to inconsistent or incomplete API responses. Immediate action is strongly advised to avoid data integrity issues.", driveIdToQuery);
+			addLogEntry(objectsExceedLimitWarning, ["info", "notify"]);
+		}
+
+		// If nothing applicable was processed across the entire run (streamed + residual), inform the user
+		if (processedCount == 0) {
 			if (!appConfig.suppressLoggingOutput) {
 				addLogEntry("No changes or items that can be applied were discovered while processing the data received from Microsoft OneDrive");
 			}
 		}
+
+		// Free up memory; processed items are no longer needed
+		jsonItemsToProcess = [];
+		// Perform Garbage Collection
+		GC.collect();
 		
 		// Keep the DriveDetailsCache array with unique entries only
 		DriveDetailsCache cachedOnlineDriveData;
@@ -2811,6 +2801,50 @@ class SyncEngine {
 		}
 	}
 	
+	// Stream-process the currently-accumulated jsonItemsToProcess through the existing 500-item
+	// chunked processor, then clear it. Safe to call repeatedly DURING /delta enumeration: the
+	// OneDrive API delivers parents before children, and each batch upserts items into
+	// items.sqlite3 before the next batch's children are looked up, so moving the chunk boundary
+	// earlier (streaming) preserves ordering while bounding peak memory to ~O(batch) instead of
+	// O(drive). This removes the O(n^2) GC re-mark that stalled large first syncs.
+	// IMPORTANT: the deltaLink is NOT saved here (that stays in processDownloadActivities(), run
+	// once after enumeration) so a mid-stream crash safely re-enumerates next run; skippedItems is
+	// likewise NOT cleared here (it must persist across the whole enumeration).
+	void flushAccumulatedJSONItems() {
+		if (jsonItemsToProcess.length == 0) return;
+		// Lets deal with the JSON items in a batch process
+		size_t batchSize = 500;
+		long batchCount = (jsonItemsToProcess.length + batchSize - 1) / batchSize;
+		long batchesProcessed = 0;
+		// For each batch, process the JSON items that need to be now processed.
+		// 'root' and deleted objects have already been handled during enumeration.
+		foreach (batchOfJSONItems; jsonItemsToProcess.chunks(batchSize)) {
+			batchesProcessed++;
+			if (appConfig.verbosityCount == 0) {
+				// Dynamic output for a non-verbose run so that the user knows something is happening
+				if (!appConfig.suppressLoggingOutput) { addProcessingDotEntry(); }
+			} else {
+				if (verboseLogging) {addLogEntry("Processing OneDrive JSON item batch [" ~ to!string(batchesProcessed) ~ "/" ~ to!string(batchCount) ~ "] to ensure consistent local state", ["verbose"]);}
+			}
+			// Process the batch
+			processJSONItemsInBatch(batchOfJSONItems, batchesProcessed, batchCount);
+			// To finish off the JSON processing items, this is needed to reflect this in the log
+			if (debugLogging) {addLogEntry(debugLogBreakType1, ["debug"]);}
+			// For this set of items, perform a DB PASSIVE checkpoint
+			itemDB.performCheckpoint("PASSIVE");
+		}
+		// Drain accumulated download JSON too, so it does not grow unbounded across the whole
+		// drive. Only safe to drain early when no global transfer ordering is requested; a
+		// configured transfer_order keeps the end-of-run sorted download in processDownloadActivities().
+		if ((appConfig.getValueString("transfer_order") == "default") && (!fileJSONItemsToDownload.empty)) {
+			downloadOneDriveItems();
+			fileJSONItemsToDownload = [];
+		}
+		// Free the processed window; heap drops back to ~O(batch) so this GC is now cheap.
+		jsonItemsToProcess = [];
+		GC.collect();
+	}
+
 	// Perform the download of any required objects in parallel
 	void processDownloadActivities() {
 		// Function Start Time


### PR DESCRIPTION
## Summary

On very large accounts, native `/delta` enumeration accumulates **every** applicable item into `jsonItemsToProcess` for the *entire* drive before any of it is processed. Peak memory therefore scales with the total number of objects rather than the batch size. On a large Personal drive (~400k objects) this exhausts available memory: under a 1 GB cap the client is OOM-killed part-way through enumeration; uncapped it approaches ~3 GB.

This PR changes the enumeration to **stream-process** the accumulator at each response-bundle boundary once it reaches a configurable threshold, so peak memory stays ~O(threshold) instead of ~O(drive).

I raised this after retesting against current `master` to check #3746 and #3748. Those changes fixed the *CPU-bound* symptom (the forced `GC.collect()` per bundle that re-marked the growing heap), which was a real improvement — current `master` no longer pins CPU. However, peak memory is still ~O(drive) because the items are still accumulated for the whole drive before processing; the `.reserve()` change pre-allocates but does not bound the working set.

## Root cause

In `src/sync.d`, the `/delta` `while(true)` loop appends each non-filtered item to `jsonItemsToProcess` across all bundles, and only processes it in 500-item chunks *after* enumeration completes. The array (and heap) therefore grow to the size of the whole drive.

## The change

- Add `flushAccumulatedJSONItems()`: runs the existing 500-item `processJSONItemsInBatch()` loop + PASSIVE checkpoint over the currently-accumulated items, drains pending downloads (only when `transfer_order = default`, so a configured transfer order still gets the end-of-run sorted download), then clears the arrays.
- Call it at a **bundle boundary** once `jsonItemsToProcess` reaches the threshold. Bundle-boundary flushing preserves the API's parent-before-child ordering (each batch upserts parents to `items.sqlite3` before later batches' children look them up), so no global sort or deferral is needed.
- `deltaLink` is still saved only once, at the end, in `processDownloadActivities()` — a mid-stream interruption safely re-enumerates on the next run.
- New config option `stream_flush_threshold` (default `5000`, `0` restores the previous accumulate-everything behaviour), documented in `docs/application-config-options.md` and the example `config`.

## Testing evidence

Identical isolated test both ways: `--sync --dry-run` performing a full `/delta` enumeration of a ~400k-object Personal drive, container capped at `mem_limit=1g`.

**Without PR (current `master`, `ea98f49`):**
```
RSS: 54 MiB -> 458 MiB -> 704 MiB -> 1022 MiB
Result: OOM-killed (exit 137) at API response bundle ~719 (~143k of ~400k items, ~36%)
        Memory grows ~linearly with items enumerated; never completes under 1 GB.
```

**With PR (default threshold 5000):**
```
RSS: flat ~110 MiB for the entire enumeration; no OOM; completes.
```

Threshold tuning on the same drive (peak RSS vs `stream_flush_threshold`):
```
1000  -> ~46 MiB
5000  -> ~110 MiB   (default)
20000 -> ~188 MiB
```
Peak memory scales ~linearly with the threshold; processing throughput is flat across these values (enumeration dominates wall-clock; per-flush checkpoint/GC overhead is negligible), so the option is effectively a memory dial with no throughput penalty.

## Notes

- Relationship to #3746 / #3748: complementary. Those removed the forced-GC CPU cost; this bounds the memory growth. My earlier local GC-throttle change is intentionally **not** included here since #3746 supersedes it.
- British English spelling used throughout; 1TBS braces, tabs, `camelCase` per `docs/contributing.md`.
- Compiled and run with LDC; happy to validate against the minimum LDC 1.20.1 as per the contributing guide if you'd like before merge — the change only uses long-stable APIs (`core.memory.GC`, `appConfig.getValueLong`, `std.algorithm.max`).
- Account: Personal, `download_only`, `sync_dir` on a network (NFS) mount, single system, no concurrent access.
