### PR TITLE
Fix Bug #3786: Fix build version generation for Git worktrees

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -108,8 +108,8 @@ distclean: clean
 	rm -f Makefile contrib/pacman/PKGBUILD contrib/spec/onedrive.spec onedrive.1 $(system_unit_files) $(user_unit_files)
 
 onedrive: $(SOURCES)
-	if git rev-parse --is-inside-work-tree >/dev/null 2>&1 ; then \
-		git describe --tags --always > version ; \
+	if [ -d .git ] || [ -f .git ]; then \
+		git describe --tags > version ; \
 	else \
 		echo $(version) > version ; \
 	fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -109,7 +109,7 @@ distclean: clean
 
 onedrive: $(SOURCES)
 	if git rev-parse --is-inside-work-tree >/dev/null 2>&1 ; then \
-		git describe --tags --always --dirty > version ; \
+		git describe --tags --always > version ; \
 	else \
 		echo $(version) > version ; \
 	fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -108,8 +108,8 @@ distclean: clean
 	rm -f Makefile contrib/pacman/PKGBUILD contrib/spec/onedrive.spec onedrive.1 $(system_unit_files) $(user_unit_files)
 
 onedrive: $(SOURCES)
-	if [ -f .git/HEAD ] ; then \
-		git describe --tags > version ; \
+	if git rev-parse --is-inside-work-tree >/dev/null 2>&1 ; then \
+		git describe --tags --always --dirty > version ; \
 	else \
 		echo $(version) > version ; \
 	fi


### PR DESCRIPTION
The current build logic determines whether the source tree is a Git checkout by testing for `.git/HEAD`.

This works for a normal Git checkout, where `.git` is a directory containing `HEAD`, but not for a linked Git worktree where `.git` is a file that references the repository metadata.

As a result, builds performed from linked Git worktrees fall back to `PACKAGE_VERSION` and lose the expected Git commit/version provenance.

This change updates the existing Git checkout detection to recognise both supported forms of `.git` metadata:

```sh
[ -d .git ] || [ -f .git ]
```

The existing version generation command remains unchanged:

```sh
git describe --tags
```

This keeps the scope of the fix limited to Git worktree detection and preserves the existing build-version behaviour for normal Git checkouts, releases and non-Git source builds.

Expected behaviour:

* Exact release tag: `onedrive v2.5.10`
* Exact release tag with local modifications: `onedrive v2.5.10`
* Development branch / master: `onedrive v2.5.11-6-gac3f042`
* Pull request / other commits after a tag: `onedrive v2.5.11-7-gbcafb25`
* Linked Git worktree: same Git-derived version as a normal checkout
* Source archive or other non-Git build: falls back to the configured `PACKAGE_VERSION`

No changes to `configure.ac` or the generated `configure` script are required.

This deliberately avoids changing the existing `git describe --tags` behaviour or broadening Git repository detection beyond the source directory itself.
