### PR TITLE
Fix Bug #3782: Change mandatory resync exit status from 126 to 78

### DIFF
--- a/contrib/systemd/onedrive.service.in
+++ b/contrib/systemd/onedrive.service.in
@@ -22,8 +22,8 @@ ExecStartPre=/bin/sh -c 'sleep 15'
 ExecStart=@prefix@/bin/onedrive --monitor
 Restart=on-failure
 RestartSec=3
-# Do not restart the service if a --resync is required which is done via a 126 exit code
-RestartPreventExitStatus=126
+# Do not restart the service if a --resync is required; the client exits with EX_CONFIG (78)
+RestartPreventExitStatus=78
 # Time to wait for the service to stop gracefully before forcefully terminating it
 TimeoutStopSec=90
 

--- a/contrib/systemd/onedrive@.service.in
+++ b/contrib/systemd/onedrive@.service.in
@@ -24,8 +24,8 @@ User=%i
 Group=users
 Restart=on-failure
 RestartSec=3
-# Do not restart the service if a --resync is required which is done via a 126 exit code
-RestartPreventExitStatus=126
+# Do not restart the service if a --resync is required; the client exits with EX_CONFIG (78)
+RestartPreventExitStatus=78
 # Time to wait for the service to stop gracefully before forcefully terminating it
 TimeoutStopSec=90
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1334,6 +1334,20 @@ onedrive --display-sync-status
 
 This shows whether you are up-to-date without requiring a resynchronisation.
 
+#### Exit status when a --resync is required
+When the client determines that it cannot safely continue until a `--resync` is performed, it exits with status **78**. This is the traditional `EX_CONFIG` value and indicates that the client has detected an application configuration or persisted-state condition that requires operator action before normal synchronisation can continue.
+
+This status is intentionally distinct from the generic application failure status (`1`). It allows scripts and service managers to detect a mandatory resync condition without conflicting with shell-reserved exit statuses. The supplied systemd service files use exit status 78 in `RestartPreventExitStatus`, so systemd will not repeatedly restart the client when a resync is required.
+
+To resolve the condition, re-run the client with `--resync` appended to the normal synchronisation mode being used, for example:
+```text
+onedrive --sync --resync
+onedrive --monitor --resync
+```
+
+> [!IMPORTANT]
+> Versions prior to v2.5.12 used exit status **126** for this condition. Scripts, monitoring integrations, and service definitions that explicitly test for status 126 must be updated to test for status 78 instead.
+
 #### What happens when you use `--resync`
 
 When invoking `--resync`, the client displays one of the following prompts depending on the client version.

--- a/src/main.d
+++ b/src/main.d
@@ -117,7 +117,9 @@ version (OpenBSD) {
 
 
 // What other constant variables do we require?
-const int EXIT_RESYNC_REQUIRED = 126;
+// A mandatory --resync is an application configuration/state condition.
+// Use the traditional EX_CONFIG status value so callers can distinguish it from a generic failure.
+const int EXIT_RESYNC_REQUIRED = 78;
 
 // Class objects
 ApplicationConfig appConfig;
@@ -636,6 +638,7 @@ int main(string[] cliArgs) {
 				// Application configuration has changed however --resync not issued, fail fast
 				addLogEntry();
 				addLogEntry("An application configuration change has been detected where a --resync is required", ["info", "notify"]);
+				addLogEntry("Re-run the client with '--resync' appended to your normal '--sync' or '--monitor' command.");
 				addLogEntry();
 				return EXIT_RESYNC_REQUIRED;
 			} else {
@@ -950,6 +953,7 @@ int main(string[] cliArgs) {
 				// Not an empty database
 				addLogEntry();
 				addLogEntry("An application cache state issue has been detected where a --resync is required", ["info", "notify"]);
+				addLogEntry("Re-run the client with '--resync' appended to your normal '--sync' or '--monitor' command.");
 				addLogEntry();
 				return EXIT_RESYNC_REQUIRED;
 			}


### PR DESCRIPTION
The client currently exits with status `126` when it detects a condition that requires the user to perform a `--resync`.

Exit status `126` is conventionally used by shells to indicate that a command was found but could not be executed. This does not accurately represent the OneDrive client's behaviour: the application has executed successfully, but has detected a persistent configuration or state condition that requires user intervention before normal synchronisation can continue.

Change the mandatory resync exit status from `126` to `78`.

Exit status `78` corresponds to the traditional `EX_CONFIG` value and more accurately represents the condition being reported. It also avoids using the shell-reserved `126` exit status.

This change:

* changes `EXIT_RESYNC_REQUIRED` from `126` to `78`;
* updates both supplied systemd service templates to use `RestartPreventExitStatus=78`;
* preserves the existing systemd behaviour where a mandatory resync prevents automatic service restart while leaving the service in a failed state requiring operator action;
* improves the resync-required error message to make it clear that `--resync` must be appended to the normal invocation, for example:

  * `onedrive --sync --resync`
  * `onedrive --monitor --resync`
* documents the new exit status and the compatibility impact for scripts, monitoring systems and custom service definitions that currently test for exit status `126`.

No synchronisation or resync processing behaviour is otherwise changed.

Existing automation that explicitly checks for exit status `126` will need to be updated to check for exit status `78` instead.