### PR TITLE
Fix Bug #3800: Fix zero disk space handling during libcurl initialisation failure

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -2709,7 +2709,9 @@ class OneDriveApi {
 							// initialization error ... prevent a run-away process if we have zero disk space
 							ulong localActualFreeSpace = getAvailableDiskSpace(".");
 							if (localActualFreeSpace == 0) {
-								throw new OneDriveError("Zero disk space detected");
+								addLogEntry("ERROR: Zero disk space detected");
+								// Must force exit here, allow logging to be done
+								forceExit();
 							}
 						} else {
 							// Unknown curl error


### PR DESCRIPTION


This change fixes the zero-disk-space handling path identified in #3800.

When libcurl reports a `Failed initialization on handle` error, the client checks the available local disk space to determine whether the failure was caused by the filesystem being completely full.

Previously, when zero available disk space was detected, the code executed:

```d
throw new OneDriveError("Zero disk space detected");
```

However, this occurs from inside an existing `catch (CurlException)` block.

The subsequent `catch (OneDriveError)` is a sibling catch handler and therefore cannot catch an error thrown from within the preceding `catch (CurlException)` block. As a result, the `OneDriveError` could escape as an unhandled D `Error`, producing an unnecessary stack trace rather than following the application's intended fatal-exit path.

This change handles the condition directly where it is detected:

```d
addLogEntry("ERROR: Zero disk space detected");
forceExit();
```

This ensures that:

* zero available disk space remains a fatal condition;
* the condition is clearly recorded in the application log;
* the existing `forceExit()` path is used;
* the `OneDriveError` no longer escapes from the `CurlException` handler;
* an unnecessary D stack trace is avoided.

The existing disk-space detection logic is otherwise unchanged.

No changes are made to other libcurl error handling paths, including the SSL CA certificate recovery logic.

The existing `OneDriveError` class and associated catch handler are also left unchanged, keeping this fix narrowly scoped to the specific control-flow defect identified in #3800.