### PR TITLE
Fix Bug #3811: Fix failed download response handling in downloadFileItem()

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -577,7 +577,7 @@ class CurlEngine {
 		return response;
 	}
 
-	CurlResponse download(string originalFilename, string downloadFilename) {
+	CurlResponse download(string downloadFilename, bool delegate(int) shouldAcceptResponseBody = null) {
 		setResponseHolder(null);
 		
 		// Open the file in append mode if resuming, else write mode
@@ -607,28 +607,39 @@ class CurlEngine {
 		QuickXorStreamHasher quickXorStreamHasher;
 		ulong streamedHashBytes = 0;
 		
+		// Only persist response bodies that the caller considers valid download
+		// responses. This prevents HTTP error bodies from contaminating a valid
+		// resumable partial file before the higher-level retry/error handler runs.
+		bool acceptResponseBody = true;
+		if (shouldAcceptResponseBody !is null) {
+			http.onReceiveStatusLine = (HTTP.StatusLine statusLine) {
+				acceptResponseBody = shouldAcceptResponseBody(statusLine.code);
+			};
+		}
+
 		// Receive data
 		http.onReceive = (ubyte[] data) {
-			if (enableStreamedHash) {
-				quickXorStreamHasher.update(data);
-				streamedHashBytes += data.length;
+			if (acceptResponseBody) {
+				if (enableStreamedHash) {
+					quickXorStreamHasher.update(data);
+					streamedHashBytes += data.length;
+				}
+				file.rawWrite(data);
 			}
-			file.rawWrite(data);
 			return data.length;
 		};
 		
 		// Perform HTTP Operation
 		http.perform();
 		
-		// close open file - avoids problems with renaming on GCS Buckets and other semi-POSIX systems
+		// close open file before returning control to the caller
 		if (file.isOpen()){
 			file.close();
 		}
-		
-		// Rename downloaded file
-		rename(downloadFilename, originalFilename);
 
-		// Update response and return response
+		// Update response and return response. Promotion of the temporary download
+		// into the final destination is deliberately owned by the API layer after
+		// HTTP response validation has completed.
 		response.update(&http);
 		if (enableStreamedHash) {
 			response.streamedQuickXorHash = quickXorStreamHasher.finishB64();

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1827,18 +1827,6 @@ class OneDriveApi {
 		// - driveId
 		// - itemId
 		
-		scope(failure) {
-			if (exists(saveToPath)) {
-				// try and remove the file, catch error
-				try {
-					remove(saveToPath);
-				} catch (FileException exception) {
-					// display the error message
-					displayFileSystemErrorMessage(exception.msg, thisFunctionName, saveToPath);
-				}
-			}
-		}
-
 		// Create the required local parental path structure if this does not exist
 		string parentalPath = dirName(saveToPath);
 
@@ -2166,6 +2154,15 @@ class OneDriveApi {
 		// To support resumable downloads, configure the 'resumable data' file path
 		string threadResumeDownloadFilePath = appConfig.resumeDownloadFilePath ~ "." ~ generateAlphanumericString();
 
+		// A terminal failure must clean up only transfer-owned artifacts. The final
+		// destination may contain the last successfully applied version and must not
+		// be removed merely because a newer download failed.
+		scope(failure) {
+			curlEngine.resetDownloadResumeOffset();
+			safeRemove(downloadFilename);
+			safeRemove(threadResumeDownloadFilePath);
+		}
+
 		// Create a JSONValue with download state so this can be used when resuming, to evaluate if the online file has changed, and if we are able to resume in a safe manner
 		JSONValue resumeDownloadData = JSONValue([
 			"driveId":          JSONValue(to!string(driveId)),
@@ -2200,6 +2197,11 @@ class OneDriveApi {
 		CurlResponse downloadResponse = null;
 
 		oneDriveErrorHandlerWrapper((CurlResponse response) {
+			// A retry starts a new transfer attempt. Do not allow a CurlResponse from a
+			// previous failed attempt to be mistaken for completion if this attempt is
+			// interrupted before curlEngine.download() returns.
+			downloadResponse = null;
+
 			if (debugLogging) {
 				addLogEntry("downloadFile() wrapper response.hasStreamedQuickXorHash before download = " ~ to!string(response.hasStreamedQuickXorHash), ["debug"]);
 				addLogEntry("downloadFile() wrapper response.streamedQuickXorHash before download = " ~ response.streamedQuickXorHash, ["debug"]);
@@ -2423,12 +2425,36 @@ class OneDriveApi {
 			// CurlResponse, preserving metadata such as streamed hashes.
 			curlEngine.setResponseHolder(response);
 
-			// Capture the result of the download action
-			auto result = curlEngine.download(originalFilename, downloadFilename);
+			// Capture the result of the download action. CurlEngine writes only to the
+			// temporary path; the final path is promoted after the wrapper has validated
+			// the HTTP response. Rejected response bodies are discarded so they cannot
+			// contaminate a resumable partial before a transient retry.
+			auto result = curlEngine.download(
+				downloadFilename,
+				(int httpStatusCode) => isSuccessfulDownloadResponseCode(httpStatusCode)
+			);
 			if (result !is null) {
 				if (debugLogging) {
 					addLogEntry("downloadFile() result.hasStreamedQuickXorHash = " ~ to!string(result.hasStreamedQuickXorHash), ["debug"]);
 					addLogEntry("downloadFile() result.streamedQuickXorHash = " ~ result.streamedQuickXorHash, ["debug"]);
+				}
+
+				// A rejected HTTP response may still report received bytes through the
+				// progress callback even though CurlEngine deliberately discarded its body.
+				// Reconcile resumable state with the actual partial-file size before the
+				// wrapper performs any transient retry/backoff.
+				if (!isSuccessfulDownloadResponseCode(result.statusLine.code)) {
+					long actualPartialSize = 0;
+					if (exists(downloadFilename)) {
+						actualPartialSize = cast(long) getSize(downloadFilename);
+					}
+
+					resumeDownloadData["resumeOffset"] = JSONValue(to!string(actualPartialSize));
+					if ((fileSize >= thresholdFileSize) && (actualPartialSize > 0)) {
+						saveResumeDownloadFile(threadResumeDownloadFilePath, resumeDownloadData);
+					} else {
+						safeRemove(threadResumeDownloadFilePath);
+					}
 				}
 			}
 			if (debugLogging) {
@@ -2437,15 +2463,40 @@ class OneDriveApi {
 			}
 			downloadResponse = result;
 
-			// Safe remove 'threadResumeDownloadFilePath' as if we get to this point, the file has been downloaded successfully
-			safeRemove(threadResumeDownloadFilePath);
-
-			// Reset this curlEngine offset value now that the file has been downloaded successfully
-			curlEngine.resetDownloadResumeOffset();
-
-			// Return the applicable result
+			// Return the applicable result. HTTP status validation and any configured
+			// retry are performed by oneDriveErrorHandlerWrapper().
 			return result;
 		}, validateJSONResponse, callingFunction, lineno);
+
+		// A controlled force_xfer_abort returns without a completed CurlResponse.
+		// Keep the partial only when resumable state was actually persisted.
+		if (downloadResponse is null) {
+			curlEngine.resetDownloadResumeOffset();
+			if (!exists(threadResumeDownloadFilePath)) {
+				safeRemove(downloadFilename);
+			}
+			return null;
+		}
+
+		// Generic API response handling accepts selected redirect responses, but a
+		// file download is complete only when the final response is content-bearing
+		// success (2xx, or the existing HTTP/2 compatibility code 0). A final redirect
+		// must never promote an empty or redirect-response partial into place.
+		if (!isSuccessfulDownloadResponseCode(downloadResponse.statusLine.code)) {
+			if (downloadResponse.statusLine.reason.length == 0) {
+				downloadResponse.statusLine.reason = getMicrosoftGraphStatusMessage(downloadResponse.statusLine.code);
+			}
+			throw new OneDriveException(downloadResponse.statusLine.code, downloadResponse.statusLine.reason, downloadResponse);
+		}
+
+		// The wrapper has now accepted the transport and HTTP response. Promote the
+		// completed temporary file atomically into the requested destination only at
+		// this point, never before HTTP status validation.
+		rename(downloadFilename, originalFilename);
+
+		// Successful promotion completes resumable-download state for this transfer.
+		safeRemove(threadResumeDownloadFilePath);
+		curlEngine.resetDownloadResumeOffset();
 
 		// Return the CurlResponse captured from the successful download attempt.
 		if (downloadResponse !is null) {
@@ -2919,6 +2970,13 @@ class OneDriveApi {
 		return result;
 	}
 	
+	// A download may promote its temporary file only for a response that can
+	// actually carry the requested file content. Redirect responses are handled by
+	// std.net.curl and must not contribute bodies to the local download artifact.
+	private bool isSuccessfulDownloadResponseCode(int httpResponseCode) {
+		return ((httpResponseCode >= 200 && httpResponseCode < 300) || httpResponseCode == 0);
+	}
+
 	// Check the HTTP Response code and determine if a OneDriveException should be thrown
 	private bool checkHttpResponseCode(int httpResponseCode) {
 	

--- a/src/sync.d
+++ b/src/sync.d
@@ -4192,6 +4192,7 @@ class SyncEngine {
 							if (debugLogging) {
 								addLogEntry("downloadResponse is null", ["debug"]);
 							}
+							downloadFailed = true;
 						}
 						
 						// OneDrive API Instance Cleanup - Shutdown API and free curl object.
@@ -4203,6 +4204,11 @@ class SyncEngine {
 					} catch (OneDriveException exception) {
 						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset); generated a OneDriveException", ["debug"]);}
 						
+						// Any propagated API exception means that the requested online version was
+						// not downloaded. A pre-existing final path, if present, is still the last
+						// successfully applied local version and must not be validated as this one.
+						downloadFailed = true;
+
 						// HTTP request returned status code 403
 						if ((exception.httpStatusCode == 403) && (appConfig.getValueBool("sync_business_shared_files"))) {
 							// We attempted to download a file, that was shared with us, but this was shared with us as read-only and no download permission
@@ -4226,9 +4232,9 @@ class SyncEngine {
 						downloadFailed = true;
 					}
 				
-					// If we get to this point, something was downloaded .. does it match what we expected?
-					// Does it still exist?
-					if (exists(newItemPath)) {
+					// Validate only when the requested online version was downloaded. A failed
+					// transfer may deliberately leave an older final file untouched.
+					if (!downloadFailed && exists(newItemPath)) {
 						// When downloading some files from SharePoint, the OneDrive API reports one file size, 
 						// but the SharePoint HTTP Server sends a totally different byte count for the same file
 						// we have implemented --disable-download-validation to disable these checks
@@ -4442,7 +4448,7 @@ class SyncEngine {
 								}
 							}
 						}	// end of (!disableDownloadValidation)
-					} else {
+					} else if (!downloadFailed) {
 					
 						// Was exitHandlerTriggered flagged
 						if (!exitHandlerTriggered) {
@@ -4519,9 +4525,9 @@ class SyncEngine {
 						fileDownloadFailures ~= newItemPath; // Add newItemPath if it's not already present
 					}
 					
-					// Since the file download failed:
-					// - The file should not exist locally
-					// - The download identifiers should not exist in the local database
+					// Since the requested online version was not downloaded, remove the
+					// database identity only when there is no final local file. If an older
+					// successfully applied file remains, preserve both it and its DB baseline.
 					if (!exists(newItemPath)) {
 						// The local path does not exist
 						if (itemDB.idInLocalDatabase(downloadDriveId, downloadItemId)) {


### PR DESCRIPTION
Prevent failed HTTP download responses from being written to disk and subsequently treated as successfully downloaded file content.

Downloads are now written to a temporary `.partial` file and only promoted to the final destination after the HTTP response has been successfully validated. Failed transfers clean up their temporary download artifacts without modifying an existing valid destination file.

Testing confirmed:

* normal OneDrive downloads complete successfully;
* forced HTTP 404 responses are correctly reported as failed downloads;
* failed response bodies are not written to disk;
* no final files or `.partial` files remain after the forced failure.