### PR TITLE
Fix Bug #3834: Remove fabricated timestamp generation

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -65,63 +65,21 @@ Item makeDatabaseItem(JSONValue driveItem) {
 		// Set mtime to SysTime(0)
 		item.mtime = SysTime(0);
 	} else {
-		// Item is not in a deleted state
+		// Item is not in a deleted state. A live database item must only ever use a
+		// timestamp supplied by Microsoft Graph fileSystemInfo. Do not manufacture a
+		// replacement timestamp when the API omits or returns an invalid value.
 		string lastModifiedTimestamp;
-		// Resolve 'Key not found: fileSystemInfo' when then item is a remote item
-		// https://github.com/abraunegg/onedrive/issues/11
-		if (isItemRemote(driveItem)) {
-			// remoteItem is a OneDrive object that exists on a 'different' OneDrive drive id, when compared to account default
-			// Normally, the 'remoteItem' field will contain 'fileSystemInfo' however, if the user uses the 'Add Shortcut ..' option in OneDrive WebUI
-			// to create a 'link', this object, whilst remote, does not have 'fileSystemInfo' in the expected place, thus leading to a application crash
-			// See: https://github.com/abraunegg/onedrive/issues/1533
-			if ("fileSystemInfo" in driveItem["remoteItem"]) {
-				// 'fileSystemInfo' is in 'remoteItem' which will be the majority of cases
-				lastModifiedTimestamp = strip(driveItem["remoteItem"]["fileSystemInfo"]["lastModifiedDateTime"].str);
-				// is lastModifiedTimestamp valid?
-				if (isValidUTCDateTime(lastModifiedTimestamp)) {
-					// string is a valid timestamp
-					item.mtime = SysTime.fromISOExtString(lastModifiedTimestamp);
-				} else {
-					// invalid timestamp from JSON file
-					addLogEntry("WARNING: Invalid timestamp provided by the Microsoft OneDrive API: " ~ lastModifiedTimestamp);
-					// Set mtime to Clock.currTime(UTC()) to ensure we have a valid UTC value
-					item.mtime = Clock.currTime(UTC());
-				}
+		if (!getFileSystemInfoLastModifiedDateTime(driveItem, item.mtime, lastModifiedTimestamp)) {
+			string itemId = ("id" in driveItem) && (driveItem["id"].type == JSONType.string) ? driveItem["id"].str : "<unknown>";
+			string itemName = ("name" in driveItem) && (driveItem["name"].type == JSONType.string) ? driveItem["name"].str : "<unknown>";
+
+			if (lastModifiedTimestamp.empty) {
+				addLogEntry("ERROR: Microsoft OneDrive API did not provide fileSystemInfo.lastModifiedDateTime for live item: " ~ itemName ~ " (" ~ itemId ~ ")");
 			} else {
-				// is a remote item, but 'fileSystemInfo' is missing from 'remoteItem'
-				lastModifiedTimestamp = strip(driveItem["fileSystemInfo"]["lastModifiedDateTime"].str);
-				// is lastModifiedTimestamp valid?
-				if (isValidUTCDateTime(lastModifiedTimestamp)) {
-					// string is a valid timestamp
-					item.mtime = SysTime.fromISOExtString(lastModifiedTimestamp);
-				} else {
-					// invalid timestamp from JSON file
-					addLogEntry("WARNING: Invalid timestamp provided by the Microsoft OneDrive API: " ~ lastModifiedTimestamp);
-					// Set mtime to Clock.currTime(UTC()) to ensure we have a valid UTC value
-					item.mtime = Clock.currTime(UTC());
-				}
+				addLogEntry("ERROR: Microsoft OneDrive API provided an invalid fileSystemInfo.lastModifiedDateTime for live item: " ~ itemName ~ " (" ~ itemId ~ "): " ~ lastModifiedTimestamp);
 			}
-		} else {
-			// Does fileSystemInfo exist at all ?
-			if ("fileSystemInfo" in driveItem) {
-				// fileSystemInfo exists
-				lastModifiedTimestamp = strip(driveItem["fileSystemInfo"]["lastModifiedDateTime"].str);
-				// is lastModifiedTimestamp valid?
-				if (isValidUTCDateTime(lastModifiedTimestamp)) {
-					// string is a valid timestamp
-					item.mtime = SysTime.fromISOExtString(lastModifiedTimestamp);
-				} else {
-					// invalid timestamp from JSON file
-					addLogEntry("WARNING: Invalid timestamp provided by the Microsoft OneDrive API: " ~ lastModifiedTimestamp);
-					// Set mtime to Clock.currTime(UTC()) to ensure we have a valid UTC value
-					item.mtime = Clock.currTime(UTC());
-				}
-			} else {
-				// no timestamp from JSON file
-				addLogEntry("WARNING: No timestamp provided by the Microsoft OneDrive API - using current system time for item!");
-				// Set mtime to Clock.currTime(UTC()) to ensure we have a valid UTC value
-				item.mtime = Clock.currTime(UTC());
-			}
+
+			throw new Exception("Unable to construct database item without a valid Microsoft OneDrive fileSystemInfo.lastModifiedDateTime");
 		}
 	}
 	

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -1468,17 +1468,6 @@ class OneDriveApi {
 		if ("fileSystemInfo" in resource) {
 			sharedItem["fileSystemInfo"] = parseJSON(resource["fileSystemInfo"].toString());
 			remoteItem["fileSystemInfo"] = parseJSON(resource["fileSystemInfo"].toString());
-		} else {
-			JSONValue fallbackFSI = JSONValue([
-				"lastModifiedDateTime": JSONValue(
-					("lastModifiedDateTime" in resource)
-						? resource["lastModifiedDateTime"].str
-						: Clock.currTime(UTC()).toISOExtString()
-				)
-			]);
-
-			sharedItem["fileSystemInfo"] = parseJSON(fallbackFSI.toString());
-			remoteItem["fileSystemInfo"] = parseJSON(fallbackFSI.toString());
 		}
 
 		JSONValue sharedFacet = buildSearchSharedFacet(resource);

--- a/src/sync.d
+++ b/src/sync.d
@@ -4500,6 +4500,8 @@ class SyncEngine {
 		bool preserveCanonicalAsSafeBackup = false;
 		string canonicalHashBeforeDownload;
 		string completedDownloadPath;
+		SysTime itemModifiedTime;
+		string itemModifiedTimestamp;
 
 		// Create a JSONValue to store the online hash for resumable file checking
 		JSONValue onlineHash;
@@ -4526,6 +4528,22 @@ class SyncEngine {
 		// Calculate this items path
 		string newItemPath = computeItemPath(downloadDriveId, downloadParentId) ~ "/" ~ downloadItemName;
 		if (debugLogging) {addLogEntry("JSON Item calculated full path for download is: " ~ newItemPath, ["debug"]);}
+
+		// A downloaded live item must have a real Microsoft Graph filesystem timestamp.
+		// Do not download an item when its authoritative timestamp is unavailable because
+		// doing so would require manufacturing a local mtime and database baseline. Track
+		// this as a download failure so the sync result cannot silently report success.
+		if (!getFileSystemInfoLastModifiedDateTime(onedriveJSONItem, itemModifiedTime, itemModifiedTimestamp)) {
+			if (itemModifiedTimestamp.empty) {
+				addLogEntry("WARNING: Skipping download because Microsoft OneDrive did not provide fileSystemInfo.lastModifiedDateTime: " ~ downloadItemName ~ " (" ~ downloadItemId ~ ")");
+			} else {
+				addLogEntry("WARNING: Skipping download because Microsoft OneDrive provided an invalid fileSystemInfo.lastModifiedDateTime: " ~ downloadItemName ~ " (" ~ downloadItemId ~ "): " ~ itemModifiedTimestamp);
+			}
+			if (!canFind(fileDownloadFailures, newItemPath)) {
+				fileDownloadFailures ~= newItemPath;
+			}
+			return;
+		}
 		canonicalFileExistedBeforeDownload = exists(newItemPath);
 		if (canonicalFileExistedBeforeDownload && ignoreDataPreservationCheck) {
 			// SharePoint enrichment downloads intentionally replace the file just uploaded.
@@ -4706,53 +4724,9 @@ class SyncEngine {
 						// but the SharePoint HTTP Server sends a totally different byte count for the same file
 						// we have implemented --disable-download-validation to disable these checks
 
-						// Regardless of --disable-download-validation we still need to set the file timestamp correctly
-						// Get the mtime from the JSON data
-						SysTime itemModifiedTime;
-						string lastModifiedTimestamp;
-						if (isItemRemote(onedriveJSONItem)) {
-							// remote file item
-							if (hasRemoteFileSystemInfoLastModifiedDateTime(onedriveJSONItem)) {
-								// JSON has correct timestamp data
-								lastModifiedTimestamp = strip(onedriveJSONItem["remoteItem"]["fileSystemInfo"]["lastModifiedDateTime"].str);
-								// is lastModifiedTimestamp valid?
-								if (isValidUTCDateTime(lastModifiedTimestamp)) {
-									// string is a valid timestamp
-									itemModifiedTime = SysTime.fromISOExtString(lastModifiedTimestamp);
-								} else {
-									// invalid timestamp from JSON file
-									addLogEntry("WARNING: Invalid timestamp provided by the Microsoft OneDrive API: " ~ lastModifiedTimestamp);
-									// Set mtime to Clock.currTime(UTC()) given that the time in the JSON should be a UTC timestamp
-									itemModifiedTime = Clock.currTime(UTC());
-								}
-							} else {
-								// Set mtime to Clock.currTime(UTC()) given that the time in the JSON should be a UTC timestamp
-								itemModifiedTime = Clock.currTime(UTC());
-								// JSON data missing, missing timestamp from JSON file
-								addLogEntry("WARNING: Missing timestamp provided by the Microsoft OneDrive API, using current UTC time: " ~ to!string(itemModifiedTime));
-							}
-						} else {
-							// not a remote file item
-							if (hasFileSystemInfoLastModifiedDateTime(onedriveJSONItem)) {
-								// JSON has correct timestamp data
-								lastModifiedTimestamp = strip(onedriveJSONItem["fileSystemInfo"]["lastModifiedDateTime"].str);
-								// is lastModifiedTimestamp valid?
-								if (isValidUTCDateTime(lastModifiedTimestamp)) {
-									// string is a valid timestamp
-									itemModifiedTime = SysTime.fromISOExtString(lastModifiedTimestamp);
-								} else {
-									// invalid timestamp from JSON file
-									addLogEntry("WARNING: Invalid timestamp provided by the Microsoft OneDrive API: " ~ lastModifiedTimestamp);
-									// Set mtime to Clock.currTime(UTC()) given that the time in the JSON should be a UTC timestamp
-									itemModifiedTime = Clock.currTime(UTC());
-								}
-							} else {
-								// Set mtime to Clock.currTime(UTC()) given that the time in the JSON should be a UTC timestamp
-								itemModifiedTime = Clock.currTime(UTC());
-								// JSON data missing, missing timestamp from JSON file
-								addLogEntry("WARNING: Missing timestamp provided by the Microsoft OneDrive API, using current UTC time: " ~ to!string(itemModifiedTime));
-							}
-						}
+						// Regardless of --disable-download-validation we still need to set the file timestamp correctly.
+						// itemModifiedTime was validated before the transfer began so this operation never
+						// needs to manufacture a replacement timestamp.
 
 						// Did the user configure --disable-download-validation ?
 						if (!disableDownloadValidation) {
@@ -13785,23 +13759,18 @@ class SyncEngine {
 					}
 				}
 
-				// Configure the modification JSON item
+				// Configure the modification JSON item. A local move must use the actual
+				// filesystem timestamp of the moved item; never manufacture a new mtime.
 				SysTime mtime;
-				if (appConfig.getValueBool("monitor")) {
-					// Use the newPath modified timestamp
-					try {
-						mtime = timeLastModified(newPath).toUTC();
-					} catch (FileException exception) {
-						if ((exception.errno == ENOENT) || (exception.errno == ENOTDIR)) {
-							addLogEntry("Moved local item disappeared before timestamp update: " ~ newPath);
-						} else {
-							displayFileSystemErrorMessage(exception.msg, thisFunctionName, newPath);
-						}
-						return;
+				try {
+					mtime = timeLastModified(newPath).toUTC();
+				} catch (FileException exception) {
+					if ((exception.errno == ENOENT) || (exception.errno == ENOTDIR)) {
+						addLogEntry("Moved local item disappeared before timestamp update: " ~ newPath);
+					} else {
+						displayFileSystemErrorMessage(exception.msg, thisFunctionName, newPath);
 					}
-				} else {
-					// Use the current system time
-					mtime = Clock.currTime().toUTC();
+					return;
 				}
 
 				JSONValue data = [
@@ -16468,9 +16437,6 @@ class SyncEngine {
 					// Debug response output
 					if (debugLogging) {addLogEntry("getSharedWithMe Response Shared File JSON: " ~ sanitiseJSONItem(searchResult), ["debug"]);}
 
-					// Make a DB item from this JSON
-					Item sharedFileOriginalData = makeItem(searchResult);
-
 					// Variables for each item
 					string sharedByName;
 					string sharedByEmail;
@@ -16560,8 +16526,22 @@ class SyncEngine {
 					// The file to download JSON details
 					fileToDownload = searchResult;
 
-					// Get the latest online details
-					latestOnlineDetails = sharedWithMeOneDriveApiInstance.getPathDetailsById(sharedFileOriginalData.remoteDriveId, sharedFileOriginalData.remoteId);
+					// Get the latest online details using the identifiers already present in the
+					// Search response. Do not construct an Item from the Search result first because
+					// Search may legitimately omit fileSystemInfo; the full DriveItem query below is
+					// the authoritative source for the filesystem timestamp used by the sync engine.
+					latestOnlineDetails = sharedWithMeOneDriveApiInstance.getPathDetailsById(
+						searchResult["remoteItem"]["parentReference"]["driveId"].str,
+						searchResult["remoteItem"]["id"].str
+					);
+
+					SysTime authoritativeModifiedTime;
+					string authoritativeLastModifiedDateTime;
+					if (!getFileSystemInfoLastModifiedDateTime(latestOnlineDetails, authoritativeModifiedTime, authoritativeLastModifiedDateTime)) {
+						addLogEntry("WARNING: Skipping OneDrive Business shared file because its full DriveItem response does not contain a valid fileSystemInfo.lastModifiedDateTime: " ~ searchResult["name"].str);
+						continue;
+					}
+
 					Item tempOnlineRecord = makeItem(latestOnlineDetails);
 
 					// With the local folders created, now update 'fileToDownload' to download the file to our location:
@@ -16606,11 +16586,17 @@ class SyncEngine {
 					// Update 'size'
 					fileToDownload["size"] = to!int(tempOnlineRecord.size);
 					fileToDownload["remoteItem"]["size"] = to!int(tempOnlineRecord.size);
-					// Update 'lastModifiedDateTime'
-					fileToDownload["lastModifiedDateTime"] = latestOnlineDetails["fileSystemInfo"]["lastModifiedDateTime"].str;
-					fileToDownload["fileSystemInfo"]["lastModifiedDateTime"] = latestOnlineDetails["fileSystemInfo"]["lastModifiedDateTime"].str;
-					fileToDownload["remoteItem"]["lastModifiedDateTime"] = latestOnlineDetails["fileSystemInfo"]["lastModifiedDateTime"].str;
-					fileToDownload["remoteItem"]["fileSystemInfo"]["lastModifiedDateTime"] = latestOnlineDetails["fileSystemInfo"]["lastModifiedDateTime"].str;
+					// Update 'lastModifiedDateTime' using the authoritative fileSystemInfo value
+					// returned by the full DriveItem query. Search responses may not contain a
+					// fileSystemInfo object at all, so create it here rather than fabricating one.
+					fileToDownload["lastModifiedDateTime"] = authoritativeLastModifiedDateTime;
+					fileToDownload["fileSystemInfo"] = JSONValue([
+						"lastModifiedDateTime": JSONValue(authoritativeLastModifiedDateTime)
+					]);
+					fileToDownload["remoteItem"]["lastModifiedDateTime"] = authoritativeLastModifiedDateTime;
+					fileToDownload["remoteItem"]["fileSystemInfo"] = JSONValue([
+						"lastModifiedDateTime": JSONValue(authoritativeLastModifiedDateTime)
+					]);
 
 					// Final JSON that will be used to download the file
 					if (debugLogging) {addLogEntry("Final fileToDownload: " ~ to!string(fileToDownload), ["debug"]);}
@@ -16807,10 +16793,10 @@ class SyncEngine {
 						}
 					}
 
-					// Configure the modification JSON item
-					SysTime mtime;
-					// Use the current system time
-					mtime = Clock.currTime().toUTC();
+					// Configure the modification JSON item using the existing online filesystem
+					// timestamp. This operation is an online move/rename and must not manufacture
+					// a new lastModifiedDateTime value from the local wall clock.
+					SysTime mtime = sourceItem.mtime;
 
 					JSONValue data = [
 						"name": JSONValue(baseName(destinationPath)),

--- a/src/util.d
+++ b/src/util.d
@@ -2002,6 +2002,28 @@ bool hasRemoteFileSystemInfoLastModifiedDateTime(const ref JSONValue item) {
 		   (item["remoteItem"]["fileSystemInfo"]["lastModifiedDateTime"].type == JSONType.string);
 }
 
+// Extract and validate the authoritative filesystem last-modified timestamp from a live
+// Microsoft Graph DriveItem. Remote items normally carry this value under remoteItem,
+// but Add Shortcut to My Files objects may only expose it on the outer DriveItem (#1533).
+//
+// IMPORTANT: this function never fabricates a timestamp. A missing or invalid timestamp
+// is reported to the caller so that the item can be rejected or deferred safely.
+bool getFileSystemInfoLastModifiedDateTime(const ref JSONValue item, out SysTime parsedTime, out string timestamp) {
+	timestamp = "";
+
+	if (isItemRemote(item) && hasRemoteFileSystemInfoLastModifiedDateTime(item)) {
+		timestamp = strip(item["remoteItem"]["fileSystemInfo"]["lastModifiedDateTime"].str);
+	} else if (hasFileSystemInfoLastModifiedDateTime(item)) {
+		// Normal non-remote item, or #1533 fallback for a remote shortcut whose
+		// remoteItem does not contain fileSystemInfo.
+		timestamp = strip(item["fileSystemInfo"]["lastModifiedDateTime"].str);
+	} else {
+		return false;
+	}
+
+	return parseUTCDateTime(timestamp, parsedTime);
+}
+
 bool isItemFile(const ref JSONValue item) {
 	return (item.type == JSONType.object) &&
 		   (("file" in item) != null) &&


### PR DESCRIPTION
## Summary

This PR removes the use of fabricated timestamps for real OneDrive objects.

Previously, in several code paths, if a valid `fileSystemInfo.lastModifiedDateTime` value was unavailable, the client could substitute the current local system time via `Clock.currTime()`. This ensured that timestamp-dependent code always had a value to work with, but it also meant that an unknown or invalid remote timestamp could be converted into a value that appeared authoritative.

With timestamp authority now available within the application, this behaviour is no longer appropriate.

This PR changes the affected code paths so that:

* real OneDrive objects no longer receive a fabricated `Clock.currTime()` timestamp;
* missing or invalid `fileSystemInfo.lastModifiedDateTime` values are treated as unavailable rather than replaced with the current time;
* affected operations are deferred or failed through existing error-handling paths rather than allowing fabricated timestamp data to propagate into the local filesystem or database;
* the existing `remoteItem.fileSystemInfo` / top-level `fileSystemInfo` fallback behaviour used for shared items and shortcuts is preserved;
* Business Shared Folder search handling now retrieves the authoritative DriveItem metadata before constructing the internal item representation;
* local move/rename operations use the actual local filesystem modification time rather than `Clock.currTime()`;
* online move/rename operations use the existing known item timestamp rather than generating a new current-time value.

## `createFakeResponse()`

`createFakeResponse()` is intentionally unchanged.

This function is used for synthetic responses where no real Microsoft Graph transaction exists, including:

* `--dry-run` operation simulation;
* locally generated synthetic objects such as the Business "Files Shared With Me" hierarchy.

In these cases the response itself is intentionally synthetic, so this behaviour is separate from the problem addressed by this PR.

## Scope

This PR is deliberately limited to **fabricated timestamp removal**.

It does **not** change:

* timestamp authority or source-of-truth policy;
* timestamp comparison logic;
* local-vs-remote conflict resolution;
* `--local-first` behaviour;
* timestamp application direction;
* whether timestamps should be updated during move/rename operations;
* existing "newer timestamp" reconciliation decisions.

Those areas will be audited separately once all timestamps entering normal reconciliation are either:

1. sourced from a legitimate timestamp authority; or
2. explicitly unavailable.

## Expected Outcome

After this change, the client should no longer convert:

```text
timestamp unknown
```

into:

```text
timestamp = current local system time
```

for real OneDrive objects.

This prevents fabricated timestamp values from being written to the local filesystem, stored in the sync database, or subsequently used as if they originated from Microsoft Graph or the local filesystem.

## Validation

Current validation includes:

* successful compilation;
* four-way multi-client soak testing;
* full E2E test execution;


