### PR TITLE
Fix Bug #3830: Improve long-running memory and resource cleanup

### DIFF
--- a/src/curlEngine.d
+++ b/src/curlEngine.d
@@ -1000,9 +1000,11 @@ void releaseAllCurlInstances() {
 				if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("CurlEngine destroyed", ["debug"]);}
 			}
 		
-			// Clear the array after all instances have been handled
-			curlEnginePool.length = 0; // More explicit than curlEnginePool = [];
 		}
+
+		// Drop the pool backing allocation as well as its logical contents. The
+		// pool is rebuilt on demand during the next monitor loop.
+		curlEnginePool = null;
 	}
 	// Log that all curl engines have been released
 	if ((debugLogging) && (debugHTTPSResponse)) {addLogEntry("CurlEngine releaseAllCurlInstances() completed", ["debug"]);}

--- a/src/log.d
+++ b/src/log.d
@@ -174,8 +174,11 @@ class LogBuffer {
 				return false;
 			}
 
+			// Transfer ownership of this batch to the flush thread and drop the
+			// producer's reference to the old backing allocation. This avoids
+			// retaining a historical high-water logging buffer indefinitely.
 			messages = buffer;
-			buffer.length = 0;
+			buffer = null;
 		} finally {
 			bufferLock.unlock();
 		}

--- a/src/main.d
+++ b/src/main.d
@@ -1477,6 +1477,15 @@ int main(string[] cliArgs) {
 							// Perform GC actions
 							GC.collect();  // Perform Garbage Collection
 							GC.minimize(); // Return free memory to the operating system
+
+							// When memory telemetry is enabled, record the immediate post-cleanup
+							// state so the effect of the scheduled GC/minimize operation can be
+							// distinguished from normal allocator/RSS high-water behaviour.
+							if (displayMemoryUsage) {
+								addLogEntry("Memory usage after scheduled monitor-mode memory cleanup");
+								displayMemoryUsageDetails();
+							}
+
 							// Update time gate
 							lastMonitorGcCleanup = monitorGcCleanupTime;
 						}

--- a/src/socketio.d
+++ b/src/socketio.d
@@ -173,6 +173,19 @@ private:
 		return interruptibleSleep(self, cast(long)seconds * 1000);
 	}
 
