### PR TITLE
Fix Alpine Docker build on musl

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,9 +6,9 @@ on:
     tags: [ 'v*' ]
   pull_request:
     # Comment these out to force a test build on a PR
-    branches:
-      - master
-    types: [closed]
+    #branches:
+    #  - master
+    #types: [closed]
 
 env:
   DOCKER_HUB_SLUG: driveone/onedrive

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,9 +6,9 @@ on:
     tags: [ 'v*' ]
   pull_request:
     # Comment these out to force a test build on a PR
-    #branches:
-    #  - master
-    #types: [closed]
+    branches:
+      - master
+    types: [closed]
 
 env:
   DOCKER_HUB_SLUG: driveone/onedrive

--- a/src/main.d
+++ b/src/main.d
@@ -39,7 +39,8 @@ import intune;
 import socketio;
 
 // Native stack trace support for fatal signal diagnostics.
-// On OpenBSD this is provided by libexecinfo; on Linux this is provided by libc.
+// On OpenBSD this is provided by libexecinfo; on Linux this is provided by glibc.
+// musl does not provide these interfaces, so Alpine builds use the fallback path.
 version (OpenBSD) {
 	
 	pragma(lib, "execinfo");
@@ -50,9 +51,11 @@ version (OpenBSD) {
 }
 
 version (linux) {
-	extern(C) nothrow @nogc @system {
-		int backtrace(void** addrlist, int len);
-		void backtrace_symbols_fd(void** addrlist, int len, int fd);
+	version (CRuntime_Glibc) {
+		extern(C) nothrow @nogc @system {
+			int backtrace(void** addrlist, int len);
+			void backtrace_symbols_fd(void** addrlist, int len, int fd);
+		}
 	}
 }
 
@@ -2274,12 +2277,16 @@ extern(C) nothrow @nogc @system void writeSignalStackTraceToStderr() {
 			write(STDERR_FILENO, stackTraceEmpty.ptr, stackTraceEmpty.length);
 		}
 	} else version (linux) {
-		void*[128] addrlist;
-		int frames = backtrace(addrlist.ptr, cast(int)addrlist.length);
-		if (frames > 0) {
-			backtrace_symbols_fd(addrlist.ptr, frames, STDERR_FILENO);
+		version (CRuntime_Glibc) {
+			void*[128] addrlist;
+			int frames = backtrace(addrlist.ptr, cast(int)addrlist.length);
+			if (frames > 0) {
+				backtrace_symbols_fd(addrlist.ptr, frames, STDERR_FILENO);
+			} else {
+				write(STDERR_FILENO, stackTraceEmpty.ptr, stackTraceEmpty.length);
+			}
 		} else {
-			write(STDERR_FILENO, stackTraceEmpty.ptr, stackTraceEmpty.length);
+			write(STDERR_FILENO, stackTraceUnavailable.ptr, stackTraceUnavailable.length);
 		}
 	} else {
 		write(STDERR_FILENO, stackTraceUnavailable.ptr, stackTraceUnavailable.length);


### PR DESCRIPTION
The OpenBSD support changes added native fatal-signal stack traces for Linux using `backtrace()` and `backtrace_symbols_fd()`.

These functions are available on glibc-based Linux distributions, but they are not provided by musl. As a result, the Alpine Docker build failed during the final link stage with undefined references to:

* `backtrace`
* `backtrace_symbols_fd`

This change limits the Linux native stack-trace implementation to builds using `CRuntime_Glibc`.

For musl-based builds, including Alpine Linux, the existing fallback message is used instead of attempting to call unavailable functions.

The OpenBSD implementation remains unchanged and continues to use `libexecinfo`.

### Behaviour after this change

* OpenBSD: native stack trace via `libexecinfo`
* Linux with glibc: native stack trace via `backtrace()` and `backtrace_symbols_fd()`
* Linux with musl: existing stack-trace-unavailable fallback
* Other platforms: existing fallback behaviour

This restores the Alpine Docker build without changing the validated OpenBSD runtime path.