### PR TITLE
Fix Bug #3788: Batch delta JSON processing into database transactions

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -1336,6 +1336,82 @@ final class ItemDatabase {
 		}
 	}
 	
+	// Begin a database transaction, so that a batch of related changes is committed as a single
+	// unit of work rather than each individual change being committed on its own.
+	//
+	// Without an explicit transaction, SQLite operates in autocommit mode, meaning every write
+	// is its own transaction. As 'synchronous' is set to FULL, each of those transactions must
+	// be flushed to physical media before the next can proceed. On storage that honours flush
+	// semantics this is the dominant cost of processing a large /delta response.
+	// https://github.com/abraunegg/onedrive/issues/3788
+	void beginTransaction() {
+		synchronized(databaseLock) {
+			// SQLite does not support nesting transactions, so do not begin another if one is
+			// already in progress
+			if (db.inTransaction()) {
+				if (debugLogging) {addLogEntry("A database transaction is already in progress - not beginning another", ["debug"]);}
+				return;
+			}
+
+			try {
+				if (debugLogging) {addLogEntry("Beginning a database transaction", ["debug"]);}
+				db.exec("BEGIN TRANSACTION;");
+			} catch (SqliteException exception) {
+				// If the transaction cannot be started, the database remains in autocommit mode.
+				// Each change is then still written as it was previously, just less efficiently,
+				// so this is a degradation rather than a failure.
+				addLogEntry();
+				addLogEntry("ERROR: Unable to begin a database transaction: " ~ exception.msg);
+				addLogEntry();
+			}
+		}
+	}
+
+	// Commit the currently open database transaction, writing all of the changes made since the
+	// transaction was begun
+	// https://github.com/abraunegg/onedrive/issues/3788
+	void commitTransaction() {
+		synchronized(databaseLock) {
+			// If no transaction is open there is nothing to commit
+			if (!db.inTransaction()) {
+				if (debugLogging) {addLogEntry("No database transaction is in progress - there is nothing to commit", ["debug"]);}
+				return;
+			}
+
+			try {
+				if (debugLogging) {addLogEntry("Committing the database transaction", ["debug"]);}
+				db.exec("COMMIT;");
+			} catch (SqliteException exception) {
+				addLogEntry();
+				addLogEntry("ERROR: Unable to commit the database transaction: " ~ exception.msg);
+				addLogEntry();
+			}
+		}
+	}
+
+	// Roll back the currently open database transaction, discarding all of the changes made since
+	// the transaction was begun. Any discarded data is re-obtained the next time the relevant
+	// /delta response is requested, as the delta link is not advanced until processing completes.
+	// https://github.com/abraunegg/onedrive/issues/3788
+	void rollbackTransaction() {
+		synchronized(databaseLock) {
+			// If no transaction is open there is nothing to roll back
+			if (!db.inTransaction()) {
+				if (debugLogging) {addLogEntry("No database transaction is in progress - there is nothing to roll back", ["debug"]);}
+				return;
+			}
+
+			try {
+				if (debugLogging) {addLogEntry("Rolling back the database transaction", ["debug"]);}
+				db.exec("ROLLBACK;");
+			} catch (SqliteException exception) {
+				addLogEntry();
+				addLogEntry("ERROR: Unable to roll back the database transaction: " ~ exception.msg);
+				addLogEntry();
+			}
+		}
+	}
+
 	// Select distinct driveId items from database
 	string[] selectDistinctDriveIds() {
 		synchronized(databaseLock) {

--- a/src/sqlite.d
+++ b/src/sqlite.d
@@ -62,6 +62,19 @@ struct Database {
 		return sqlite3_wal_checkpoint(pDb, null);
 	}
 
+	// Is a transaction currently open on this database connection?
+	// SQLite does not support nesting transactions, so this is used to avoid issuing a
+	// BEGIN when one is already in progress, or a COMMIT when there is nothing to commit.
+	// https://www.sqlite.org/c3ref/get_autocommit.html
+	bool inTransaction() {
+		// If there is no database handle, there cannot be a transaction in progress
+		if (pDb is null) {
+			return false;
+		}
+		// sqlite3_get_autocommit() returns zero whilst a transaction is open
+		return (sqlite3_get_autocommit(pDb) == 0);
+	}
+
 	// Dump open statements
 	void dump_open_statements() {
 		if (debugLogging) {addLogEntry("Dumping open SQL statements:", ["debug"]);}

--- a/src/sync.d
+++ b/src/sync.d
@@ -1674,9 +1674,27 @@ class SyncEngine {
 					if (verboseLogging) {addLogEntry("Processing OneDrive JSON item batch [" ~ to!string(batchesProcessed) ~ "/" ~ to!string(batchCount) ~ "] to ensure consistent local state", ["verbose"]);}
 				}	
 					
+				// Process this batch of JSON items within a single database transaction.
+				//
+				// Each item processed here would otherwise be written as its own transaction, and
+				// as 'synchronous' is set to FULL, that requires a flush to physical media per
+				// item. Batching these changes is safe because this phase performs no network
+				// activity, is processed sequentially, and the data written is reconstructible -
+				// the delta link is not advanced until any required transfers have completed, so
+				// an incomplete batch is simply re-obtained on the next run.
+				// https://github.com/abraunegg/onedrive/issues/3788
+				itemDB.beginTransaction();
+
+				// If processing this batch throws, discard the partial batch rather than leaving
+				// the transaction open
+				scope(failure) itemDB.rollbackTransaction();
+
 				// Process the batch
 				processJSONItemsInBatch(batchOfJSONItems, batchesProcessed, batchCount);
-				
+
+				// Commit this batch of changes to the database
+				itemDB.commitTransaction();
+
 				// To finish off the JSON processing items, this is needed to reflect this in the log
 				if (debugLogging) {addLogEntry(debugLogBreakType1, ["debug"]);}
 				
@@ -12004,12 +12022,30 @@ class SyncEngine {
 		
 		Item[] drivePathChildren = getChildren(searchItem.driveId, searchItem.id);
 		if (count(drivePathChildren) > 0) {
-			// Children to process and flag as out-of-sync	
+			// Flag the entire set of children within a single transaction. Each item flagged here
+			// would otherwise be committed individually, and as 'synchronous' is FULL that
+			// requires a flush to physical media per item. For a shared folder containing many
+			// thousands of items this dominates the time taken to generate the /delta response.
+			//
+			// This is safe for the same reasons as the batched processing of received items: no
+			// network activity is performed here, the loop is sequential, and the change is
+			// reconstructible, as this only flags existing records as requiring re-validation.
+			// https://github.com/abraunegg/onedrive/issues/3788
+			itemDB.beginTransaction();
+
+			// If flagging these items throws, discard the partial set rather than leaving the
+			// transaction open
+			scope(failure) itemDB.rollbackTransaction();
+
+			// Children to process and flag as out-of-sync
 			foreach (drivePathChild; drivePathChildren) {
 				// Flag any object in the database as out-of-sync for this driveId & and object id
 				if (debugLogging) {addLogEntry("Downgrading item as out-of-sync: " ~ drivePathChild.id, ["debug"]);}
 				itemDB.downgradeSyncStatusFlag(drivePathChild.driveId, drivePathChild.id);
 			}
+
+			// Commit the flagged items to the database
+			itemDB.commitTransaction();
 		}
 		// Clear DB response array
 		drivePathChildren = [];


### PR DESCRIPTION
### Summary

When processing a `/delta` response, every item is written to the database as an individual autocommitted transaction. As `synchronous` is set to `FULL`, each of those transactions must be flushed to physical media before the next can proceed, resulting in one `fdatasync()` per item.

This adds explicit transaction control and wraps the existing per-batch processing loop in `applyDifferences()` so that a batch of items is committed as a single unit of work:

```d
itemDB.beginTransaction();
scope(failure) itemDB.rollbackTransaction();
processJSONItemsInBatch(batchOfJSONItems, batchesProcessed, batchCount);
itemDB.commitTransaction();
```

`batchSize` is 500, so this reduces the number of flushes during reconciliation by approximately three orders of magnitude.

Note that `synchronous` is deliberately left as `FULL`, and transfer-completion writes are deliberately left committing individually - there the flush is amortised against actual network activity and its cost is negligible.

### Why this is safe

- `processJSONItemsInBatch()` is processed sequentially, as the API returns items in the order in which they must be processed, so there are no concurrent writers within the transaction.
- This phase performs no network activity. Downloads are handled separately in `processDownloadActivities()`, so the database write lock is held only for the duration of local database work.
- The data written is reconstructible. `setDeltaLink()` is not called until any required transfers have completed, so an incomplete batch is simply re-obtained from the API on the next run.

### Implementation

- `sqlite.d`: add `inTransaction()`, using `sqlite3_get_autocommit()`, so that a transaction is never nested and a commit is never attempted when none is open.
- `itemdb.d`: add `beginTransaction()`, `commitTransaction()` and `rollbackTransaction()`, following the existing `performCheckpoint()` pattern. If a transaction cannot be started the database simply remains in autocommit mode, so the behaviour degrades to what it was previously.
- `sync.d`: wrap the existing batch processing loop.

No user visible logging output is changed. The new log entries are debug level only, matching the existing convention used by the surrounding database functions.