### PR TITLE
Fix Bug #3814: Fix that WebSocket retry path can crash monitor mode when no message-producing worker is active

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -1625,8 +1625,16 @@ int main(string[] cliArgs) {
 						int res = 0;
 						bool onlineSignal = false;
 						bool shutdownDetectedDuringWait = false;
+						bool monitorMessageProducerActive = filesystemMonitor.initialised || webhookEnabled || oneDriveSocketIo !is null;
 
-						shutdownDetectedDuringWait = waitForMonitorEventsInterruptibly(sleepTime, appConfig.getValueBool("upload_only"), res, onlineSignal);
+						if (monitorMessageProducerActive) {
+							shutdownDetectedDuringWait = waitForMonitorEventsInterruptibly(sleepTime, appConfig.getValueBool("upload_only"), res, onlineSignal);
+						} else {
+							// A WebSocket retry can shorten the monitor sleep even when no message-producing
+							// worker exists. In that state, use a normal interruptible sleep rather than
+							// std.concurrency.receiveTimeout(), which requires an active thread relationship.
+							shutdownDetectedDuringWait = sleepInterruptibly(sleepTime, "monitor WebSocket retry sleep");
+						}
 						if (shutdownDetectedDuringWait) {
 							performFileSystemMonitoring = false;
 							addShutdownTelemetry("monitor wait exited early due to shutdown request");

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -112,7 +112,6 @@ class OneDriveApi {
 	immutable string defaultSiteSearchUrlAPIEndpoint = "/v1.0/sites?search";
 	immutable string defaultSiteDriveUrlAPIEndpoint = "/v1.0/sites/";
 	immutable string defaultSubscriptionUrlAPIEndpoint = "/v1.0/subscriptions";
-	immutable string defaultWebsocketEndpointAPIEndpoint = "/v1.0/me/drive/root/subscriptions/socketIo";
 	immutable string defaultSearchQueryUrlAPIEndpoint = "/v1.0/search/query";
 		
 	// Class variables
@@ -131,8 +130,6 @@ class OneDriveApi {
 	string subscriptionUrl = "";
 	string tenantId = "";
 	string authScope = "";
-	string websocketEndpoint = "";
-	string websocketEndpointAPIEndpoint = defaultWebsocketEndpointAPIEndpoint;
 	string searchQueryUrl = "";
 	const(char)[] refreshToken = "";
 	bool dryRun = false;
@@ -160,9 +157,6 @@ class OneDriveApi {
 
 		// Subscriptions
 		subscriptionUrl = appConfig.globalGraphEndpoint ~ defaultSubscriptionUrlAPIEndpoint;
-		
-		// WebSocket Endpoint - sets the default: /v1.0/me/drive/root/subscriptions/socketIo
-		websocketEndpoint = appConfig.globalGraphEndpoint ~ websocketEndpointAPIEndpoint;
 		
 		// Search Queries
 		searchQueryUrl = appConfig.globalGraphEndpoint ~ defaultSearchQueryUrlAPIEndpoint;
@@ -278,8 +272,6 @@ class OneDriveApi {
 			itemByIdUrl = driveUrl ~ "/items";
 			itemByPathUrl = driveUrl ~ "/root:/";
 			
-			// Need to update 'websocketEndpointAPIEndpoint' to /v1.0/drives/{driveId}/root/subscriptions/socketIo
-			websocketEndpointAPIEndpoint = "/v1.0/drives/" ~ appConfig.getValueString("drive_id") ~ "/root/subscriptions/socketIo";
 		}
 		
 		// Configure the authentication scope
@@ -325,8 +317,6 @@ class OneDriveApi {
 					redirectUrl = appConfig.globalAuthEndpoint ~ "/" ~ tenantId ~ "/oauth2/nativeclient";
 				}
 				
-				// WebSocket Endpoint
-				websocketEndpoint = appConfig.globalGraphEndpoint ~ websocketEndpointAPIEndpoint;
 				break;
 			case "USL4":
 				if (!appConfig.apiWasInitialised) addLogEntry("Configuring Azure AD for US Government Endpoints");
@@ -354,8 +344,6 @@ class OneDriveApi {
 				siteDriveUrl = appConfig.usl4GraphEndpoint ~ defaultSiteDriveUrlAPIEndpoint;
 				// Subscriptions
 				subscriptionUrl = appConfig.usl4GraphEndpoint ~ defaultSubscriptionUrlAPIEndpoint;
-				// WebSocket Endpoint
-				websocketEndpoint = appConfig.usl4GraphEndpoint ~ websocketEndpointAPIEndpoint;
 				// Search Queries
 				searchQueryUrl = appConfig.usl4GraphEndpoint ~ defaultSearchQueryUrlAPIEndpoint;
 				break;
@@ -385,8 +373,6 @@ class OneDriveApi {
 				siteDriveUrl = appConfig.usl5GraphEndpoint ~ defaultSiteDriveUrlAPIEndpoint;
 				// Subscriptions
 				subscriptionUrl = appConfig.usl5GraphEndpoint ~ defaultSubscriptionUrlAPIEndpoint;
-				// WebSocket Endpoint
-				websocketEndpoint = appConfig.usl5GraphEndpoint ~ websocketEndpointAPIEndpoint;
 				// Search Queries
 				searchQueryUrl = appConfig.usl5GraphEndpoint ~ defaultSearchQueryUrlAPIEndpoint;
 				break;
@@ -416,8 +402,6 @@ class OneDriveApi {
 				siteDriveUrl = appConfig.deGraphEndpoint ~ defaultSiteDriveUrlAPIEndpoint;
 				// Subscriptions
 				subscriptionUrl = appConfig.deGraphEndpoint ~ defaultSubscriptionUrlAPIEndpoint;
-				// WebSocket Endpoint
-				websocketEndpoint = appConfig.deGraphEndpoint ~ websocketEndpointAPIEndpoint;
 				// Search Queries
 				searchQueryUrl = appConfig.deGraphEndpoint ~ defaultSearchQueryUrlAPIEndpoint;
 				break;
@@ -447,8 +431,6 @@ class OneDriveApi {
 				siteDriveUrl = appConfig.cnGraphEndpoint ~ defaultSiteDriveUrlAPIEndpoint;
 				// Subscriptions
 				subscriptionUrl = appConfig.cnGraphEndpoint ~ defaultSubscriptionUrlAPIEndpoint;
-				// WebSocket Endpoint
-				websocketEndpoint = appConfig.cnGraphEndpoint ~ websocketEndpointAPIEndpoint;
 				// Search Queries
 				searchQueryUrl = appConfig.cnGraphEndpoint ~ defaultSearchQueryUrlAPIEndpoint;
 				break;
@@ -536,8 +518,6 @@ class OneDriveApi {
 			// SharePoint Queries
 			addLogEntry("Configured siteSearchUrl:     " ~ siteSearchUrl, ["debug"]);
 			addLogEntry("Configured siteDriveUrl:      " ~ siteDriveUrl, ["debug"]);
-			// Websocket 
-			addLogEntry("Configured websocketEndpoint: " ~ websocketEndpoint, ["debug"]);
 			// Search Queries
 			addLogEntry("Configured searchQueryUrl:    " ~ searchQueryUrl, ["debug"]);
 		}
@@ -1812,6 +1792,8 @@ class OneDriveApi {
 
 	// Obtain the Websocket Notification URL
 	JSONValue obtainWebSocketNotificationURL() {
+		// Build the endpoint from the tenant-aware Drive URL and the resolved account Drive ID
+		string websocketEndpoint = driveByIdUrl ~ appConfig.defaultDriveId ~ "/root/subscriptions/socketIo";
 		if (debugLogging) {addLogEntry("Request a Socket.IO Subscription Endpoint: " ~ websocketEndpoint, ["debug"]);}
 		return get(websocketEndpoint);
 	}


### PR DESCRIPTION


This fixes a monitor-mode crash that can occur when initial WebSocket notification URL acquisition fails and no message-producing worker is active.

The issue is most easily exposed with:

```text
--monitor --download-only
```

In this mode, the filesystem monitor worker is not started. If WebSocket URL acquisition also fails, no Socket.IO worker exists either.

Following the WebSocket retry changes, the client remains eligible to retry acquisition. However, that retryable state could also cause the monitor loop to enter `waitForMonitorEventsInterruptibly()`, which uses `std.concurrency.receiveTimeout()`.

When no filesystem, webhook, or Socket.IO worker exists, there is no active concurrency relationship capable of delivering a message, resulting in:

```text
AssertError:
Cannot receive a message until a thread was spawned or thisTid was passed to a running thread.
```

This change separates **WebSocket retry scheduling** from **message-producer availability**.

When an actual message-producing worker exists, the existing message-aware wait path continues to be used.

When no message-producing worker exists but a WebSocket retry is pending, the client instead uses the existing interruptible timed sleep while retaining the calculated WebSocket retry deadline.

This preserves WebSocket retry behaviour without:

* changing the WebSocket retry interval;
* changing WebSocket URL acquisition;
* changing Microsoft Graph requests;
* creating unnecessary worker threads;
* busy-looping; or
* affecting normal filesystem or Socket.IO wakeups.

The Microsoft Graph `400 notSupported` response that exposed this condition is being investigated separately and is intentionally not addressed by this change.