+	// Deterministically release the native libcurl handle before a WebSocket
+	// instance is replaced or the worker exits. Do not rely on a later GC cycle
+	// to run CurlWebSocket.~this() for native resource cleanup.
+	static void cleanupCurrentWebSocket(OneDriveSocketIo self, ushort closeCode, string reason) {
+		if (self.ws is null) return;
+
+		collectException(self.ws.close(closeCode, reason));
+		collectException(self.ws.cleanupCurlHandle());
+		logSocketIOOutput("Cleaned up an instance of a CurlWebSocket object via cleanupCurlHandle()");
+		object.destroy(self.ws);
+		self.ws = null;
+	}
+
 	// Main function that listens and sends events
 	static void run(shared OneDriveSocketIo _this) {
 		logSocketIOOutput("run() entered");
@@ -185,6 +198,9 @@ private:
 		bool online;
 		
 		scope(exit) {
+			// Ensure any final WebSocket instance is released by the worker that owns it.
+			cleanupCurrentWebSocket(self, 1000, "worker-exit");
+
 			// Signal that the worker is fully done (visible across threads)
 			atomicStore(self.workerExited, true);
 			
@@ -219,7 +235,9 @@ private:
 					self.currentNotifUrl = notif;
 					string wsUrl = toSocketIoWsUrl(notif);
 
-					// Fresh WS instance per attempt
+					// Fresh WS instance per attempt. Ensure a previous failed/retrying
+					// instance cannot retain its native libcurl handle.
+					cleanupCurrentWebSocket(self, 1001, "replace-stale");
 					self.ws = new CurlWebSocket();
 
 					// Use application configuration values
@@ -232,7 +250,7 @@ private:
 					auto rc = self.ws.connect(wsUrl);
 					if (rc != 0) {
 						logSocketIOOutput("self.ws.connect failed; will retry");
-						collectException(self.ws.close(1002, "connect-failed"));
+						cleanupCurrentWebSocket(self, 1002, "connect-failed");
 						if (!interruptibleBackoffSleep(self, backoffSeconds)) return;
 						if (backoffSeconds < maxBackoffSeconds) backoffSeconds *= 2;
 						continue;
@@ -241,7 +259,7 @@ private:
 					// Socket.IO handshake: wait for '0{json}'
 					if (!awaitEngineOpen(self.ws, self)) {
 						logSocketIOOutput("Socket.IO open handshake failed; will retry");
-						collectException(self.ws.close(1002, "handshake-failed"));
+						cleanupCurrentWebSocket(self, 1002, "handshake-failed");
 						if (!interruptibleBackoffSleep(self, backoffSeconds)) return;
 						if (backoffSeconds < maxBackoffSeconds) backoffSeconds *= 2;
 						continue;
@@ -251,7 +269,7 @@ private:
 					logSocketIOOutput("Sending Socket.IO connect (40) to default namespace");
 					if (self.ws.sendText("40") != 0) {
 						logSocketIOOutput("Failed to send 40 (open namespace); will retry");
-						collectException(self.ws.close(1002, "ns40-failed"));
+						cleanupCurrentWebSocket(self, 1002, "ns40-failed");
 						if (!interruptibleBackoffSleep(self, backoffSeconds)) return;
 						if (backoffSeconds < maxBackoffSeconds) backoffSeconds *= 2;
 						continue;
@@ -263,7 +281,7 @@ private:
 					logSocketIOOutput("Sending Socket.IO connect (40) to '/notifications' namespace");
 					if (self.ws.sendText("40/notifications") != 0) {
 						logSocketIOOutput("Failed to send 40 for '/notifications' namespace; will retry");
-						collectException(self.ws.close(1002, "ns40-failed"));
+						cleanupCurrentWebSocket(self, 1002, "ns40-failed");
 						if (!interruptibleBackoffSleep(self, backoffSeconds)) return;
 						if (backoffSeconds < maxBackoffSeconds) backoffSeconds *= 2;
 						continue;
@@ -285,9 +303,7 @@ private:
 						// Stop request
 						if (stopRequested(self)) {
 							logSocketIOOutput("Stop requested; shutting down run() loop");
-							collectException(self.ws.close(1000, "stop-requested"));
-							collectException(self.ws.cleanupCurlHandle());
-							logSocketIOOutput("Cleaned up an instance of a CurlWebSocket object via cleanupCurlHandle()");
+							cleanupCurrentWebSocket(self, 1000, "stop-requested");
 							return;
 						}
 
@@ -317,9 +333,7 @@ private:
 							self.appConfig.websocketNotificationUrl != self.currentNotifUrl) {
 
 							logSocketIOOutput("Detected new notificationUrl; reconnecting");
-							collectException(self.ws.close(1000, "reconnect"));
-							collectException(self.ws.cleanupCurlHandle());
-							logSocketIOOutput("Cleaned up an instance of a CurlWebSocket object via cleanupCurlHandle()");
+							cleanupCurrentWebSocket(self, 1000, "reconnect");
 
 							// Establish a fresh connection and handshakes
 							self.currentNotifUrl = self.appConfig.websocketNotificationUrl;
@@ -426,7 +440,7 @@ private:
 
 					// Fell out of the inner loop → close and backoff, then retry
 					logSocketIOOutput("Retrying WebSocket Connection");
-					collectException(self.ws.close(1001, "reconnect"));
+					cleanupCurrentWebSocket(self, 1001, "reconnect");
 					logSocketIOOutput("Backoff " ~ to!string(backoffSeconds) ~ "s before retry");
 					if (!interruptibleBackoffSleep(self, backoffSeconds)) return;
 					if (backoffSeconds < maxBackoffSeconds) backoffSeconds *= 2;
@@ -434,14 +448,17 @@ private:
 			} catch (CurlException e) {
 				// Caught a CurlException
 				addLogEntry("Network error during socketio loop: " ~ e.msg ~ " (will retry)");
+				cleanupCurrentWebSocket(self, 1001, "exception");
 				if (!interruptibleSleep(self, 5000)) return;
 			} catch (SocketException e) {
 				// Caught a SocketException
 				addLogEntry("Socket error during socketio loop: " ~ e.msg ~ " (will retry)");
+				cleanupCurrentWebSocket(self, 1001, "exception");
 				if (!interruptibleSleep(self, 5000)) return;
 			} catch (Exception e) {
 				// Caught some other error
 				addLogEntry("Unexpected error during socketio loop: " ~ e.toString());
+				cleanupCurrentWebSocket(self, 1001, "exception");
 				if (!interruptibleSleep(self, 5000)) return;
 			}
 		}

--- a/src/sync.d
+++ b/src/sync.d
@@ -1306,29 +1306,33 @@ class SyncEngine {
 		if (debugLogging) {addLogEntry("Cleaning up all internal arrays used when processing data", ["debug"]);}
 
 		// Multi Dimensional Arrays
-		idsToDelete.length = 0;
-		idsFaked.length = 0;
-		databaseItemsWhereContentHasChanged.length = 0;
+		// Set per-sync arrays to null so their backing allocations are no longer
+		// retained by this long-lived SyncEngine instance between monitor loops.
+		idsToDelete = null;
+		idsFaked = null;
+		databaseItemsWhereContentHasChanged = null;
 
 		// JSON Items Arrays
-		jsonItemsToProcess = [];
-		fileJSONItemsToDownload = [];
-		jsonItemsToResumeUpload = [];
-		jsonItemsToResumeDownload = [];
+		jsonItemsToProcess = null;
+		fileJSONItemsToDownload = null;
+		jsonItemsToResumeUpload = null;
+		jsonItemsToResumeDownload = null;
 
 		// String Arrays
-		fileDownloadFailures = [];
-		pathFakeDeletedArray = [];
-		pathsRenamed = [];
-		newLocalFilesToUploadToOneDrive = [];
-		fileUploadFailures = [];
-		posixViolationPaths = [];
-		businessSharedFoldersOnlineToSkip = [];
-		interruptedUploadsSessionFiles = [];
-		interruptedDownloadFiles = [];
-		pathsToCreateOnline = [];
-		databaseItemsToDeleteOnline = [];
-		pathsRetained = [];
+		fileDownloadFailures = null;
+		pathFakeDeletedArray = null;
+		pathsRenamed = null;
+		newLocalFilesToUploadToOneDrive = null;
+		fileUploadFailures = null;
+		posixViolationPaths = null;
+		businessSharedFoldersOnlineToSkip = null;
+		interruptedUploadsSessionFiles = null;
+		interruptedDownloadFiles = null;
+		pathsToCreateOnline = null;
+		databaseItemsToDeleteOnline = null;
+		pathsRetained = null;
+		syncListSkippedParentIds = null;
+		onenotePackageIdentifiers = null;
 
 		// Log completion of cleanup
 		if (debugLogging) {addLogEntry("Cleaning of internal arrays complete", ["debug"]);}
@@ -4637,12 +4641,6 @@ class SyncEngine {
 							downloadFailed = true;
 						}
 
-						// OneDrive API Instance Cleanup - Shutdown API and free curl object.
-						// Do not force GC collection here: downloadFileItem() runs once per file
-						// inside the parallel download worker pool, and forcing a full GC after
-						// every downloaded file causes repeated stop-the-world mark scans.
-						downloadFileOneDriveApiInstance.releaseCurlEngine();
-						downloadFileOneDriveApiInstance = null;
 					} catch (OneDriveException exception) {
 						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, true); generated a OneDriveException", ["debug"]);}
 						
@@ -4672,6 +4670,15 @@ class SyncEngine {
 						displayFileSystemErrorMessage(e.msg, thisFunctionName, newItemPath, FsErrorSeverity.error);
 						if (verboseLogging) {addLogEntry("Download failed (local file system error): " ~ newItemPath, ["verbose"]);}
 						downloadFailed = true;
+					}
+
+					// OneDrive API Instance Cleanup - shutdown API and return the CurlEngine
+					// to the pool on both successful and handled-failure paths. Do not leave
+					// native HTTP ownership dependent on a later GC/finalizer cycle.
+					// Do not force GC here: this function runs once per downloaded file.
+					if (downloadFileOneDriveApiInstance !is null) {
+						downloadFileOneDriveApiInstance.releaseCurlEngine();
+						downloadFileOneDriveApiInstance = null;
 					}
 				
 					// Validate only when the requested online version was downloaded. A failed
@@ -7436,22 +7443,27 @@ class SyncEngine {
 						// Path is unwanted, flag to exclude
 						clientSideRuleExcludesPath = true;
 
-						// Has this itemId already been flagged as being skipped?
+						// Has this itemId already been flagged as being skipped during this sync?
 						if (!syncListSkippedParentIds.canFind(thisItemId)) {
+							bool skippedParentIdLogged = false;
+
 							if (isItemFolder(onedriveJSONItem)) {
 								// Detail we are skipping this JSON data from online
 								if (verboseLogging) {addLogEntry("Skipping path - excluded by sync_list config: " ~ newItemPath, ["verbose"]);}
-								// Add this folder id to the elements we have already detailed we are skipping, so we do no output this again
+								skippedParentIdLogged = true;
+							}
+
+							// Is this is a 'add shortcut to onedrive' link?
+							if (isItemRemote(onedriveJSONItem)) {
+								// Detail we are skipping this JSON data from online
+								if (verboseLogging) {addLogEntry("Skipping Shared Folder Link - excluded by sync_list config: " ~ newItemPath, ["verbose"]);}
+								skippedParentIdLogged = true;
+							}
+
+							// Track this identifier once so verbose output is not repeated.
+							if (skippedParentIdLogged) {
 								syncListSkippedParentIds ~= thisItemId;
 							}
-						}
-
-						// Is this is a 'add shortcut to onedrive' link?
-						if (isItemRemote(onedriveJSONItem)) {
-							// Detail we are skipping this JSON data from online
-							if (verboseLogging) {addLogEntry("Skipping Shared Folder Link - excluded by sync_list config: " ~ newItemPath, ["verbose"]);}
-							// Add this folder id to the elements we have already detailed we are skipping, so we do no output this again
-							syncListSkippedParentIds ~= thisItemId;
 						}
 					}
 				} else {
@@ -8388,6 +8400,8 @@ class SyncEngine {
 					} else {
 						displayFileSystemErrorMessage(exception.msg, thisFunctionName, localFilePath);
 					}
+					uploadFileOneDriveApiInstance.releaseCurlEngine();
+					uploadFileOneDriveApiInstance = null;
 					return uploadResponse;
 				}
 				SysTime onlineModifiedTime = currentOnlineItemData.mtime;
@@ -8410,6 +8424,8 @@ class SyncEngine {
 					// snapshot while keeping the canonical filename present, then upload it.
 					string backupPath;
 					if (!safeBackupPreserveForReplacement(localFilePath, false, backupPath, true)) {
+						uploadFileOneDriveApiInstance.releaseCurlEngine();
+						uploadFileOneDriveApiInstance = null;
 						return uploadResponse;
 					}
 					uploadNewFile(backupPath);
@@ -8426,6 +8442,8 @@ class SyncEngine {
 
 					// The original modified-file upload was intentionally not performed. Return
 					// its response after handling the newer-online conflict safely.
+					uploadFileOneDriveApiInstance.releaseCurlEngine();
+					uploadFileOneDriveApiInstance = null;
 					return uploadResponse;
 				}
 			}
@@ -8483,6 +8501,8 @@ class SyncEngine {
 					if ((exception.httpStatusCode == 403) && (appConfig.getValueBool("sync_business_shared_files"))) {
 						// We attempted to upload a file, that was shared with us, but this was shared with us as read-only
 						addLogEntry("Unable to upload this modified file as this was shared as read-only: " ~ localFilePath);
+						uploadFileOneDriveApiInstance.releaseCurlEngine();
+						uploadFileOneDriveApiInstance = null;
 						return uploadResponse;
 					}
 
@@ -8492,6 +8512,8 @@ class SyncEngine {
 						// The file is currently checked out or locked for editing by another user
 						// We cant upload this file at this time
 						addLogEntry("Unable to upload this modified file as this is currently checked out or locked for editing by another user: " ~ localFilePath);
+						uploadFileOneDriveApiInstance.releaseCurlEngine();
+						uploadFileOneDriveApiInstance = null;
 						return uploadResponse;
 					} else {
 						// Handle all other HTTP status codes


### PR DESCRIPTION
This PR addresses several long-running memory and resource-retention findings identified while investigating #3830.

The changes are deliberately targeted and avoid altering sync behaviour.

Key improvements include:

* deterministically clean up WebSocket `CurlWebSocket` / libcurl handles during reconnect and failure paths rather than relying on GC finalisation
* ensure locally-created `OneDriveApi` instances are released on handled failure and early-return paths in long-running download and upload operations
* clear per-sync tracking arrays that do not need to persist between monitor cycles
* prevent duplicate accumulation of `syncListSkippedParentIds`
* release backing allocations for transient `SyncEngine`, CurlEngine pool, and logging buffers after use
* retain the existing 24-hour `GC.collect()` / `GC.minimize()` behaviour rather than adding more aggressive GC calls
* add post-cleanup memory telemetry so RSS and GC statistics can be compared immediately before and after the scheduled 24-hour cleanup

These changes focus on correcting identifiable object/resource lifetime issues first, before considering any broader allocator or GC tuning.