### PR TITLE
Fix Bug #3796: Drain inotify events on the monitor worker thread so bursts are not lost while the caller is busy

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -576,6 +576,7 @@ Thh
 thnk
 tidx
 timerfd
+timeval
 tkx
 tlsv
 tpgid

--- a/src/monitor.d
+++ b/src/monitor.d
@@ -86,16 +86,110 @@ class MonitorBackgroundWorker {
 	bool isAlive;
 	bool workerExited;
 
+	// The kernel queue for an inotify instance is bounded by fs.inotify.max_queued_events,
+	// 16384 by default, and it is filled by the kernel whether or not anything is reading.
+	// Draining it only when the caller is ready therefore makes event loss a function of how
+	// long the caller is busy. This worker drains it as soon as it is readable and buffers the
+	// result in user space, where the bound is ours to choose and the memory is pageable
+	// rather than a pinned kernel allocation.
+	//
+	// Events are buffered exactly as the kernel delivered them. A read() always returns a whole
+	// number of events - the kernel never splits one across a read boundary - so each chunk is
+	// self-contained and the consumer walks it with the same pointer arithmetic as before.
+	// Copying the block once, rather than decoding each event into an owned structure, keeps
+	// this to one allocation per read() instead of one per event.
+	private ubyte[][] eventQueue;
+	private shared(Mutex) queueMutex;
+	private size_t queuedBytes;
+	private bool queueOverflowed;
+
+	// Bound the buffer by bytes rather than event count: inotify events are variable length, so
+	// a count gives no predictable ceiling on memory.
+	private enum size_t queueByteLimit = 64 * 1024 * 1024;
+
+	// The kernel never returns a partial event, so a larger read buffer only reduces the
+	// syscall count.
+	private enum size_t readBufferSize = 256 * 1024;
+
 	this() {
 		isAlive = true;
 		workerExited = false;
 		p = pipe();
+		queueMutex = cast(shared)new Mutex();
 	}
 
 	shared void initialise() {
 		workerExited = false;
-		fd = inotify_init();
-		if (fd < 0) throw new MonitorException("inotify_init failed");
+		// IN_NONBLOCK so the drain loop can read until EAGAIN rather than blocking once the
+		// kernel queue has been emptied.
+		fd = inotify_init1(IN_NONBLOCK);
+		if (fd < 0) throw new MonitorException("inotify_init1 failed");
+	}
+
+	// Buffer one block exactly as the kernel delivered it.
+	private shared void enqueueChunk(ubyte[] chunk) {
+		if (chunk.length == 0) return;
+		auto self = cast(MonitorBackgroundWorker) this;
+		auto m = cast(Mutex) queueMutex;
+		m.lock();
+		scope(exit) m.unlock();
+
+		// Already latched - keep discarding until the consumer has taken the overflow.
+		if (self.queueOverflowed) return;
+
+		if (self.queuedBytes + chunk.length > queueByteLimit) {
+			// Recovery from here is a full local rescan, so the events already held are
+			// worthless. Release them rather than sitting at the ceiling.
+			self.queueOverflowed = true;
+			self.eventQueue = null;
+			self.queuedBytes = 0;
+			return;
+		}
+
+		self.eventQueue ~= chunk;
+		self.queuedBytes += chunk.length;
+	}
+
+	// Hand the whole buffer over in one move, so the consumer never holds the lock whilst
+	// walking events.
+	shared ubyte[][] takeEvents(out bool overflowed) {
+		auto self = cast(MonitorBackgroundWorker) this;
+		auto m = cast(Mutex) queueMutex;
+		m.lock();
+		scope(exit) m.unlock();
+
+		overflowed = self.queueOverflowed;
+		ubyte[][] taken = self.eventQueue;
+		self.eventQueue = null;
+		self.queuedBytes = 0;
+		self.queueOverflowed = false;
+		return taken;
+	}
+
+	shared bool hasQueuedEvents() {
+		auto self = cast(MonitorBackgroundWorker) this;
+		auto m = cast(Mutex) queueMutex;
+		m.lock();
+		scope(exit) m.unlock();
+		return (self.eventQueue.length > 0) || self.queueOverflowed;
+	}
+
+	// Read until the kernel queue is empty. Returns false only on a genuine read error.
+	private shared bool drainInotifyDescriptor(void[] readBuffer) {
+		while (true) {
+			ptrdiff_t length = read(fd, readBuffer.ptr, readBuffer.length);
+
+			if (length < 0) {
+				// EAGAIN / EWOULDBLOCK simply means the kernel queue is now empty, which is
+				// the expected exit from this loop on a non-blocking descriptor.
+				if ((errno() == EAGAIN) || (errno() == EWOULDBLOCK) || (errno() == EINTR)) return true;
+				return false;
+			}
+
+			if (length == 0) return true;
+
+			enqueueChunk((cast(ubyte*) readBuffer.ptr)[0 .. cast(size_t) length].dup);
+		}
 	}
 
 	// Add this path to be monitored
@@ -159,7 +253,26 @@ class MonitorBackgroundWorker {
 		// Wait for the caller to be ready.
 		receiveOnly!bool();
 
+		// Reused across iterations; the kernel never returns a partial event, so this only
+		// governs how many events come back per read().
+		void[] readBuffer = new void[readBufferSize];
+
+		// True whilst the caller has been told there is work and has not yet re-armed.
+		bool notifyPending = false;
+
 		while (isAlive) {
+			// Announce buffered work BEFORE deciding whether to block.
+			//
+			// This ordering matters. The descriptor is drained into user space below, so it
+			// goes empty and select() has nothing to report even when events are still held
+			// here awaiting collection. Announcing only after select() returns would leave a
+			// batch that arrived whilst the caller was busy unannounced: the caller re-arms,
+			// notifyPending clears, and the next iteration blocks on an empty descriptor.
+			if (!notifyPending && hasQueuedEvents()) {
+				callerTid.send(1);
+				notifyPending = true;
+			}
+
 			fd_set fds;
 			FD_ZERO(&fds);
 			FD_SET(fd, &fds);
@@ -168,9 +281,22 @@ class MonitorBackgroundWorker {
 			int controlPipeFd = (cast()p).readEnd.fileno;
 			FD_SET(controlPipeFd, &fds);
 
+			// Whilst a notification is outstanding the caller may re-arm at any moment, so
+			// poll rather than block indefinitely; otherwise the re-arm would not be noticed
+			// until the next filesystem event arrived. With nothing outstanding and nothing
+			// buffered there is genuinely nothing to do until the descriptor becomes
+			// readable, so blocking is correct.
+			timeval tv;
+			timeval* tvp = null;
+			if (notifyPending) {
+				tv.tv_sec = 0;
+				tv.tv_usec = 100_000;
+				tvp = &tv;
+			}
+
 			// select() only needs to scan up to the highest descriptor plus one.
 			int maxFd = max(fd, controlPipeFd) + 1;
-			res = select(maxFd, &fds, null, null, null);
+			res = select(maxFd, &fds, null, null, tvp);
 
 			if (res == -1) {
 				if (errno() == EINTR) {
@@ -197,17 +323,24 @@ class MonitorBackgroundWorker {
 				continue;
 			}
 
-			// Only inotify descriptor readiness should wake the caller for local
-			// filesystem processing.
-			if (FD_ISSET(fd, &fds)) {
-				callerTid.send(1);
-
-				// Wait for the caller to acknowledge whether monitoring should continue.
-				if (isAlive) {
-					isAlive = receiveOnly!bool();
+			// Drain the kernel queue into user space immediately, whether or not the caller
+			// is ready to process anything yet. This is the point of the exercise: the
+			// bounded kernel queue stops being the thing that decides whether events survive.
+			if ((res > 0) && FD_ISSET(fd, &fds)) {
+				if (!drainInotifyDescriptor(readBuffer)) {
+					callerTid.send(-1);
+					break;
 				}
+			}
 
-				continue;
+			// Has the caller re-armed? Checked without blocking so that draining continues
+			// whilst the caller is busy. Anything still buffered is announced at the top of
+			// the next iteration, which is why that check must come first.
+			if (notifyPending) {
+				bool rearmed = receiveTimeout(dur!"msecs"(0), (bool alive) {
+					isAlive = alive;
+				});
+				if (rearmed) notifyPending = false;
 			}
 		}
 	}
@@ -481,8 +614,6 @@ final class Monitor {
 	private bool monitorStateDirty = false;
 	// map the inotify cookies of move_from events to their path
 	private string[int] cookieToPath;
-	// buffer to receive the inotify events
-	private void[] buffer;
 	
 	// Mutex to support thread safe access of inotify watch descriptors
 	private Mutex inotifyMutex;
@@ -536,7 +667,6 @@ final class Monitor {
 			verbose = true;
 		}
 		
-		if (!buffer) buffer = new void[4096];
 		worker = cast(shared) new MonitorBackgroundWorker;
 		worker.initialise();
 
@@ -1352,28 +1482,36 @@ final class Monitor {
 		if(!initialised)
 			return;
 	
-		pollfd fds = {
-			fd: worker.fd,
-			events: POLLIN
-		};
+		// The descriptor is drained by the background worker, not here. Collect whatever it
+		// has buffered; each element is one block exactly as the kernel returned it.
+		bool queueOverflowed = false;
+		ubyte[][] collectedChunks = worker.takeEvents(queueOverflowed);
+
+		if (queueOverflowed) {
+			// The user-space buffer hit its ceiling, so events have been discarded and which
+			// ones is not knowable. Flag the monitor state as unreliable and let the caller
+			// recover, exactly as an IN_Q_OVERFLOW is handled below.
+			monitorStateDirty = true;
+			clearTransientEventState();
+			throw new MonitorException("local event buffer overflow: some events may be lost");
+		}
 
 		while (true) {
 			bool hasNotification = false;
 			int sleep_counter = 0;
 			// Batch events up to 5 seconds
 			while (sleep_counter < 5) {
-				int ret = poll(&fds, 1, 0);
-				if (ret == -1) throw new MonitorException("poll failed");
-				else if (ret == 0) break; // no events available
+				if (collectedChunks.length == 0) break; // no events available
 				hasNotification = true;
-				size_t length = read(worker.fd, buffer.ptr, buffer.length);
-				if (length == -1) throw new MonitorException("read failed");
+				ubyte[] chunk = collectedChunks[0];
+				collectedChunks = collectedChunks[1 .. $];
+				size_t length = chunk.length;
 				readBatchCount++;
 				bytesRead += length;
 
 				int i = 0;
 				while (i < length) {
-					inotify_event *event = cast(inotify_event*) &buffer[i];
+					inotify_event *event = cast(inotify_event*) &chunk[i];
 					rawEventCount++;
 					if (event.mask & IN_MOVED_FROM) movedFromEventCount++;
 					if (event.mask & IN_MOVED_TO) movedToEventCount++;
@@ -1739,10 +1877,22 @@ final class Monitor {
 					i += inotify_event.sizeof + event.len;
 				}
 
-				// Sleep for one second to prevent missing fast-changing events.
-				if (poll(&fds, 1, 0) == 0) {
-					sleep_counter += 1;
-					Thread.sleep(dur!"seconds"(1));
+				// Sleep for one second to prevent missing fast-changing events. The worker
+				// keeps draining the descriptor throughout this pause, so anything arriving
+				// during it is buffered in user space rather than left in the kernel queue.
+				if (collectedChunks.length == 0) {
+					if (!worker.hasQueuedEvents()) {
+						sleep_counter += 1;
+						Thread.sleep(dur!"seconds"(1));
+					}
+
+					bool moreOverflowed = false;
+					collectedChunks ~= worker.takeEvents(moreOverflowed);
+					if (moreOverflowed) {
+						monitorStateDirty = true;
+						clearTransientEventState();
+						throw new MonitorException("local event buffer overflow: some events may be lost");
+					}
 				}
 			}
 			if (!hasNotification) break;

--- a/src/monitor.d
+++ b/src/monitor.d
@@ -287,16 +287,16 @@ class MonitorBackgroundWorker {
 			// buffered there is genuinely nothing to do until the descriptor becomes
 			// readable, so blocking is correct.
 			timeval tv;
-			timeval* tvp = null;
+			timeval* selectTimeout = null;
 			if (notifyPending) {
 				tv.tv_sec = 0;
 				tv.tv_usec = 100_000;
-				tvp = &tv;
+				selectTimeout = &tv;
 			}
 
 			// select() only needs to scan up to the highest descriptor plus one.
 			int maxFd = max(fd, controlPipeFd) + 1;
-			res = select(maxFd, &fds, null, null, tvp);
+			res = select(maxFd, &fds, null, null, selectTimeout);
 
 			if (res == -1) {
 				if (errno() == EINTR) {


### PR DESCRIPTION
Re-raises the fix for [#3796](https://github.com/abraunegg/onedrive/issues/3796), which was closed
and is now locked, so I cannot comment there. **Please could you reopen it** — the analysis below is
against current `master`, not against what I filed in August.

Branch: 1 file, +179/−29, cut from `master` at `368bb57`.

## The defect

`watch()` drains the inotify descriptor from the caller: `poll()` with a zero timeout, then
`read(worker.fd, ...)` inline (`monitor.d:1365-1369`). Nothing reads the descriptor while the caller
is doing anything else. A synchronisation cycle is exactly such a period, and it is measured in
minutes on a large tree. Meanwhile the kernel queue is bounded at
`fs.inotify.max_queued_events`, 16384 by default, so a burst of local activity during a cycle can
fill it. When it does, the kernel drops events and delivers `IN_Q_OVERFLOW`.

## Why the current recovery cannot make up for it

**A rename is only ever recognised as a rename if both halves meet in the same batch.**
`IN_MOVED_FROM` stores the source under its cookie; the matching `IN_MOVED_TO` looks that cookie up
and records a move:

```d
auto from = event.cookie in cookieToPath;
if (from) {
    ...
    pendingChanges.append(LocalChangeType.moved, sourcePath, path);
```

If the partner never arrives, the end-of-batch fallback is explicit about what it assumes:

```d
// Assume that the items moved outside the watched directory have been deleted
foreach (cookie, path; cookieToPath.dup) {
    ...
    pendingChanges.append(LocalChangeType.deleted, path);
```

And the overflow branch discards the machinery that pairing depends on, then throws:

```d
} else if (event.mask & IN_Q_OVERFLOW) {
    monitorStateDirty = true;
    clearTransientEventState();
    throw new MonitorException("inotify queue overflow: some events may be lost");
}
```

`clearTransientEventState()` nulls `cookieToPath` and `movedNotDeleted` and resets `pendingChanges`.
The `throw` is inside `while (i < length)`, iterating a buffer **already read from the kernel** — so
every event after the marker in that buffer is abandoned too. The damage is therefore strictly larger
than what the kernel dropped: successfully delivered events, and the rename-pairing table, are
destroyed as well.

### Worked example

A 40 GB directory `Projects/` is renamed to `Archive/Projects/` while a cycle is in progress, and an
unrelated build is writing thousands of files into the tree at the same time — which is precisely the
condition that fills the queue.

1. The build's events fill the kernel queue. The queue overflows; the kernel begins dropping.
2. Some of the rename's events are dropped, and `IN_Q_OVERFLOW` is queued.
3. The caller finishes its cycle and reads. It processes what it can, reaches the overflow marker,
   nulls `cookieToPath` and `pendingChanges`, abandons the rest of the buffer and throws.
4. **No rename observation exists.** Not a degraded one — none.
5. The database still records every item under `Projects/`. The filesystem has them under
   `Archive/Projects/`.
6. The next cycle's local scan compares state. It finds an unknown tree at `Archive/Projects/` and
   database records at `Projects/` with no local files. That is, by construction, *a new upload and a
   deletion* — the scan has no way to express "these are the same objects".
7. The client deletes 40 GB of items from OneDrive and re-uploads 40 GB of identical content.

The API offers a server-side move for this. Instead every item gets a **new item ID**, so version
history, share links and anything else keyed to identity is lost, and the transfer happens at the
moment the machine is already under heavy load. `tc0046` already accepts
`Deleting item from Microsoft OneDrive` followed by `Uploading new file` as a valid outcome for a
directory rename, so this degradation is present in the suite as an expectation today.

### That example takes the benign interleaving

Which of the two outcomes occurs depends on where the overflow marker falls relative to the rename's
own events, and only one of them is as gentle as step 4 suggests:

- **the marker is reached in the same batch, after the `IN_MOVED_FROM`.** `cookieToPath` is nulled and
  the remainder of the buffer abandoned before the end-of-batch fallback can run, so nothing is
  recorded at all. That is the case walked above, and the next scan repairs it as delete + upload.
- **the `IN_MOVED_FROM` is delivered, its `IN_MOVED_TO` is dropped, and the marker is not reached in
  that batch.** The fallback at `monitor.d:1776-1787` then fires and appends
  `LocalChangeType.deleted` for a path whose file still exists under its new name. That is not an
  absence of information, it is an affirmative and incorrect one, and it is acted on before any scan
  has an opportunity to correct it.

I walked the first because it is the easier case to follow end to end. The second is strictly worse,
and it is reachable from the same condition.

### The scan cannot fix this in principle

It is a **state comparison, not an event replay**. It sees the final state, never the sequence that
produced it, so causal ordering is unavailable to it — that is exactly why a rename is
indistinguishable from a delete plus a create. A name swap (`A→tmp`, `B→A`, `tmp→B`) reduces the same
way. It also walks a tree that is still changing, so anything created after the walk passes its
directory waits for another cycle.

### And nothing connects the overflow to the recovery

`monitorStateDirty` is set at `monitor.d:1435`. `isMonitorStateDirty()` and `clearMonitorStateDirty()`
are defined at 689 and 693. **Neither is called anywhere** — no call site in `monitor.d`, `main.d`,
`sync.d` or `config.d`. The scan that rescues the situation runs every cycle for unrelated reasons.
So today's recovery is a side effect, not a guarantee: the reasonable future optimisation "skip the
local scan when inotify reported nothing" would silently reintroduce the loss, with nothing in the
code to warn whoever writes it. The user is never told either — the client does not report degraded
state, so during the window it reports success while the two sides do not agree.

## The change

Move the descriptor drain to the existing worker thread:

- `inotify_init1(IN_NONBLOCK)` so the drain loop reads until `EAGAIN` rather than blocking
- the worker reads continuously and hands complete buffers to the caller through a mutex-guarded
  queue, capped at 64 MiB, latching an overflow flag if that cap is ever reached
- `capture()` consumes queued buffers instead of polling and reading the descriptor itself
- the kernel never splits an event across a `read()`, so a handed-over buffer is always a whole
  number of events

The caller's semantics are unchanged; it is simply no longer the only thing that can empty the queue.
Renames now pair normally because both halves survive to be processed together.

## Without PR / With PR

jco-linux, OneDrive Personal, `--monitor`, real account. 20,000 `*.tmp` files (~40,000 events)
written into the watched tree while the main thread was busy. `*.tmp` is matched by the runtime
`skip_file`, so the flood generates the full kernel event load and uploads nothing.
`fs.inotify.max_queued_events` left untouched at 16384. Runs interleaved A/B/A/B so that
environmental drift shows up as disagreement between repeats of the same build.

| run | build | `inotify queue overflow` logged |
|---|---|---|
| A1 | `master` `368bb57` | **yes** |
| B1 | this branch | no |
| A2 | `master` `368bb57` | **yes** |
| B2 | this branch | no |

Attributed by PID rather than by time window: both vanilla processes logged it, neither patched
process did.

**In fairness, what these runs do not show.** No canary was lost on either build — the local scan
recovered them, and the end-to-end latencies did not separate the two builds. I tried twice to
construct a run that isolates the latency cost and could not: the overflow requires the main thread to
be busy and not draining, whilst exposing the delay requires the change to land after that cycle's
local scan, by which point the thread is draining again. The two conditions fight each other. So I am
resting this on the correctness argument above, which is checkable by reading the file, rather than on
a benchmark I was unable to make discriminate.

## Happy to split this

If you would rather take the smaller step first, the natural one is to make the existing contract
explicit: have the overflow deliberately require the next local scan, and have that scan deliberately
honour it. That is a few lines against scaffolding already present — `isMonitorStateDirty()` exists
and is simply never called — it changes nothing observable, and it would make the recovery a stated
guarantee rather than an accident. This receiver-thread change then becomes an optimisation argument
(avoid the O(tree) scan, keep renames as renames) rather than a correctness one. Say which you would
prefer and I will raise it that way.
