### PR TITLE
Implement FR #3787: Use different browser with --reauth and friends

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -46,18 +46,16 @@ Authenticate the client using the specific configuration file:
 ```text
 onedrive --confdir="~/.config/my-new-config"
 ```
-You will be asked to open a specific URL by using your web browser where you will have to login into your Microsoft Account and give the application the permission to access your files. After giving permission to the application, you will be redirected to a blank page. Copy the URI of the blank page into the application.
-```text
-[user@hostname ~]$ onedrive --confdir="~/.config/my-new-config"
-Configuration file successfully loaded
-Configuring Global Azure AD Endpoints
-Authorize this app visiting:
 
-https://.....
+Authentication follows the standard client authentication process documented in [Authorise the Application with Your Microsoft OneDrive Account](usage.md#authorise-the-application-with-your-microsoft-onedrive-account). When running inside a supported graphical desktop environment, the application will automatically open the Microsoft authorisation URL and receive the authorisation response using the local browser redirect. When graphical browser authentication cannot be used, the application falls back to the documented manual browser authentication process.
 
-Enter the response uri: 
+If a specific browser is required for this configuration, set the `BROWSER` environment variable when starting the client. For example:
 
+```bash
+BROWSER=microsoft-edge-stable onedrive --confdir="~/.config/my-new-config"
 ```
+
+If `BROWSER` is not set, the normal desktop browser launch mechanism is used.
 
 ### 5. Display and Test the configuration
 Test the configuration using '--display-config' and '--dry-run'. By doing so, this allows you to test any configuration that you have currently made, enabling you to fix this configuration before using the configuration.

--- a/docs/application-config-options.md
+++ b/docs/application-config-options.md
@@ -1696,6 +1696,21 @@ _**Description:**_ This CLI option controls the ability to re-authenticate your 
 
 _**Usage Example:**_ `onedrive --reauth`
 
+When using interactive authentication from a graphical desktop session, a specific browser can be selected by setting the `BROWSER` environment variable to the required browser executable. For example:
+
+```bash
+BROWSER=/usr/bin/microsoft-edge-stable onedrive --reauth
+```
+
+If the browser executable is available through your `PATH`, the executable name can also be used:
+
+```bash
+BROWSER=microsoft-edge-stable onedrive --reauth
+```
+
+> [!NOTE]
+> `BROWSER` is an environment variable, not an application configuration option. If the configured browser cannot be launched, the application falls back to the normal desktop browser launch mechanism. The value is treated as a browser executable name or path and is not interpreted as a shell command.
+
 ### CLI Option: --remove-directory
 _**Description:**_ This CLI option allows the user to remove the specified directory path on Microsoft OneDrive without performing a sync.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -366,16 +366,36 @@ This client supports the following methods to authenticate the application with 
 #### Interactive Authentication using OAuth2 and a redirect URI
 When you run the application for the first time, the recommended authentication method is interactive browser-based OAuth2 authentication. The application will direct you to the Microsoft login page, where you sign in with your Microsoft Account and grant the application permission to access your files.
 
-When the application detects that it is running inside a graphical desktop session, it will automatically open the Microsoft authorisation URL in your default browser and listen locally for the Microsoft authorisation response. In this mode, you do **not** need to manually copy and paste the redirect URI from your browser back into the terminal.
+When the application detects that it is running inside a graphical desktop session, it will automatically open the Microsoft authorisation URL and listen locally for the Microsoft authorisation response. By default, the application uses the browser configured by your desktop environment. If the `BROWSER` environment variable is set, the application will first attempt to use the browser executable specified by that variable. In this mode, you do **not** need to manually copy and paste the redirect URI from your browser back into the terminal.
 
 When no graphical desktop session is detected, or when the local browser-based authentication flow cannot be used, the application will fall back to the existing manual copy-and-paste authentication method. This fallback behaviour may also occur when running remotely via SSH, inside containers, under WSL, or when no supported browser launch mechanism is available.
 
 ##### Graphical Desktop Authentication using the Local Browser Redirect
-When running inside a supported graphical desktop environment, the application will open your default browser and wait for the Microsoft authorisation response on:
+When running inside a supported graphical desktop environment, the application will open the Microsoft authorisation URL and wait for the Microsoft authorisation response on:
 
 ```text
 http://127.0.0.1:53100/
 ```
+
+By default, the application uses the browser configured by your desktop environment. To use a specific browser for interactive authentication, set the `BROWSER` environment variable to the browser executable when starting the client. For example, to use Microsoft Edge:
+
+```bash
+BROWSER=/usr/bin/microsoft-edge-stable onedrive --reauth
+```
+
+If the browser executable is available through your `PATH`, the executable name can be used instead:
+
+```bash
+BROWSER=microsoft-edge-stable onedrive --reauth
+```
+
+The same override can be used during initial authentication by running the client without `--reauth`:
+
+```bash
+BROWSER=microsoft-edge-stable onedrive
+```
+
+If the browser configured by `BROWSER` cannot be launched, the application falls back to the normal desktop browser launch mechanism. The `BROWSER` value is treated as a browser executable name or path; it is not interpreted as a shell command.
 
 This local listener is only used during the authentication process. It binds only to the loopback interface, does not require any inbound firewall changes, and is closed once authentication has completed or failed.
 

--- a/src/localAuth.d
+++ b/src/localAuth.d
@@ -9,7 +9,7 @@ import std.concurrency;
 import std.conv;
 import std.datetime;
 import std.exception;
-import std.process : spawnProcess, Config;
+import std.process : environment, spawnProcess, Config;
 import std.stdio : File;
 import std.socket;
 import std.string;
@@ -71,6 +71,28 @@ ushort findAvailableLocalAuthPort() {
 }
 
 bool openUrlInDefaultBrowser(string url) {
+	string browser = environment.get("BROWSER", "").strip;
+	if (!browser.empty) {
+		try {
+			auto devNullIn = File("/dev/null", "r");
+			auto devNullOut = File("/dev/null", "w");
+			auto devNullErr = File("/dev/null", "w");
+
+			spawnProcess(
+				[browser, url],
+				devNullIn,
+				devNullOut,
+				devNullErr,
+				null,
+				Config.detached
+			);
+
+			return true;
+		} catch (Exception e) {
+			addLogEntry("Unable to open the authorisation URL with the browser configured by BROWSER ('" ~ browser ~ "'): " ~ e.msg ~ ". Falling back to xdg-open.", ["debug"]);
+		}
+	}
+
 	try {
 		auto devNullIn = File("/dev/null", "r");
 		auto devNullOut = File("/dev/null", "w");


### PR DESCRIPTION
## Overview

This pull request implements the feature request raised in #3787 to allow a user to explicitly select which browser is used for interactive Microsoft authentication.

The current GUI authentication path launches the Microsoft authorisation URL using `xdg-open`. This means the desktop environment's configured default browser is normally selected. In environments where a user intentionally uses a different browser for Microsoft 365 authentication, setting the standard `BROWSER` environment variable does not reliably override that desktop preference because `xdg-open` may successfully select the desktop-configured browser before consulting `BROWSER`.

For example, a user may use Firefox as their normal desktop browser while using Microsoft Edge exclusively for Microsoft 365 authentication and SSO.

This change allows that user to run:

```bash
BROWSER=/usr/bin/microsoft-edge-stable onedrive --reauth
```

and have the Microsoft authentication URL opened directly using Microsoft Edge.

## Changes

The browser launch logic in `src/localAuth.d` has been updated so that:

1. If the `BROWSER` environment variable is set, the client first attempts to launch the configured executable directly with the Microsoft authorisation URL.
2. If the configured browser cannot be launched, the failure is written to the debug log and the client falls back to the existing `xdg-open` behaviour.
3. If `BROWSER` is not set, behaviour remains unchanged and `xdg-open` is used as before.
4. If browser launch ultimately fails, the existing authentication fallback behaviour remains unchanged.

Both an explicit executable path:

```bash
BROWSER=/usr/bin/microsoft-edge-stable onedrive --reauth
```

and an executable available through `PATH`:

```bash
BROWSER=microsoft-edge-stable onedrive --reauth
```

are supported.

## Design Considerations

This change deliberately does not attempt to automatically detect Microsoft Edge or introduce a Microsoft Edge-specific configuration option.

`BROWSER` is treated as a user-selected browser executable, making the implementation browser-neutral and allowing the same mechanism to be used with Firefox, Chromium, Chrome, Edge or another browser.

The value is passed directly to `spawnProcess()` as an executable rather than being executed through a shell. This keeps the authentication path deterministic and avoids introducing shell command parsing into OAuth browser launching.

The existing behaviour remains the fallback path, so an invalid or stale `BROWSER` value does not prevent authentication from proceeding through the normal desktop browser.

## Behaviour

With no override configured:

```bash
unset BROWSER
onedrive --reauth
```

the existing desktop/default-browser behaviour is retained.

With an explicit browser configured:

```bash
BROWSER=/usr/bin/microsoft-edge-stable onedrive --reauth
```

the selected browser is used for Microsoft authentication.

If the configured browser does not exist or cannot be started:

```bash
BROWSER=/does/not/exist onedrive --reauth
```

the client falls back to `xdg-open`.

## Scope

This is intentionally a laser-focused change.

There are no changes to:

* OAuth request or response handling
* local loopback authentication
* GUI session detection
* authentication callback processing
* device authentication
* headless or SSH authentication behaviour
* application configuration options
* Microsoft Edge detection
* the existing manual authentication fallback

Only the browser-selection step of the existing GUI authentication workflow is changed.
