### PR TITLE
Fix Bug #3802: Fix recovery from transient WebSocket notification URL failures

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1133,10 +1133,10 @@ int main(string[] cliArgs) {
 							addLogEntry("Attempting to enable WebSocket support to monitor Microsoft Graph API changes in near real-time.");
 							
 							// Obtain the WebSocket Notification URL from the API endpoint
-							syncEngineInstance.obtainWebSocketNotificationURL();
+							bool websocketNotificationUrlObtained = syncEngineInstance.obtainWebSocketNotificationURL();
 							
 							// Were we able to correctly obtain the endpoint response and build the socket.io WS endpoint
-							if (appConfig.websocketNotificationUrlAvailable) {
+							if (websocketNotificationUrlObtained) {
 								// Notification URL is available
 								if (oneDriveSocketIo is null) {
 									oneDriveSocketIo = new OneDriveSocketIo(thisTid, appConfig);
@@ -1144,9 +1144,7 @@ int main(string[] cliArgs) {
 								}
 								addLogEntry("Enabled WebSocket support to monitor Microsoft Graph API changes in near real-time.");
 							} else {
-								addLogEntry("ERROR: Unable to configure WebSocket support to monitor Microsoft Graph API changes in near real-time.");
-								if (debugLogging) {addLogEntry("Setting 'disable_websocket_support' to 'true' to force WebSockets to be disabled.", ["debug"]);}
-								appConfig.setValueBool("disable_websocket_support" , true);
+								addLogEntry("WARNING: Unable to configure WebSocket support to monitor Microsoft Graph API changes in near real-time. The client will retry while monitor mode remains active.");
 							}
 						} else {
 							// WebSocket Support has been disabled
@@ -1272,6 +1270,8 @@ int main(string[] cliArgs) {
 			// Immutables
 			immutable auto checkOnlineInterval = dur!"seconds"(appConfig.getValueLong("monitor_interval"));
 			immutable auto githubCheckInterval = dur!"seconds"(86400);
+			immutable auto websocketRetryInterval = dur!"seconds"(60);
+			immutable auto websocketRenewEarly = dur!"seconds"(120);
 			immutable ulong fullScanFrequency = appConfig.getValueLong("monitor_fullscan_frequency");
 			immutable ulong logOutputSuppressionInterval = appConfig.getValueLong("monitor_log_frequency");
 			immutable bool webhookEnabled = appConfig.getValueBool("webhook_enabled");
@@ -1284,6 +1284,10 @@ int main(string[] cliArgs) {
 			ulong monitorLogOutputLoopCount = 0;
 			MonoTime lastCheckTime = MonoTime.currTime();
 			MonoTime lastGitHubCheckTime = MonoTime.currTime();
+			// Startup WebSocket URL acquisition, when enabled, occurs immediately before
+			// entering the monitor loop. Rate-limit any subsequent acquisition attempt so
+			// frequent local filesystem activity cannot hammer the Graph endpoint.
+			MonoTime lastWebSocketAcquisitionAttempt = MonoTime.currTime();
 			SysTime lastMonitorGcCleanup = Clock.currTime();
 			
 			monitorLoop: while (performFileSystemMonitoring) {
@@ -1321,19 +1325,45 @@ int main(string[] cliArgs) {
 						if (appConfig.curlSupportsWebSockets) {
 							// Did the user configure to disable 'websocket' support?
 							if (!appConfig.getValueBool("disable_websocket_support")) {
-								// Do we need to renew the notification URL?
-								auto renewEarly = dur!"seconds"(120);
+								// WebSocket notification URL acquisition is recoverable. This covers both
+								// an initial startup failure (no URL available yet) and renewal of an
+								// existing endpoint shortly before expiry.
+								auto acquisitionNow = MonoTime.currTime();
+								bool websocketAcquisitionRequired = !appConfig.websocketNotificationUrlAvailable;
+								bool websocketRenewalRequired = false;
+								
 								if (appConfig.websocketNotificationUrlAvailable && appConfig.websocketUrlExpiry.length) {
-									auto expiry = SysTime.fromISOExtString(appConfig.websocketUrlExpiry);
-									auto now    = Clock.currTime(UTC());
-									if (expiry - now <= renewEarly) {
-										try {
-											// Obtain the WebSocket Notification URL from the API endpoint
-											syncEngineInstance.obtainWebSocketNotificationURL();
-											if (debugLogging) addLogEntry("Refreshed WebSocket notification URL prior to expiry", ["debug"]);
-										} catch (Exception e) {
-											if (debugLogging) addLogEntry("Failed to refresh WebSocket notification URL: " ~ e.msg, ["debug"]);
+									try {
+										auto expiry = SysTime.fromISOExtString(appConfig.websocketUrlExpiry);
+										auto now = Clock.currTime(UTC());
+										websocketRenewalRequired = (expiry - now <= websocketRenewEarly);
+									} catch (Exception e) {
+										// Existing expiry state is malformed; attempt to replace it through the
+										// normal, rate-limited acquisition path rather than terminating monitor mode.
+										websocketRenewalRequired = true;
+										if (debugLogging) addLogEntry("Unable to parse current WebSocket notification URL expiry: " ~ e.msg, ["debug"]);
+									}
+								}
+								
+								if ((websocketAcquisitionRequired || websocketRenewalRequired) &&
+									(acquisitionNow - lastWebSocketAcquisitionAttempt >= websocketRetryInterval)) {
+									if (websocketAcquisitionRequired) {
+										addLogEntry("Retrying WebSocket notification URL acquisition.");
+									}
+									
+									lastWebSocketAcquisitionAttempt = acquisitionNow;
+									bool websocketNotificationUrlObtained = syncEngineInstance.obtainWebSocketNotificationURL();
+									
+									if (websocketNotificationUrlObtained) {
+										if (oneDriveSocketIo is null) {
+											oneDriveSocketIo = new OneDriveSocketIo(thisTid, appConfig);
+											oneDriveSocketIo.start();
+											addLogEntry("Enabled WebSocket support to monitor Microsoft Graph API changes in near real-time.");
+										} else if (debugLogging) {
+											addLogEntry("Refreshed WebSocket notification URL prior to expiry", ["debug"]);
 										}
+									} else if (debugLogging) {
+										addLogEntry("WebSocket notification URL acquisition failed; retaining existing state and retrying later", ["debug"]);
 									}
 								}
 							}
@@ -1527,7 +1557,11 @@ int main(string[] cliArgs) {
 					auto sleepTime = nextCheckTime - currentTime;
 					if (debugLogging) {addLogEntry("Sleep for " ~ to!string(sleepTime), ["debug"]);}
 					
-					if (filesystemMonitor.initialised || webhookEnabled || oneDriveSocketIo !is null) {
+					bool websocketSupportActiveOrRetryable = !appConfig.getValueBool("upload_only") &&
+						!webhookEnabled && appConfig.curlSupportsWebSockets &&
+						!appConfig.getValueBool("disable_websocket_support");
+					
+					if (filesystemMonitor.initialised || webhookEnabled || oneDriveSocketIo !is null || websocketSupportActiveOrRetryable) {
 
 						if (filesystemMonitor.initialised) {
 							// If local monitor is on and is waiting (previous event was not from webhook)
@@ -1554,8 +1588,33 @@ int main(string[] cliArgs) {
 								Duration nextWebhookCheckDuration = oneDriveWebhook.getNextExpirationCheckDuration();
 								if (nextWebhookCheckDuration < sleepTime) sleepTime = nextWebhookCheckDuration;
 								notificationReceived = false;
-							} else if (oneDriveSocketIo !is null && !appConfig.getValueBool("disable_websocket_support") && appConfig.curlSupportsWebSockets) {
-								Duration nextWebsocketCheckDuration = oneDriveSocketIo.getNextExpirationCheckDuration();
+							} else if (websocketSupportActiveOrRetryable) {
+								Duration nextWebsocketCheckDuration;
+								if (oneDriveSocketIo !is null) {
+									nextWebsocketCheckDuration = oneDriveSocketIo.getNextExpirationCheckDuration();
+									
+									// If a renewal attempt has failed while the existing connection remains
+									// usable, wake at the retry cadence rather than waiting until expiry.
+									if (appConfig.websocketNotificationUrlAvailable && appConfig.websocketUrlExpiry.length) {
+										try {
+											auto expiry = SysTime.fromISOExtString(appConfig.websocketUrlExpiry);
+											if (expiry - Clock.currTime(UTC()) <= websocketRenewEarly) {
+												auto elapsedSinceAcquisitionAttempt = MonoTime.currTime() - lastWebSocketAcquisitionAttempt;
+												auto retryWait = (elapsedSinceAcquisitionAttempt < websocketRetryInterval) ?
+													(websocketRetryInterval - elapsedSinceAcquisitionAttempt) : Duration.zero;
+												if (retryWait < nextWebsocketCheckDuration) nextWebsocketCheckDuration = retryWait;
+											}
+										} catch (Exception exception) {
+											// Malformed expiry is handled by the acquisition path at the top of the loop.
+										}
+									}
+								} else {
+									// No worker exists yet because initial URL acquisition failed. Wake the
+									// monitor loop when the retry interval elapses even in --download-only mode.
+									auto elapsedSinceAcquisitionAttempt = MonoTime.currTime() - lastWebSocketAcquisitionAttempt;
+									nextWebsocketCheckDuration = (elapsedSinceAcquisitionAttempt < websocketRetryInterval) ?
+										(websocketRetryInterval - elapsedSinceAcquisitionAttempt) : Duration.zero;
+								}
 								if (nextWebsocketCheckDuration < sleepTime) sleepTime = nextWebsocketCheckDuration;
 							}
 						}

--- a/src/socketio.d
+++ b/src/socketio.d
@@ -34,7 +34,6 @@ final class OneDriveSocketIo {
 	private Duration renewEarly = dur!"seconds"(120);
 	private string engineSid;
 	private bool expiryWarned = false;
-	private bool renewRequested = false;
 	private string currentNotifUrl;
 
 	// Worker / state
@@ -274,9 +273,8 @@ private:
 
 					// Connected successfully → reset backoff
 					backoffSeconds = 1;
-					// Reset per-connection flags so renew logic and ns-open tracking work after reconnection
-					self.expiryWarned   = false;
-					self.renewRequested = false;
+					// Reset per-connection flags so expiry warning and ns-open tracking work after reconnection
+					self.expiryWarned = false;
 					self.namespaceOpened = false;
 
 					// Track last server ping received to detect a dead connection
@@ -302,21 +300,6 @@ private:
 								if (remain <= dur!"minutes"(5)) {
 									self.expiryWarned = true; // emit only once
 									logSocketIOOutput("subscription nearing expiry; renewal required soon");
-								}
-							}
-						}
-
-						// Renewal window check (emit once; 2 minutes before)
-						if (!self.renewRequested && self.appConfig.websocketUrlExpiry.length > 0) {
-							SysTime expiry;
-							auto e = collectException(expiry = SysTime.fromISOExtString(self.appConfig.websocketUrlExpiry));
-							if (e is null) {
-								auto remain = expiry - Clock.currTime(UTC());
-								if (remain <= dur!"minutes"(2)) {
-									self.renewRequested = true;
-									logSocketIOOutput("Subscription nearing expiry; requesting renewal from main() monitor loop");
-									send(self.parentTid, "SOCKETIO_RENEWAL_REQUEST");
-									send(self.parentTid, "SOCKETIO_RENEWAL_CONTEXT:" ~ "id=" ~ self.appConfig.websocketEndpointResponse ~ " url=" ~ self.appConfig.websocketNotificationUrl);
 								}
 							}
 						}

--- a/src/sync.d
+++ b/src/sync.d
@@ -16402,7 +16402,12 @@ class SyncEngine {
 	}
 	
 	// Obtain the Websocket Notification URL
-	void obtainWebSocketNotificationURL() {
+	//
+	// Return true only when a complete, valid replacement endpoint has been
+	// obtained and committed to the runtime configuration. A failed request or
+	// malformed response must leave any existing working endpoint untouched so
+	// that callers can safely retry later.
+	bool obtainWebSocketNotificationURL() {
 		// Function Start Time
 		SysTime functionStartTime;
 		string logKey;
@@ -16414,7 +16419,7 @@ class SyncEngine {
 			displayFunctionProcessingStart(thisFunctionName, logKey);
 		}
 		
-		string websocketURL;
+		bool websocketNotificationUrlObtained = false;
 		
 		// Create a new API Instance for this thread and initialise it
 		OneDriveApi queryWebsocketURLApiInstance;
@@ -16427,35 +16432,44 @@ class SyncEngine {
 			
 			// Was a valid JSON response with the required endpoint fields provided?
 			if ((endpointResponse.type() == JSONType.object) && (("notificationUrl" in endpointResponse) != null) && (("expirationDateTime" in endpointResponse) != null)) {
-				
-				// Log response
-				if (debugLogging) {addLogEntry("Response for a Socket.IO Subscription Endpoint: " ~ to!string(endpointResponse), ["debug"]);}
-				
-				// Store the JSON in the configuration for reuse
-				appConfig.websocketEndpointResponse = to!string(endpointResponse);
-				
-				// Extract and store the Notification URL from the response we received (no transformation)
-				websocketURL = endpointResponse["notificationUrl"].str;
-				
-				// Extract and store the expiry
-				appConfig.websocketUrlExpiry = endpointResponse["expirationDateTime"].str;
-				SysTime expiryUTC = SysTime.fromISOExtString(appConfig.websocketUrlExpiry);
-				SysTime expiryLocal = expiryUTC.toLocalTime();
-				
-				// Do we have a valid Notification URL ?
-				if (!websocketURL.empty) {
-					// Store the websocket notification URL
-					appConfig.websocketNotificationUrl = websocketURL;
-					// Set flag
-					appConfig.websocketNotificationUrlAvailable = true;
-				
-					// Log WebSocket specifics
-					if (debugLogging) {
-						addLogEntry("WebSocket Notification URL: " ~ websocketURL, ["debug"]);
-						addLogEntry("WebSocket Expiry (UTC):     " ~ to!string(expiryUTC), ["debug"]);
-						addLogEntry("WebSocket Expiry (Local):   " ~ to!string(expiryLocal), ["debug"]);
+				// Validate the complete replacement response before changing any existing
+				// WebSocket state. This ensures a failed renewal cannot partially replace
+				// a working endpoint, expiry or response payload.
+				try {
+					string websocketURL = endpointResponse["notificationUrl"].str;
+					string websocketExpiry = endpointResponse["expirationDateTime"].str;
+					
+					if (!websocketURL.empty && !websocketExpiry.empty) {
+						SysTime expiryUTC = SysTime.fromISOExtString(websocketExpiry);
+						SysTime expiryLocal = expiryUTC.toLocalTime();
+						
+						// Log response only after all required fields have been validated
+						if (debugLogging) {addLogEntry("Response for a Socket.IO Subscription Endpoint: " ~ to!string(endpointResponse), ["debug"]);}
+						
+						// Commit the new endpoint only after the complete replacement response
+						// has been validated.
+						appConfig.websocketEndpointResponse = to!string(endpointResponse);
+						appConfig.websocketUrlExpiry = websocketExpiry;
+						// Publish the URL after its associated metadata so the Socket.IO worker
+						// cannot observe a new endpoint paired with the previous expiry.
+						appConfig.websocketNotificationUrl = websocketURL;
+						appConfig.websocketNotificationUrlAvailable = true;
+						websocketNotificationUrlObtained = true;
+						
+						// Log WebSocket specifics
+						if (debugLogging) {
+							addLogEntry("WebSocket Notification URL: " ~ websocketURL, ["debug"]);
+							addLogEntry("WebSocket Expiry (UTC):     " ~ to!string(expiryUTC), ["debug"]);
+							addLogEntry("WebSocket Expiry (Local):   " ~ to!string(expiryLocal), ["debug"]);
+						}
+					} else {
+						if (debugLogging) {addLogEntry("Socket.IO Subscription Endpoint response did not contain a usable notification URL and expiry", ["debug"]);}
 					}
-				}	
+				} catch (Exception exception) {
+					if (debugLogging) {addLogEntry("Socket.IO Subscription Endpoint response could not be validated: " ~ exception.msg, ["debug"]);}
+				}
+			} else {
+				if (debugLogging) {addLogEntry("Socket.IO Subscription Endpoint response did not contain the required notificationUrl and expirationDateTime fields", ["debug"]);}
 			}
 			
 		} catch (OneDriveException exception) {
@@ -16474,8 +16488,10 @@ class SyncEngine {
 			// Combine module name & running Function
 			displayFunctionProcessingTime(thisFunctionName, functionStartTime, Clock.currTime(), logKey);
 		}
+		
+		return websocketNotificationUrlObtained;
 	}
-	
+
 	// Download a single file via --download-file <path/to/file>
 	void downloadSingleFile(string pathToQuery) {
 		// Function Start Time


### PR DESCRIPTION
The client currently treats a failure to obtain the Microsoft Graph WebSocket notification URL during startup as a permanent condition for the lifetime of the process.

If the initial `/subscriptions/socketIo` request fails transiently, WebSocket support is disabled and is not attempted again until the client is restarted.

The renewal path also assumes that a valid WebSocket URL already exists, so it cannot recover from an initial acquisition failure.

This change makes WebSocket notification URL acquisition recoverable and ensures failed renewals do not corrupt existing working state.

### Changes

* Change `obtainWebSocketNotificationURL()` to return whether a valid WebSocket endpoint was successfully obtained.
* Validate the new notification URL and expiration timestamp before updating the active WebSocket state.
* Preserve the existing WebSocket URL and expiry if a renewal attempt fails.
* Do not set `disable_websocket_support` following a transient startup acquisition failure.
* Retry WebSocket URL acquisition while monitor mode remains active.
* Rate-limit failed acquisition attempts to avoid repeatedly calling `/subscriptions/socketIo` during frequent monitor-loop activity.
* Start the Socket.IO worker when a later retry successfully obtains a WebSocket URL.
* Include the WebSocket retry deadline in monitor-loop wake-up calculations so recovery also works when no filesystem monitor or Socket.IO worker is currently available.
* Only report successful WebSocket renewal when a new endpoint was actually obtained.
* Remove the unused `SOCKETIO_RENEWAL_REQUEST` and `SOCKETIO_RENEWAL_CONTEXT` messages and associated renewal state from the Socket.IO worker, as renewal is owned by the main monitor loop.

### Expected behaviour

If initial WebSocket URL acquisition succeeds:

```text
Attempting to enable WebSocket support ...
Enabled WebSocket support ...
```

Operation continues unchanged.

If initial acquisition fails transiently:

```text
Attempting to enable WebSocket support ...
WARNING: Unable to configure WebSocket support ... The client will retry while monitor mode remains active.
```

The client remains running and WebSocket support remains eligible for recovery.

After the retry interval:

```text
Retrying WebSocket notification URL acquisition.
Enabled WebSocket support ...
```

The Socket.IO worker is then started without requiring the OneDrive client to be restarted.

If renewal of an existing WebSocket endpoint fails, the previously valid URL and expiry remain intact and another renewal attempt can be made later.

### Testing

The change compiles successfully.

The initial-failure recovery path was tested using a temporary one-shot fault injection in `obtainWebSocketNotificationURL()` to simulate failure of only the first WebSocket endpoint request without affecting other Microsoft Graph operations.

Observed output:

```text
Attempting to enable WebSocket support to monitor Microsoft Graph API changes in near real-time.
TEST #3802: Simulating initial WebSocket notification URL acquisition failure
WARNING: Unable to configure WebSocket support to monitor Microsoft Graph API changes in near real-time. The client will retry while monitor mode remains active.
Retrying WebSocket notification URL acquisition.
Enabled WebSocket support to monitor Microsoft Graph API changes in near real-time.
```

This confirms that a transient initial acquisition failure no longer permanently disables WebSocket support and that the client successfully recovers without being restarted.