### PR TITLE
Fix Bug #3853: Concurrent downloads of the same DriveItem race on shared .partial file and can report false download failures

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -5,6 +5,7 @@ module onedrive;
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE, exit;
 import core.memory;
 import core.thread;
+import core.sync.mutex;
 import std.stdio;
 import std.string;
 import std.utf;
@@ -31,6 +32,73 @@ import util;
 import curlEngine;
 import intune;
 import localAuth;
+
+// Download staging is shared by pathname, so the download subsystem must serialize
+// transactions targeting the same canonical file. This is intentionally enforced
+// here rather than in sync.d: callers request a canonical download, while onedrive.d
+// and curlEngine.d exclusively own the temporary .partial lifecycle and promotion.
+private class DownloadPathLockEntry {
+	Mutex mutex;
+	size_t users;
+
+	this() {
+		mutex = new Mutex();
+	}
+}
+
+private __gshared Mutex downloadPathRegistryMutex;
+private __gshared DownloadPathLockEntry[string] downloadPathLocks;
+
+shared static this() {
+	downloadPathRegistryMutex = new Mutex();
+}
+
+private DownloadPathLockEntry acquireDownloadPathLock(string canonicalPath) {
+	DownloadPathLockEntry entry;
+
+	downloadPathRegistryMutex.lock();
+	try {
+		auto existingEntry = canonicalPath in downloadPathLocks;
+		if (existingEntry is null) {
+			entry = new DownloadPathLockEntry();
+			downloadPathLocks[canonicalPath] = entry;
+		} else {
+			entry = *existingEntry;
+		}
+		entry.users++;
+	} finally {
+		downloadPathRegistryMutex.unlock();
+	}
+
+	entry.mutex.lock();
+	return entry;
+}
+
+private void releaseDownloadPathLock(string canonicalPath, DownloadPathLockEntry entry) {
+	entry.mutex.unlock();
+
+	downloadPathRegistryMutex.lock();
+	try {
+		if (entry.users > 0) {
+			entry.users--;
+		}
+		if (entry.users == 0) {
+			downloadPathLocks.remove(canonicalPath);
+		}
+	} finally {
+		downloadPathRegistryMutex.unlock();
+	}
+}
+
+// Facts about a completed private staging file that sync.d needs in order to
+// apply its existing download-integrity and data-preservation policy. The staging
+// pathname itself is deliberately not exposed.
+struct DownloadCommitInfo {
+	long size;
+	bool hasStreamedQuickXorHash;
+	string quickXorHash;
+	string sha256Hash;
+}
 
 // Define the 'OneDriveException' class
 class OneDriveException : Exception {
@@ -1788,7 +1856,7 @@ class OneDriveApi {
 	}
 
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get_content
-	CurlResponse downloadById(const(char)[] driveId, const(char)[] itemId, string saveToPath, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool deferFinalRename = false) {
+	CurlResponse downloadById(const(char)[] driveId, const(char)[] itemId, string saveToPath, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) prepareDownloadCommit = null) {
 		// Set this function name
 		string thisFunctionName = format("%s.%s", strip(__MODULE__) , strip(getFunctionName!({})));
 
@@ -1825,7 +1893,7 @@ class OneDriveApi {
 		const(char)[] url = driveByIdUrl ~ driveId ~ "/items/" ~ itemId ~ "/content?AVOverride=1";
 
 		// Download file using the URL created above
-		CurlResponse downloadResponse = downloadFile(driveId, itemId, url, saveToPath, fileSize, onlineHash, resumeOffset, deferFinalRename);
+		CurlResponse downloadResponse = downloadFile(driveId, itemId, url, saveToPath, fileSize, onlineHash, resumeOffset, prepareDownloadCommit);
 		if (downloadResponse !is null) {
 			if (debugLogging) {
 				addLogEntry("downloadById() downloadResponse.hasStreamedQuickXorHash = " ~ to!string(downloadResponse.hasStreamedQuickXorHash), ["debug"]);
@@ -1833,25 +1901,24 @@ class OneDriveApi {
 			}
 		}
 
-		// Does the completed download now exist locally? When final promotion is
-		// deferred, the accepted response body intentionally remains at .partial
-		// so the sync layer can validate and transactionally replace an existing file.
-		string completedDownloadPath = deferFinalRename ? saveToPath ~ ".partial" : saveToPath;
+		// A successful downloadById() call means the download subsystem has completed
+		// the entire staging transaction and the canonical file now exists. The .partial
+		// pathname is an internal implementation detail and is never exposed to sync.d.
 		try {
-			if ((downloadResponse !is null) && exists(completedDownloadPath)) {
+			if ((downloadResponse !is null) && exists(saveToPath)) {
 				// Has the user disabled the setting of filesystem permissions?
 				if (!appConfig.getValueBool("disable_permission_set")) {
 					// File was downloaded successfully - configure the applicable permissions for the file
-					if (debugLogging) {addLogEntry("Setting file permissions for: " ~ completedDownloadPath, ["debug"]);}
-					completedDownloadPath.setAttributes(appConfig.returnRequiredFilePermissions());
+					if (debugLogging) {addLogEntry("Setting file permissions for: " ~ saveToPath, ["debug"]);}
+					saveToPath.setAttributes(appConfig.returnRequiredFilePermissions());
 				} else {
 					// Use inherited permissions
-					if (debugLogging) {addLogEntry("Using inherited filesystem permissions for: " ~ completedDownloadPath, ["debug"]);}
+					if (debugLogging) {addLogEntry("Using inherited filesystem permissions for: " ~ saveToPath, ["debug"]);}
 				}
 			}
 		} catch (FileException exception) {
 			// display the error message
-			displayFileSystemErrorMessage(exception.msg, thisFunctionName, completedDownloadPath);
+			displayFileSystemErrorMessage(exception.msg, thisFunctionName, saveToPath);
 		}
 
 		// Return the CurlResponse from the completed download so callers can inspect
@@ -2116,13 +2183,24 @@ class OneDriveApi {
 	}
 
 	// Download a file based on the URL request
-	private CurlResponse downloadFile(const(char)[] driveId, const(char)[] itemId, const(char)[] url, string filename, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool deferFinalRename = false, string callingFunction=__FUNCTION__, int lineno=__LINE__) {
+	private CurlResponse downloadFile(const(char)[] driveId, const(char)[] itemId, const(char)[] url, string filename, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) prepareDownloadCommit = null, string callingFunction=__FUNCTION__, int lineno=__LINE__) {
 		// Threshold for displaying download bar
 		long thresholdFileSize = 4 * 2^^20; // 4 MiB
 
-		// To support marking of partially-downloaded files
+		// To support marking of partially-downloaded files. The temporary path and its
+		// promotion are private to the download subsystem; sync.d only supplies the
+		// canonical destination and receives success/failure.
 		string originalFilename = filename;
 		string downloadFilename = filename ~ ".partial";
+
+		// Multiple reconciliation workers may request the same canonical pathname.
+		// Serialize that transaction here so two CurlEngine instances can never open,
+		// write, resume, remove or promote the same deterministic .partial file at once.
+		string canonicalLockPath = buildNormalizedPath(absolutePath(originalFilename));
+		DownloadPathLockEntry downloadPathLock = acquireDownloadPathLock(canonicalLockPath);
+		scope(exit) {
+			releaseDownloadPathLock(canonicalLockPath, downloadPathLock);
+		}
 
 		// To support resumable downloads, configure the 'resumable data' file path
 		string threadResumeDownloadFilePath = appConfig.resumeDownloadFilePath ~ "." ~ generateAlphanumericString();
@@ -2475,17 +2553,86 @@ class OneDriveApi {
 			throw new OneDriveException(downloadResponse.statusLine.code, downloadResponse.statusLine.reason, downloadResponse);
 		}
 
-		// The wrapper has now accepted the transport and HTTP response. Normally the
-		// completed temporary file is promoted here. Replacement downloads can defer
-		// this final rename so the sync layer can validate the completed .partial while
-		// leaving the existing canonical file untouched.
-		if (!deferFinalRename) {
-			rename(downloadFilename, originalFilename);
+		// Build an opaque description of the completed staging object for the caller's
+		// existing integrity and reconciliation policy. onedrive.d computes these facts
+		// while it still owns the staging file; sync.d never receives its pathname.
+		DownloadCommitInfo downloadCommitInfo;
+		downloadCommitInfo.size = cast(long) getSize(downloadFilename);
+
+		bool expectedQuickXorHash = (onlineHash.type == JSONType.object) &&
+			(("quickXorHash" in onlineHash) != null) &&
+			(onlineHash["quickXorHash"].type == JSONType.string) &&
+			!onlineHash["quickXorHash"].str.empty;
+		bool expectedSHA256Hash = (onlineHash.type == JSONType.object) &&
+			(("sha256Hash" in onlineHash) != null) &&
+			(onlineHash["sha256Hash"].type == JSONType.string) &&
+			!onlineHash["sha256Hash"].str.empty;
+
+		downloadCommitInfo.hasStreamedQuickXorHash = downloadResponse.hasStreamedQuickXorHash;
+		if (downloadResponse.hasStreamedQuickXorHash) {
+			downloadCommitInfo.quickXorHash = downloadResponse.streamedQuickXorHash;
+		} else if (expectedQuickXorHash || appConfig.getValueBool("disable_download_validation")) {
+			downloadCommitInfo.quickXorHash = computeQuickXorHash(downloadFilename);
 		}
 
-		// A successful complete transfer no longer needs resumable-download state.
-		// In deferred mode the completed .partial remains intentionally for the sync
-		// layer to validate and promote.
+		if (expectedSHA256Hash || (!expectedQuickXorHash && !appConfig.getValueBool("disable_download_validation"))) {
+			downloadCommitInfo.sha256Hash = computeSHA256Hash(downloadFilename);
+		}
+
+		// The caller may need to preserve unique local data before an authoritative
+		// replacement is committed. That policy remains in sync.d, but the callback is
+		// deliberately opaque: it never receives or manipulates the .partial pathname.
+		// Snapshot the canonical object around the callback so a concurrent local edit
+		// cannot be overwritten while preservation is being prepared.
+		bool canonicalExistsBeforeCommit = exists(originalFilename);
+		string canonicalHashBeforeCommit;
+		if (canonicalExistsBeforeCommit) {
+			canonicalHashBeforeCommit = computeQuickXorHash(originalFilename);
+			if (canonicalHashBeforeCommit.empty) {
+				addLogEntry("ERROR: Unable to verify canonical file before download commit; refusing replacement: " ~ originalFilename, ["error", "notify"]);
+				safeRemove(downloadFilename);
+				safeRemove(threadResumeDownloadFilePath);
+				curlEngine.resetDownloadResumeOffset();
+				return null;
+			}
+		}
+
+		if ((prepareDownloadCommit !is null) && !prepareDownloadCommit(downloadCommitInfo)) {
+			safeRemove(downloadFilename);
+			safeRemove(threadResumeDownloadFilePath);
+			curlEngine.resetDownloadResumeOffset();
+			return null;
+		}
+
+		bool canonicalExistsAfterCommitPreparation = exists(originalFilename);
+		bool canonicalChangedDuringCommit = canonicalExistsAfterCommitPreparation != canonicalExistsBeforeCommit;
+		if (!canonicalChangedDuringCommit && canonicalExistsAfterCommitPreparation) {
+			string canonicalHashAfterCommitPreparation = computeQuickXorHash(originalFilename);
+			canonicalChangedDuringCommit = canonicalHashAfterCommitPreparation.empty ||
+				(canonicalHashAfterCommitPreparation != canonicalHashBeforeCommit);
+		}
+
+		if (canonicalChangedDuringCommit) {
+			addLogEntry("WARNING: Canonical file changed while the validated replacement was being prepared for commit; refusing promotion: " ~ originalFilename, ["info", "notify"]);
+			safeRemove(downloadFilename);
+			safeRemove(threadResumeDownloadFilePath);
+			curlEngine.resetDownloadResumeOffset();
+			return null;
+		}
+
+		// The download subsystem owns the staging file for the complete transaction.
+		// A successful return is therefore only possible after the validated staging
+		// object has been atomically promoted to the canonical destination. Keep the
+		// current retry-aware rename handling, but perform it exclusively here.
+		if (!safeRename(downloadFilename, originalFilename, false)) {
+			addLogEntry("ERROR: Validated download could not be promoted; retaining any existing canonical file: " ~ originalFilename, ["error", "notify"]);
+			safeRemove(downloadFilename);
+			safeRemove(threadResumeDownloadFilePath);
+			curlEngine.resetDownloadResumeOffset();
+			return null;
+		}
+
+		// Successful canonical promotion completes resumable-download state.
 		safeRemove(threadResumeDownloadFilePath);
 		curlEngine.resetDownloadResumeOffset();
 

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -33,10 +33,11 @@ import curlEngine;
 import intune;
 import localAuth;
 
-// Download staging is shared by pathname, so the download subsystem must serialize
-// transactions targeting the same canonical file. This is intentionally enforced
-// here rather than in sync.d: callers request a canonical download, while onedrive.d
-// and curlEngine.d exclusively own the temporary .partial lifecycle and promotion.
+// Downloads use a deterministic '<canonical>.partial' staging pathname. Multiple
+// reconciliation workers can legitimately reach the download subsystem in parallel,
+// however only one download transaction may own a given canonical pathname at a time.
+// Keep that ownership enforcement here so sync.d does not need to know anything about
+// the transport staging filename or its lifecycle.
 private class DownloadPathLockEntry {
 	Mutex mutex;
 	size_t users;
@@ -90,14 +91,17 @@ private void releaseDownloadPathLock(string canonicalPath, DownloadPathLockEntry
 	}
 }
 
-// Facts about a completed private staging file that sync.d needs in order to
-// apply its existing download-integrity and data-preservation policy. The staging
-// pathname itself is deliberately not exposed.
+// Neutral facts about a completed download staging file. onedrive.d owns the staging
+// pathname and therefore generates any on-disk hashes that sync.d needs for integrity
+// inspection. The decision whether those values are acceptable remains exclusively in
+// sync.d; this structure intentionally contains no Graph comparison or policy result.
 struct DownloadCommitInfo {
 	long size;
+	SysTime transferEndTime;
 	bool hasStreamedQuickXorHash;
-	string quickXorHash;
-	string sha256Hash;
+	string streamedQuickXorHash;
+	string generatedQuickXorHash;
+	string generatedSHA256Hash;
 }
 
 // Define the 'OneDriveException' class
@@ -1856,7 +1860,7 @@ class OneDriveApi {
 	}
 
 	// https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get_content
-	CurlResponse downloadById(const(char)[] driveId, const(char)[] itemId, string saveToPath, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) prepareDownloadCommit = null) {
+	CurlResponse downloadById(const(char)[] driveId, const(char)[] itemId, string saveToPath, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) inspectDownloadBeforeCommit = null) {
 		// Set this function name
 		string thisFunctionName = format("%s.%s", strip(__MODULE__) , strip(getFunctionName!({})));
 
@@ -1893,7 +1897,7 @@ class OneDriveApi {
 		const(char)[] url = driveByIdUrl ~ driveId ~ "/items/" ~ itemId ~ "/content?AVOverride=1";
 
 		// Download file using the URL created above
-		CurlResponse downloadResponse = downloadFile(driveId, itemId, url, saveToPath, fileSize, onlineHash, resumeOffset, prepareDownloadCommit);
+		CurlResponse downloadResponse = downloadFile(driveId, itemId, url, saveToPath, fileSize, onlineHash, resumeOffset, inspectDownloadBeforeCommit);
 		if (downloadResponse !is null) {
 			if (debugLogging) {
 				addLogEntry("downloadById() downloadResponse.hasStreamedQuickXorHash = " ~ to!string(downloadResponse.hasStreamedQuickXorHash), ["debug"]);
@@ -1901,9 +1905,9 @@ class OneDriveApi {
 			}
 		}
 
-		// A successful downloadById() call means the download subsystem has completed
-		// the entire staging transaction and the canonical file now exists. The .partial
-		// pathname is an internal implementation detail and is never exposed to sync.d.
+		// A successful downloadById() call means the complete private staging transaction
+		// has finished and the canonical file now exists. The '.partial' pathname remains
+		// an implementation detail of onedrive.d/curlEngine.d and is never exposed here.
 		try {
 			if ((downloadResponse !is null) && exists(saveToPath)) {
 				// Has the user disabled the setting of filesystem permissions?
@@ -2183,19 +2187,18 @@ class OneDriveApi {
 	}
 
 	// Download a file based on the URL request
-	private CurlResponse downloadFile(const(char)[] driveId, const(char)[] itemId, const(char)[] url, string filename, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) prepareDownloadCommit = null, string callingFunction=__FUNCTION__, int lineno=__LINE__) {
+	private CurlResponse downloadFile(const(char)[] driveId, const(char)[] itemId, const(char)[] url, string filename, long fileSize, JSONValue onlineHash, long resumeOffset = 0, bool delegate(DownloadCommitInfo) inspectDownloadBeforeCommit = null, string callingFunction=__FUNCTION__, int lineno=__LINE__) {
 		// Threshold for displaying download bar
 		long thresholdFileSize = 4 * 2^^20; // 4 MiB
 
-		// To support marking of partially-downloaded files. The temporary path and its
-		// promotion are private to the download subsystem; sync.d only supplies the
-		// canonical destination and receives success/failure.
+		// To support marking of partially-downloaded files. The staging pathname and its
+		// final promotion are private to the download subsystem.
 		string originalFilename = filename;
 		string downloadFilename = filename ~ ".partial";
 
-		// Multiple reconciliation workers may request the same canonical pathname.
-		// Serialize that transaction here so two CurlEngine instances can never open,
-		// write, resume, remove or promote the same deterministic .partial file at once.
+		// Multiple parallel workers can request the same canonical pathname. Serialize
+		// the complete transaction here so two CurlEngine instances can never open,
+		// write, resume, remove or promote the same deterministic '.partial' file at once.
 		string canonicalLockPath = buildNormalizedPath(absolutePath(originalFilename));
 		DownloadPathLockEntry downloadPathLock = acquireDownloadPathLock(canonicalLockPath);
 		scope(exit) {
@@ -2553,42 +2556,46 @@ class OneDriveApi {
 			throw new OneDriveException(downloadResponse.statusLine.code, downloadResponse.statusLine.reason, downloadResponse);
 		}
 
-		// Build an opaque description of the completed staging object for the caller's
-		// existing integrity and reconciliation policy. onedrive.d computes these facts
-		// while it still owns the staging file; sync.d never receives its pathname.
+		// The HTTP transfer is complete and accepted, but the canonical destination has
+		// not yet been touched. Generate neutral facts about the private staging file so
+		// sync.d can perform the existing Graph integrity inspection and data-preservation
+		// policy without ever seeing the staging pathname itself.
 		DownloadCommitInfo downloadCommitInfo;
+		downloadCommitInfo.transferEndTime = Clock.currTime();
 		downloadCommitInfo.size = cast(long) getSize(downloadFilename);
+		downloadCommitInfo.hasStreamedQuickXorHash = downloadResponse.hasStreamedQuickXorHash;
+		downloadCommitInfo.streamedQuickXorHash = downloadResponse.streamedQuickXorHash;
 
 		bool expectedQuickXorHash = (onlineHash.type == JSONType.object) &&
-			(("quickXorHash" in onlineHash) != null) &&
+			("quickXorHash" in onlineHash) &&
 			(onlineHash["quickXorHash"].type == JSONType.string) &&
 			!onlineHash["quickXorHash"].str.empty;
-		bool expectedSHA256Hash = (onlineHash.type == JSONType.object) &&
-			(("sha256Hash" in onlineHash) != null) &&
-			(onlineHash["sha256Hash"].type == JSONType.string) &&
-			!onlineHash["sha256Hash"].str.empty;
+		bool disableDownloadValidation = appConfig.getValueBool("disable_download_validation");
 
-		downloadCommitInfo.hasStreamedQuickXorHash = downloadResponse.hasStreamedQuickXorHash;
-		if (downloadResponse.hasStreamedQuickXorHash) {
-			downloadCommitInfo.quickXorHash = downloadResponse.streamedQuickXorHash;
-		} else if (expectedQuickXorHash || appConfig.getValueBool("disable_download_validation")) {
-			downloadCommitInfo.quickXorHash = computeQuickXorHash(downloadFilename);
+		// Preserve the existing hash-selection semantics from sync.d. A generated
+		// QuickXorHash is required when no streamed value is available, and also for
+		// the non-Personal --disable-download-validation AIP/SharePoint enrichment path.
+		if ((expectedQuickXorHash && !downloadCommitInfo.hasStreamedQuickXorHash) ||
+			(disableDownloadValidation && (appConfig.accountType != "personal"))) {
+			downloadCommitInfo.generatedQuickXorHash = computeQuickXorHash(downloadFilename);
 		}
 
-		if (expectedSHA256Hash || (!expectedQuickXorHash && !appConfig.getValueBool("disable_download_validation"))) {
-			downloadCommitInfo.sha256Hash = computeSHA256Hash(downloadFilename);
+		// When no QuickXorHash was supplied by Graph, sync.d falls back to SHA256 for
+		// download-integrity evaluation. Generate that value while the staging file is
+		// still private to this layer.
+		if (!expectedQuickXorHash && !disableDownloadValidation) {
+			downloadCommitInfo.generatedSHA256Hash = computeSHA256Hash(downloadFilename);
 		}
 
-		// The caller may need to preserve unique local data before an authoritative
-		// replacement is committed. That policy remains in sync.d, but the callback is
-		// deliberately opaque: it never receives or manipulates the .partial pathname.
-		// Snapshot the canonical object around the callback so a concurrent local edit
-		// cannot be overwritten while preservation is being prepared.
-		bool canonicalExistsBeforeCommit = exists(originalFilename);
-		string canonicalHashBeforeCommit;
-		if (canonicalExistsBeforeCommit) {
-			canonicalHashBeforeCommit = computeQuickXorHash(originalFilename);
-			if (canonicalHashBeforeCommit.empty) {
+		// Snapshot the current canonical file around the sync-layer inspection callback.
+		// The callback may create a non-destructive safeBackup, but it must not replace
+		// or otherwise modify the canonical object. A genuine local edit that occurs
+		// while the completed download is being inspected must win over this replacement.
+		bool canonicalExistsBeforeInspection = exists(originalFilename);
+		string canonicalHashBeforeInspection;
+		if (canonicalExistsBeforeInspection) {
+			canonicalHashBeforeInspection = computeQuickXorHash(originalFilename);
+			if (canonicalHashBeforeInspection.empty) {
 				addLogEntry("ERROR: Unable to verify canonical file before download commit; refusing replacement: " ~ originalFilename, ["error", "notify"]);
 				safeRemove(downloadFilename);
 				safeRemove(threadResumeDownloadFilePath);
@@ -2597,33 +2604,39 @@ class OneDriveApi {
 			}
 		}
 
-		if ((prepareDownloadCommit !is null) && !prepareDownloadCommit(downloadCommitInfo)) {
+		if ((inspectDownloadBeforeCommit !is null) && !inspectDownloadBeforeCommit(downloadCommitInfo)) {
+			// sync.d rejected the completed staging file or could not preserve required
+			// local data. Discard only the transfer-owned staging artifact; any existing
+			// canonical file remains untouched.
 			safeRemove(downloadFilename);
 			safeRemove(threadResumeDownloadFilePath);
 			curlEngine.resetDownloadResumeOffset();
 			return null;
 		}
 
-		bool canonicalExistsAfterCommitPreparation = exists(originalFilename);
-		bool canonicalChangedDuringCommit = canonicalExistsAfterCommitPreparation != canonicalExistsBeforeCommit;
-		if (!canonicalChangedDuringCommit && canonicalExistsAfterCommitPreparation) {
-			string canonicalHashAfterCommitPreparation = computeQuickXorHash(originalFilename);
-			canonicalChangedDuringCommit = canonicalHashAfterCommitPreparation.empty ||
-				(canonicalHashAfterCommitPreparation != canonicalHashBeforeCommit);
+		// Recheck the canonical path after sync.d has completed integrity inspection
+		// and any safeBackup preservation. If its existence or bytes changed while the
+		// commit was being prepared, local intent wins and the staged replacement is
+		// discarded for a later reconciliation.
+		bool canonicalExistsAfterInspection = exists(originalFilename);
+		bool canonicalChangedDuringInspection = canonicalExistsAfterInspection != canonicalExistsBeforeInspection;
+		if (!canonicalChangedDuringInspection && canonicalExistsAfterInspection) {
+			string canonicalHashAfterInspection = computeQuickXorHash(originalFilename);
+			canonicalChangedDuringInspection = canonicalHashAfterInspection.empty ||
+				(canonicalHashAfterInspection != canonicalHashBeforeInspection);
 		}
 
-		if (canonicalChangedDuringCommit) {
-			addLogEntry("WARNING: Canonical file changed while the validated replacement was being prepared for commit; refusing promotion: " ~ originalFilename, ["info", "notify"]);
+		if (canonicalChangedDuringInspection) {
+			addLogEntry("WARNING: Canonical file changed while the validated replacement was being committed; refusing promotion: " ~ originalFilename, ["info", "notify"]);
 			safeRemove(downloadFilename);
 			safeRemove(threadResumeDownloadFilePath);
 			curlEngine.resetDownloadResumeOffset();
 			return null;
 		}
 
-		// The download subsystem owns the staging file for the complete transaction.
-		// A successful return is therefore only possible after the validated staging
-		// object has been atomically promoted to the canonical destination. Keep the
-		// current retry-aware rename handling, but perform it exclusively here.
+		// onedrive.d owns the completed staging file for the entire transaction. The
+		// only successful exit is after the accepted staging object has been promoted
+		// to the canonical pathname. Keep the current retry-aware filesystem handling.
 		if (!safeRename(downloadFilename, originalFilename, false)) {
 			addLogEntry("ERROR: Validated download could not be promoted; retaining any existing canonical file: " ~ originalFilename, ["error", "notify"]);
 			safeRemove(downloadFilename);

--- a/src/sync.d
+++ b/src/sync.d
@@ -4548,6 +4548,7 @@ class SyncEngine {
 		string OneDriveFileSHA256Hash;
 		long jsonFileSize = 0;
 		Item databaseItem;
+		bool fileFoundInDB = false;
 		bool canonicalFileExistedBeforeDownload = false;
 		string canonicalHashBeforeDownload;
 		SysTime itemModifiedTime;
@@ -4601,7 +4602,6 @@ class SyncEngine {
 			// transfer is still detected and preserved at commit time.
 			canonicalHashBeforeDownload = computeQuickXorHash(newItemPath);
 		}
-
 		// Is the item reported as Malware ?
 		if (isMalware(onedriveJSONItem)){
 			// OneDrive reports that this file is malware
@@ -4658,6 +4658,7 @@ class SyncEngine {
 			if (canonicalFileExistedBeforeDownload && !ignoreDataPreservationCheck) {
 				foreach (driveId; onlineDriveDetails.keys) {
 					if (itemDB.selectByPath(newItemPath, driveId, databaseItem)) {
+						fileFoundInDB = true;
 						break;
 					}
 				}
@@ -4691,57 +4692,90 @@ class SyncEngine {
 					// Attempt to download the file as there is enough free space locally
 					OneDriveApi downloadFileOneDriveApiInstance;
 
-					// The download subsystem owns the .partial file and final canonical promotion.
-					// This callback contains only reconciliation policy: once onedrive.d has a
-					// complete staging file, validate it and decide whether the current canonical file
-					// contains local data that must be preserved before replacement. The callback
-					// never receives or manipulates the transport staging pathname.
-					bool delegate(DownloadCommitInfo) prepareDownloadCommit = (DownloadCommitInfo downloadCommitInfo) {
-						bool canonicalExistsAtCommit = exists(newItemPath);
-						string canonicalHashAtCommit;
-						bool preserveCanonicalAsSafeBackup = false;
+					// onedrive.d owns the private '.partial' staging file and generates neutral
+					// facts about the completed transfer. All integrity inspection and the
+					// decision whether that download is acceptable remain here in sync.d.
+					bool delegate(DownloadCommitInfo) inspectDownloadBeforeCommit = (DownloadCommitInfo downloadCommitInfo) {
+						// Preserve the transfer-only timing boundary used by displayTransferMetrics().
+						downloadTransferEndTime = downloadCommitInfo.transferEndTime;
 
-						// Keep download integrity policy in sync.d, as in the original download
-						// architecture. onedrive.d supplies only facts about its completed private
-						// staging object and will not promote it unless this callback accepts it.
+						// Validate only when the requested online version was downloaded. A failed
+						// transfer may deliberately leave an older final file untouched.
+						// The staging pathname is intentionally not exposed to sync.d; onedrive.d
+						// supplies the size and generated/streamed hashes required below.
+
+						// When downloading some files from SharePoint, the OneDrive API reports one file size, 
+						// but the SharePoint HTTP Server sends a totally different byte count for the same file
+						// we have implemented --disable-download-validation to disable these checks
+
+						// Regardless of --disable-download-validation we still need to set the file timestamp correctly.
+						// itemModifiedTime was validated before the transfer began so this operation never
+						// needs to manufacture a replacement timestamp.
+
+						// Did the user configure --disable-download-validation ?
 						if (!disableDownloadValidation) {
+							// A 'file' was downloaded - does what we downloaded = reported jsonFileSize or if there is some sort of funky local disk compression going on
+							// Does the file hash OneDrive reports match what we have locally?
 							string onlineFileHash;
 							string downloadedFileHash;
 							long downloadFileSize = downloadCommitInfo.size;
 
 							if (!OneDriveFileXORHash.empty) {
 								onlineFileHash = OneDriveFileXORHash;
+								// Use the streamed QuickXorHash from the completed download when available; otherwise calculate the QuickXorHash for this file
 								if (downloadCommitInfo.hasStreamedQuickXorHash) {
-									if (debugLogging) {addLogEntry("Using stream calculated hash", ["debug"]);}
-								} else if (debugLogging) {
-									addLogEntry("Must generate file hash", ["debug"]);
+									if (debugLogging) {
+										addLogEntry("Using stream calculated hash", ["debug"]);
+									}
+									downloadedFileHash = downloadCommitInfo.streamedQuickXorHash;
+								} else {
+									if (debugLogging) {
+										addLogEntry("Must generate file hash", ["debug"]);
+									}
+									downloadedFileHash = downloadCommitInfo.generatedQuickXorHash;
 								}
-								downloadedFileHash = downloadCommitInfo.quickXorHash;
 							} else {
 								onlineFileHash = OneDriveFileSHA256Hash;
-								downloadedFileHash = downloadCommitInfo.sha256Hash;
+								// Fallback: Calculate the SHA256 Hash for this file
+								downloadedFileHash = downloadCommitInfo.generatedSHA256Hash;
 							}
 
 							if ((downloadFileSize == jsonFileSize) && (downloadedFileHash == onlineFileHash)) {
+								// Downloaded file matches size and hash
 								if (debugLogging) {addLogEntry("Downloaded file matches reported size and reported file hash", ["debug"]);}
+
+								// Set the timestamp, logging and error handling done within function
+								// Timestamp application occurs after onedrive.d has promoted the accepted
+								// staging file to the canonical pathname.
 								applyAuthoritativeTimestamp = true;
 							} else {
+								// QuickXorHash in this client incorporates the file length into the final digest, so a size mismatch would be expected to also produce a hash mismatch.
+								// However, QuickXorHash is not collision-resistant, so we treat the hash mismatch as the definitive integrity failure condition and log size mismatches
+								// as advisory
+
+								// Downloaded file does not match size or hash .. which is it?
 								bool downloadValueMismatch = false;
 
+								// Size difference between what was written to disk and what the API reported as the file size
 								if (downloadFileSize != jsonFileSize) {
+									// downloaded file size does not match
 									downloadValueMismatch = true;
 									if (debugLogging) {
 										addLogEntry("Actual file size on disk:   " ~ to!string(downloadFileSize), ["debug"]);
 										addLogEntry("OneDrive API reported size: " ~ to!string(jsonFileSize), ["debug"]);
 									}
 									if ((verboseLogging)||(debugLogging)) {
+										// verbose or debug message
 										addLogEntry("WARNING: Download validation failed (size mismatch): " ~ newItemPath ~ " | expected=" ~ to!string(jsonFileSize) ~ " | actual=" ~ to!string(downloadFileSize), ["verbose"]);
 									} else {
+										// non-verbose message
 										addLogEntry("WARNING: File download size mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
 									}
 								}
 
+								// Hash difference between what was written to disk and then QuickXOR calculated and what the API reported as the file hash online
 								if (downloadedFileHash != onlineFileHash) {
+									// downloaded file hash does not match
 									downloadValueMismatch = true;
 									if (debugLogging) {
 										addLogEntry("Actual local file hash:     " ~ downloadedFileHash, ["debug"]);
@@ -4749,42 +4783,85 @@ class SyncEngine {
 									}
 
 									if ((verboseLogging)||(debugLogging)) {
+										// verbose or debug message
 										addLogEntry("ERROR: Download validation failed (hash mismatch): " ~ newItemPath ~ " | expected=" ~ onlineFileHash ~ " | actual=" ~ downloadedFileHash, ["verbose"]);
 									} else {
+										// non-verbose message
 										addLogEntry("ERROR: File download hash mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
 									}
 								}
 
+								// .heic data loss check
+								// - https://github.com/abraunegg/onedrive/issues/2471
+								// - https://github.com/OneDrive/onedrive-api-docs/issues/1532
+								// - https://github.com/OneDrive/onedrive-api-docs/issues/1723
 								if (downloadValueMismatch && (toLower(extension(newItemPath)) == ".heic")) {
+									// Need to display a message to the user that they have experienced data loss
 									addLogEntry("DATA-LOSS: File downloaded has experienced data loss due to a Microsoft OneDrive API bug. DO NOT DELETE THIS FILE ONLINE: " ~ newItemPath, ["info", "notify"]);
 									if (verboseLogging) {addLogEntry("           Please read https://github.com/OneDrive/onedrive-api-docs/issues/1723 for more details.", ["verbose"]);}
 								}
 
-								if (appConfig.accountType == "documentLibrary") {
+								// Add some workaround messaging for SharePoint
+								if (appConfig.accountType == "documentLibrary"){
+									// It has been seen where SharePoint / OneDrive API reports one size via the JSON
+									// but the content length and file size written to disk is totally different - example:
+									// From JSON:         "size": 17133
+									// From HTTPS Server: < Content-Length: 19340
+									// with no logical reason for the difference, except for a 302 redirect before file download
 									addLogEntry("INFO: It is most likely that a SharePoint OneDrive API issue is the root cause. Add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
 								} else {
+									// other account types
 									addLogEntry("INFO: Potentially add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
 								}
 
+								// If the computed hash does not equal provided online hash, consider this a failed download
 								if (downloadedFileHash != onlineFileHash) {
-									// Preserve the existing diagnostic while refusing the commit before
-									// the private staging file can replace the canonical destination.
+									// We do not want this downloaded file to be promoted as it failed the integrity checks
 									addLogEntry("Removing local file " ~ newItemPath ~ " due to failed integrity checks");
+
+									// Was this item previously in-sync with the local system?
+									// We previously searched for the file in the DB, we need to use that record
+									if (fileFoundInDB && !exists(newItemPath)) {
+										// Purge DB record only when no canonical local file remains
+										// In a --dry-run scenario, this is being done against a DB copy
+										addLogEntry("Removing DB record due to failed integrity checks");
+										itemDB.deleteById(databaseItem.driveId, databaseItem.id);
+									}
+
+									// onedrive.d owns and removes the private staging file when this callback
+									// rejects the download. The canonical path is left untouched.
 									return false;
 								}
 							}
 						} else {
+							// Download validation checks were disabled
 							if (debugLogging) {addLogEntry("Downloaded file validation disabled due to --disable-download-validation", ["debug"]);}
 							if (verboseLogging) {addLogEntry("WARNING: Skipping download integrity check for: " ~ newItemPath, ["verbose"]);}
+
+							// Whilst the download integrity checks were disabled, we still have to set the correct timestamp on the file
+							// Set the timestamp, logging and error handling done within function
+							// Timestamp application occurs after onedrive.d has promoted the accepted
+							// staging file to the canonical path.
 							applyAuthoritativeTimestamp = true;
 
-							// Preserve the existing AIP/SharePoint enrichment behaviour using facts
-							// calculated by the download layer before canonical promotion.
+							// Azure Information Protection (AIP) protected files potentially have missing data and/or inconsistent data
 							if (appConfig.accountType != "personal") {
-								string localFileHash = downloadCommitInfo.quickXorHash;
+								// AIP Protected Files cause issues here, as the online size & hash are not what has been downloaded
+								// There is ZERO way to determine if this is an AIP protected file either from the JSON data
+
+								// Calculate the local file hash and get the local file size
+								// The actual hash generation is performed by onedrive.d while it owns
+								// the private staging file; evaluation of those values remains here.
+								string localFileHash = downloadCommitInfo.generatedQuickXorHash;
 								long downloadFileSize = downloadCommitInfo.size;
 
 								if ((OneDriveFileXORHash != localFileHash) && (jsonFileSize != downloadFileSize)) {
+									// High potential to be an AIP protected file given the following scenario
+									// Business | SharePoint Account Type (not a personal account)
+									// --disable-download-validation is being used .. meaning the user has specifically configured this due the Microsoft SharePoint Enrichment Feature (bug)
+									// The file downloaded but the XOR hash and file size locally is not as per the provided JSON - both are different
+									//
+									// Update the 'onedriveJSONItem' JSON data with the local values .....
 									if (debugLogging) {
 										string aipLogMessage = format("POTENTIAL AIP FILE (Issue 3070) - Changing the source JSON data provided by Graph API to use actual on-disk values (quickXorHash,size): %s", newItemPath);
 										addLogEntry(aipLogMessage, ["debug"]);
@@ -4794,12 +4871,22 @@ class SyncEngine {
 										addLogEntry(" - Local Size   : " ~ to!string(downloadFileSize), ["debug"]);
 									}
 
+									// Make the change in the JSON using local values
 									onedriveJSONItem["file"]["hashes"]["quickXorHash"] = localFileHash;
 									onedriveJSONItem["size"] = downloadFileSize;
 								}
 							}
-						}
+						} // end of (!disableDownloadValidation)
 
+						// The completed download has passed integrity inspection. Re-evaluate the
+						// canonical path now, before onedrive.d is allowed to promote its private
+						// staging file. This preserves the transactional safeBackup behaviour.
+						bool canonicalExistsAtCommit = exists(newItemPath);
+						string canonicalHashAtCommit;
+						bool preserveCanonicalAsSafeBackup = false;
+
+						// Snapshot the canonical bytes at the commit boundary. onedrive.d performs
+						// a final recheck after this callback returns and immediately before promotion.
 						if (canonicalExistsAtCommit) {
 							canonicalHashAtCommit = computeQuickXorHash(newItemPath);
 							if (canonicalHashAtCommit.empty) {
@@ -4810,21 +4897,22 @@ class SyncEngine {
 
 						// If this workflow started as a replacement but the canonical file has
 						// disappeared, a genuine local removal/move may have occurred during the
-						// transfer. Do not silently recreate it and erase that local intent.
+						// download. Do not silently recreate it and erase that local intent.
 						if (canonicalFileExistedBeforeDownload && !canonicalExistsAtCommit) {
 							addLogEntry("WARNING: Canonical file changed or disappeared while replacement was downloading; refusing validated replacement: " ~ newItemPath, ["info", "notify"]);
 							return false;
 						}
 
 						if (canonicalExistsAtCommit && ignoreDataPreservationCheck) {
-							// Post-upload enrichment normally replaces the file just uploaded without
-							// creating a safeBackup. Preserve only if a new local file appeared or the
-							// canonical bytes changed while the replacement download was in flight.
+							// The caller expects replacement of the file it just uploaded, so do not
+							// create a safeBackup for that known difference. However, if the canonical
+							// bytes changed again while this download was running, that is new local
+							// data and must be preserved. A file that appeared unexpectedly is treated
+							// the same way.
 							if (!canonicalFileExistedBeforeDownload) {
 								preserveCanonicalAsSafeBackup = true;
 							} else {
-								preserveCanonicalAsSafeBackup = canonicalHashBeforeDownload.empty ||
-									(canonicalHashAtCommit != canonicalHashBeforeDownload);
+								preserveCanonicalAsSafeBackup = canonicalHashBeforeDownload.empty || (canonicalHashAtCommit != canonicalHashBeforeDownload);
 							}
 
 							if (preserveCanonicalAsSafeBackup) {
@@ -4877,25 +4965,40 @@ class SyncEngine {
 						}
 
 						// Perform the download with any applicable resume offset. onedrive.d and
-						// curlEngine.d own the complete staging lifecycle; a non-null response means
-						// the validated staging file has already been promoted to newItemPath.
+						// curlEngine.d own the complete staging lifecycle. sync.d supplies only
+						// integrity/preservation inspection policy and never sees '.partial'.
 						downloadTransferStartTime = Clock.currTime();
-						auto downloadResponse = downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, prepareDownloadCommit);
-						downloadTransferEndTime = Clock.currTime();
+						auto downloadResponse = downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, inspectDownloadBeforeCommit);
 						if (downloadResponse !is null) {
 							// A non-null response means the private staging file passed sync.d's
-							// integrity/preservation policy and was promoted by onedrive.d.
+							// integrity/preservation inspection and onedrive.d promoted it to
+							// the canonical destination.
 							downloadTransferCompleted = true;
+
+							// File should now exist at the canonical pathname. Apply the authoritative
+							// Microsoft timestamp only after successful lower-layer promotion.
 							if (exists(newItemPath)) {
 								if (applyAuthoritativeTimestamp) {
 									setLocalPathTimestamp(dryRun, newItemPath, itemModifiedTime);
 								}
 							} else {
+								// Was exitHandlerTriggered flagged
 								if (!exitHandlerTriggered) {
+									// File does not exist locally ... so the download failed
 									if ((verboseLogging)||(debugLogging)) {
+										// If we are doing verbose logging,
 										addLogEntry("ERROR: Download failed (file not present after download): " ~ newItemPath ~ " | expectedSize=" ~ to!string(jsonFileSize) ~ " | resumeOffset=" ~ to!string(resumeOffset), ["verbose"]);
 									} else {
 										addLogEntry("ERROR: File failed to download. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
+									}
+
+									// Was this item previously in-sync with the local system?
+									// We previously searched for the file in the DB, we need to use that record
+									if (fileFoundInDB && !exists(newItemPath)) {
+										// Purge DB record only when no canonical local file remains
+										// In a --dry-run scenario, this is being done against a DB copy
+										addLogEntry("Removing existing DB record due to failed file download.");
+										itemDB.deleteById(databaseItem.driveId, databaseItem.id);
 									}
 								}
 								downloadFailed = true;
@@ -4904,11 +5007,22 @@ class SyncEngine {
 							if (debugLogging) {
 								addLogEntry("downloadResponse is null", ["debug"]);
 							}
+
+							// Was exitHandlerTriggered flagged
+							if (exitHandlerTriggered && appConfig.getValueBool("force_xfer_abort")) {
+								// exitHandlerTriggered triggered
+								// this is force abort
+								if ((verboseLogging)||(debugLogging)) {
+									// add log message
+									addLogEntry("Download aborted: " ~ newItemPath, ["verbose"]);
+								}
+							}
+							// Flag that the download failed
 							downloadFailed = true;
 						}
 
 					} catch (OneDriveException exception) {
-						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, prepareDownloadCommit); generated a OneDriveException", ["debug"]);}
+						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, inspectDownloadBeforeCommit); generated a OneDriveException", ["debug"]);}
 
 						// Any propagated API exception means that the requested online version was
 						// not downloaded. A pre-existing final path, if present, is still the last
@@ -4949,8 +5063,9 @@ class SyncEngine {
 				}
 			}
 
-			// A successful downloadById() call has already completed the private
-			// .partial -> canonical transaction inside the download subsystem.
+			// File should have been downloaded. A successful downloadById() call has
+			// already completed the private '.partial' -> canonical transaction inside
+			// onedrive.d.
 			if (!downloadFailed) {
 				// Download did not fail
 				addLogEntry("Downloading file: " ~ newItemPath ~ " ... done", fileTransferNotifications());

--- a/src/sync.d
+++ b/src/sync.d
@@ -4543,15 +4543,13 @@ class SyncEngine {
 		// Function variables
 		bool downloadFailed = false;
 		bool downloadTransferCompleted = false;
+		bool applyAuthoritativeTimestamp = false;
 		string OneDriveFileXORHash;
 		string OneDriveFileSHA256Hash;
 		long jsonFileSize = 0;
 		Item databaseItem;
-		bool fileFoundInDB = false;
 		bool canonicalFileExistedBeforeDownload = false;
-		bool preserveCanonicalAsSafeBackup = false;
 		string canonicalHashBeforeDownload;
-		string completedDownloadPath;
 		SysTime itemModifiedTime;
 		string itemModifiedTimestamp;
 
@@ -4603,9 +4601,6 @@ class SyncEngine {
 			// transfer is still detected and preserved at commit time.
 			canonicalHashBeforeDownload = computeQuickXorHash(newItemPath);
 		}
-		// All downloads remain staged until sync-layer validation and commit. This also
-		// protects a new-file download if a local file appears while transfer is in flight.
-		completedDownloadPath = newItemPath ~ ".partial";
 
 		// Is the item reported as Malware ?
 		if (isMalware(onedriveJSONItem)){
@@ -4663,7 +4658,6 @@ class SyncEngine {
 			if (canonicalFileExistedBeforeDownload && !ignoreDataPreservationCheck) {
 				foreach (driveId; onlineDriveDetails.keys) {
 					if (itemDB.selectByPath(newItemPath, driveId, databaseItem)) {
-						fileFoundInDB = true;
 						break;
 					}
 				}
@@ -4696,8 +4690,179 @@ class SyncEngine {
 				if (!dryRun) {
 					// Attempt to download the file as there is enough free space locally
 					OneDriveApi downloadFileOneDriveApiInstance;
-					bool hasDownloadedStreamedQuickXorHash = false;
-					string downloadedStreamedQuickXorHash;
+
+					// The download subsystem owns the .partial file and final canonical promotion.
+					// This callback contains only reconciliation policy: once onedrive.d has a
+					// complete staging file, validate it and decide whether the current canonical file
+					// contains local data that must be preserved before replacement. The callback
+					// never receives or manipulates the transport staging pathname.
+					bool delegate(DownloadCommitInfo) prepareDownloadCommit = (DownloadCommitInfo downloadCommitInfo) {
+						bool canonicalExistsAtCommit = exists(newItemPath);
+						string canonicalHashAtCommit;
+						bool preserveCanonicalAsSafeBackup = false;
+
+						// Keep download integrity policy in sync.d, as in the original download
+						// architecture. onedrive.d supplies only facts about its completed private
+						// staging object and will not promote it unless this callback accepts it.
+						if (!disableDownloadValidation) {
+							string onlineFileHash;
+							string downloadedFileHash;
+							long downloadFileSize = downloadCommitInfo.size;
+
+							if (!OneDriveFileXORHash.empty) {
+								onlineFileHash = OneDriveFileXORHash;
+								if (downloadCommitInfo.hasStreamedQuickXorHash) {
+									if (debugLogging) {addLogEntry("Using stream calculated hash", ["debug"]);}
+								} else if (debugLogging) {
+									addLogEntry("Must generate file hash", ["debug"]);
+								}
+								downloadedFileHash = downloadCommitInfo.quickXorHash;
+							} else {
+								onlineFileHash = OneDriveFileSHA256Hash;
+								downloadedFileHash = downloadCommitInfo.sha256Hash;
+							}
+
+							if ((downloadFileSize == jsonFileSize) && (downloadedFileHash == onlineFileHash)) {
+								if (debugLogging) {addLogEntry("Downloaded file matches reported size and reported file hash", ["debug"]);}
+								applyAuthoritativeTimestamp = true;
+							} else {
+								bool downloadValueMismatch = false;
+
+								if (downloadFileSize != jsonFileSize) {
+									downloadValueMismatch = true;
+									if (debugLogging) {
+										addLogEntry("Actual file size on disk:   " ~ to!string(downloadFileSize), ["debug"]);
+										addLogEntry("OneDrive API reported size: " ~ to!string(jsonFileSize), ["debug"]);
+									}
+									if ((verboseLogging)||(debugLogging)) {
+										addLogEntry("WARNING: Download validation failed (size mismatch): " ~ newItemPath ~ " | expected=" ~ to!string(jsonFileSize) ~ " | actual=" ~ to!string(downloadFileSize), ["verbose"]);
+									} else {
+										addLogEntry("WARNING: File download size mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
+									}
+								}
+
+								if (downloadedFileHash != onlineFileHash) {
+									downloadValueMismatch = true;
+									if (debugLogging) {
+										addLogEntry("Actual local file hash:     " ~ downloadedFileHash, ["debug"]);
+										addLogEntry("OneDrive API reported hash: " ~ onlineFileHash, ["debug"]);
+									}
+
+									if ((verboseLogging)||(debugLogging)) {
+										addLogEntry("ERROR: Download validation failed (hash mismatch): " ~ newItemPath ~ " | expected=" ~ onlineFileHash ~ " | actual=" ~ downloadedFileHash, ["verbose"]);
+									} else {
+										addLogEntry("ERROR: File download hash mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
+									}
+								}
+
+								if (downloadValueMismatch && (toLower(extension(newItemPath)) == ".heic")) {
+									addLogEntry("DATA-LOSS: File downloaded has experienced data loss due to a Microsoft OneDrive API bug. DO NOT DELETE THIS FILE ONLINE: " ~ newItemPath, ["info", "notify"]);
+									if (verboseLogging) {addLogEntry("           Please read https://github.com/OneDrive/onedrive-api-docs/issues/1723 for more details.", ["verbose"]);}
+								}
+
+								if (appConfig.accountType == "documentLibrary") {
+									addLogEntry("INFO: It is most likely that a SharePoint OneDrive API issue is the root cause. Add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
+								} else {
+									addLogEntry("INFO: Potentially add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
+								}
+
+								if (downloadedFileHash != onlineFileHash) {
+									// Preserve the existing diagnostic while refusing the commit before
+									// the private staging file can replace the canonical destination.
+									addLogEntry("Removing local file " ~ newItemPath ~ " due to failed integrity checks");
+									return false;
+								}
+							}
+						} else {
+							if (debugLogging) {addLogEntry("Downloaded file validation disabled due to --disable-download-validation", ["debug"]);}
+							if (verboseLogging) {addLogEntry("WARNING: Skipping download integrity check for: " ~ newItemPath, ["verbose"]);}
+							applyAuthoritativeTimestamp = true;
+
+							// Preserve the existing AIP/SharePoint enrichment behaviour using facts
+							// calculated by the download layer before canonical promotion.
+							if (appConfig.accountType != "personal") {
+								string localFileHash = downloadCommitInfo.quickXorHash;
+								long downloadFileSize = downloadCommitInfo.size;
+
+								if ((OneDriveFileXORHash != localFileHash) && (jsonFileSize != downloadFileSize)) {
+									if (debugLogging) {
+										string aipLogMessage = format("POTENTIAL AIP FILE (Issue 3070) - Changing the source JSON data provided by Graph API to use actual on-disk values (quickXorHash,size): %s", newItemPath);
+										addLogEntry(aipLogMessage, ["debug"]);
+										addLogEntry(" - Online XOR   : " ~ to!string(OneDriveFileXORHash), ["debug"]);
+										addLogEntry(" - Online Size  : " ~ to!string(jsonFileSize), ["debug"]);
+										addLogEntry(" - Local XOR    : " ~ to!string(localFileHash), ["debug"]);
+										addLogEntry(" - Local Size   : " ~ to!string(downloadFileSize), ["debug"]);
+									}
+
+									onedriveJSONItem["file"]["hashes"]["quickXorHash"] = localFileHash;
+									onedriveJSONItem["size"] = downloadFileSize;
+								}
+							}
+						}
+
+						if (canonicalExistsAtCommit) {
+							canonicalHashAtCommit = computeQuickXorHash(newItemPath);
+							if (canonicalHashAtCommit.empty) {
+								addLogEntry("ERROR: Unable to verify canonical file at download commit; refusing replacement: " ~ newItemPath, ["error", "notify"]);
+								return false;
+							}
+						}
+
+						// If this workflow started as a replacement but the canonical file has
+						// disappeared, a genuine local removal/move may have occurred during the
+						// transfer. Do not silently recreate it and erase that local intent.
+						if (canonicalFileExistedBeforeDownload && !canonicalExistsAtCommit) {
+							addLogEntry("WARNING: Canonical file changed or disappeared while replacement was downloading; refusing validated replacement: " ~ newItemPath, ["info", "notify"]);
+							return false;
+						}
+
+						if (canonicalExistsAtCommit && ignoreDataPreservationCheck) {
+							// Post-upload enrichment normally replaces the file just uploaded without
+							// creating a safeBackup. Preserve only if a new local file appeared or the
+							// canonical bytes changed while the replacement download was in flight.
+							if (!canonicalFileExistedBeforeDownload) {
+								preserveCanonicalAsSafeBackup = true;
+							} else {
+								preserveCanonicalAsSafeBackup = canonicalHashBeforeDownload.empty ||
+									(canonicalHashAtCommit != canonicalHashBeforeDownload);
+							}
+
+							if (preserveCanonicalAsSafeBackup) {
+								addLogEntry("The canonical file changed while its post-upload replacement was downloading; preserving the new local data before replacement: " ~ newItemPath);
+							}
+						}
+
+						if (canonicalExistsAtCommit && !ignoreDataPreservationCheck) {
+							Item commitDatabaseItem;
+							bool commitFileFoundInDB = false;
+							foreach (driveId; onlineDriveDetails.keys) {
+								if (itemDB.selectByPath(newItemPath, driveId, commitDatabaseItem)) {
+									commitFileFoundInDB = true;
+									break;
+								}
+							}
+
+							Item incomingOnlineItem = makeItem(onedriveJSONItem);
+							bool localMatchesIncomingOnline = testFileHash(newItemPath, incomingOnlineItem);
+							bool localMatchesDatabaseBaseline = commitFileFoundInDB && testFileHash(newItemPath, commitDatabaseItem);
+
+							preserveCanonicalAsSafeBackup = !localMatchesIncomingOnline && !localMatchesDatabaseBaseline;
+							if (preserveCanonicalAsSafeBackup) {
+								addLogEntry("The local file to replace (" ~ newItemPath ~ ") contains local data that must be preserved before replacement.");
+							} else if (localMatchesIncomingOnline && debugLogging) {
+								addLogEntry("Canonical file content already matches the validated OneDrive replacement; no safeBackup is required", ["debug"]);
+							}
+						}
+
+						if (preserveCanonicalAsSafeBackup) {
+							string backupPath;
+							if (!safeBackupPreserveForReplacement(newItemPath, bypassDataPreservation, backupPath)) {
+								return false;
+							}
+						}
+
+						return true;
+					};
 
 					try {
 						// Initialise API instance
@@ -4711,17 +4876,30 @@ class SyncEngine {
 							}
 						}
 
-						// Perform the download with any applicable resume offset, always deferring
-						// Curl-layer promotion so the completed .partial is validated before any
-						// canonical pathname can be created or replaced.
+						// Perform the download with any applicable resume offset. onedrive.d and
+						// curlEngine.d own the complete staging lifecycle; a non-null response means
+						// the validated staging file has already been promoted to newItemPath.
 						downloadTransferStartTime = Clock.currTime();
-						auto downloadResponse = downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, true);
+						auto downloadResponse = downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, prepareDownloadCommit);
 						downloadTransferEndTime = Clock.currTime();
 						if (downloadResponse !is null) {
-							// Every download remains at .partial until sync-layer validation and commit.
-							downloadTransferCompleted = false;
-							hasDownloadedStreamedQuickXorHash = downloadResponse.hasStreamedQuickXorHash;
-							downloadedStreamedQuickXorHash = downloadResponse.streamedQuickXorHash;
+							// A non-null response means the private staging file passed sync.d's
+							// integrity/preservation policy and was promoted by onedrive.d.
+							downloadTransferCompleted = true;
+							if (exists(newItemPath)) {
+								if (applyAuthoritativeTimestamp) {
+									setLocalPathTimestamp(dryRun, newItemPath, itemModifiedTime);
+								}
+							} else {
+								if (!exitHandlerTriggered) {
+									if ((verboseLogging)||(debugLogging)) {
+										addLogEntry("ERROR: Download failed (file not present after download): " ~ newItemPath ~ " | expectedSize=" ~ to!string(jsonFileSize) ~ " | resumeOffset=" ~ to!string(resumeOffset), ["verbose"]);
+									} else {
+										addLogEntry("ERROR: File failed to download. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
+									}
+								}
+								downloadFailed = true;
+							}
 						} else {
 							if (debugLogging) {
 								addLogEntry("downloadResponse is null", ["debug"]);
@@ -4730,8 +4908,8 @@ class SyncEngine {
 						}
 
 					} catch (OneDriveException exception) {
-						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, true); generated a OneDriveException", ["debug"]);}
-						
+						if (debugLogging) {addLogEntry("downloadFileOneDriveApiInstance.downloadById(downloadDriveId, downloadItemId, newItemPath, jsonFileSize, onlineHash, resumeOffset, prepareDownloadCommit); generated a OneDriveException", ["debug"]);}
+
 						// Any propagated API exception means that the requested online version was
 						// not downloaded. A pre-existing final path, if present, is still the last
 						// successfully applied local version and must not be validated as this one.
@@ -4768,319 +4946,11 @@ class SyncEngine {
 						downloadFileOneDriveApiInstance.releaseCurlEngine();
 						downloadFileOneDriveApiInstance = null;
 					}
-				
-					// Validate only when the requested online version was downloaded. A failed
-					// transfer may deliberately leave an older final file untouched.
-					if (!downloadFailed && exists(completedDownloadPath)) {
-						// When downloading some files from SharePoint, the OneDrive API reports one file size, 
-						// but the SharePoint HTTP Server sends a totally different byte count for the same file
-						// we have implemented --disable-download-validation to disable these checks
-
-						// Regardless of --disable-download-validation we still need to set the file timestamp correctly.
-						// itemModifiedTime was validated before the transfer began so this operation never
-						// needs to manufacture a replacement timestamp.
-
-						// Did the user configure --disable-download-validation ?
-						if (!disableDownloadValidation) {
-							// A 'file' was downloaded - does what we downloaded = reported jsonFileSize or if there is some sort of funky local disk compression going on
-							// Does the file hash OneDrive reports match what we have locally?
-							string onlineFileHash;
-							string downloadedFileHash;
-							long downloadFileSize = getSize(completedDownloadPath);
-
-							if (!OneDriveFileXORHash.empty) {
-								onlineFileHash = OneDriveFileXORHash;
-								// Use the streamed QuickXorHash from the completed download when available; otherwise calculate the QuickXorHash for this file
-								if (hasDownloadedStreamedQuickXorHash) {
-									if (debugLogging) {
-										addLogEntry("Using stream calculated hash", ["debug"]);
-									}
-									downloadedFileHash = downloadedStreamedQuickXorHash;
-								} else {
-									if (debugLogging) {
-										addLogEntry("Must generate file hash", ["debug"]);
-									}
-									downloadedFileHash = computeQuickXorHash(completedDownloadPath);
-								}
-							} else {
-								onlineFileHash = OneDriveFileSHA256Hash;
-								// Fallback: Calculate the SHA256 Hash for this file
-								downloadedFileHash = computeSHA256Hash(completedDownloadPath);
-							}
-
-							if ((downloadFileSize == jsonFileSize) && (downloadedFileHash == onlineFileHash)) {
-								// Downloaded file matches size and hash
-								if (debugLogging) {addLogEntry("Downloaded file matches reported size and reported file hash", ["debug"]);}
-
-								// Set the timestamp, logging and error handling done within function
-								setLocalPathTimestamp(dryRun, completedDownloadPath, itemModifiedTime);
-							} else {
-								// QuickXorHash in this client incorporates the file length into the final digest, so a size mismatch would be expected to also produce a hash mismatch.
-								// However, QuickXorHash is not collision-resistant, so we treat the hash mismatch as the definitive integrity failure condition and log size mismatches
-								// as advisory
-
-								// Downloaded file does not match size or hash .. which is it?
-								bool downloadValueMismatch = false;
-
-								// Size difference between what was written to disk and what the API reported as the file size
-								if (downloadFileSize != jsonFileSize) {
-									// downloaded file size does not match
-									downloadValueMismatch = true;
-									if (debugLogging) {
-										addLogEntry("Actual file size on disk:   " ~ to!string(downloadFileSize), ["debug"]);
-										addLogEntry("OneDrive API reported size: " ~ to!string(jsonFileSize), ["debug"]);
-									}
-									if ((verboseLogging)||(debugLogging)) {
-										// verbose or debug message
-										addLogEntry("WARNING: Download validation failed (size mismatch): " ~ newItemPath ~ " | expected=" ~ to!string(jsonFileSize) ~ " | actual=" ~ to!string(downloadFileSize), ["verbose"]);
-									} else {
-										// non-verbose message
-										addLogEntry("WARNING: File download size mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
-									}
-								}
-
-								// Hash difference between what was written to disk and then QuickXOR calculated and what the API reported as the file hash online
-								if (downloadedFileHash != onlineFileHash) {
-									// downloaded file hash does not match
-									downloadValueMismatch = true;
-									if (debugLogging) {
-										addLogEntry("Actual local file hash:     " ~ downloadedFileHash, ["debug"]);
-										addLogEntry("OneDrive API reported hash: " ~ onlineFileHash, ["debug"]);
-									}
-
-									if ((verboseLogging)||(debugLogging)) {
-										// verbose or debug message
-										addLogEntry("ERROR: Download validation failed (hash mismatch): " ~ newItemPath ~ " | expected=" ~ onlineFileHash ~ " | actual=" ~ downloadedFileHash, ["verbose"]);
-									} else {
-										// non-verbose message
-										addLogEntry("ERROR: File download hash mismatch. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
-									}
-								}
-
-								// .heic data loss check
-								// - https://github.com/abraunegg/onedrive/issues/2471
-								// - https://github.com/OneDrive/onedrive-api-docs/issues/1532
-								// - https://github.com/OneDrive/onedrive-api-docs/issues/1723
-								if (downloadValueMismatch && (toLower(extension(newItemPath)) == ".heic")) {
-									// Need to display a message to the user that they have experienced data loss
-									addLogEntry("DATA-LOSS: File downloaded has experienced data loss due to a Microsoft OneDrive API bug. DO NOT DELETE THIS FILE ONLINE: " ~ newItemPath, ["info", "notify"]);
-									if (verboseLogging) {addLogEntry("           Please read https://github.com/OneDrive/onedrive-api-docs/issues/1723 for more details.", ["verbose"]);}
-								}
-
-								// Add some workaround messaging for SharePoint
-								if (appConfig.accountType == "documentLibrary"){
-									// It has been seen where SharePoint / OneDrive API reports one size via the JSON
-									// but the content length and file size written to disk is totally different - example:
-									// From JSON:         "size": 17133
-									// From HTTPS Server: < Content-Length: 19340
-									// with no logical reason for the difference, except for a 302 redirect before file download
-									addLogEntry("INFO: It is most likely that a SharePoint OneDrive API issue is the root cause. Add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
-								} else {
-									// other account types
-									addLogEntry("INFO: Potentially add --disable-download-validation to work around this issue but downloaded data integrity cannot be guaranteed.");
-								}
-
-								// If the computed hash does not equal provided online hash, consider this a failed download
-								if (downloadedFileHash != onlineFileHash) {
-									// We do not want this local file to remain on the local file system as it failed the integrity checks
-									addLogEntry("Removing local file " ~ newItemPath ~ " due to failed integrity checks");
-									if (!dryRun) {
-										safeRemove(completedDownloadPath);
-									}
-
-									// Was this item previously in-sync with the local system?
-									// We previously searched for the file in the DB, we need to use that record
-									if (fileFoundInDB && !exists(newItemPath)) {
-										// Purge DB record only when no canonical local file remains
-										// In a --dry-run scenario, this is being done against a DB copy
-										addLogEntry("Removing DB record due to failed integrity checks");
-										itemDB.deleteById(databaseItem.driveId, databaseItem.id);
-									}
-
-									// Flag that the download failed
-									downloadFailed = true;
-								}
-							}
-						} else {
-							// Download validation checks were disabled
-							if (debugLogging) {addLogEntry("Downloaded file validation disabled due to --disable-download-validation", ["debug"]);}
-							if (verboseLogging) {addLogEntry("WARNING: Skipping download integrity check for: " ~ newItemPath, ["verbose"]);}
-
-							// Whilst the download integrity checks were disabled, we still have to set the correct timestamp on the file
-							// Set the timestamp, logging and error handling done within function
-							setLocalPathTimestamp(dryRun, completedDownloadPath, itemModifiedTime);
-
-							// Azure Information Protection (AIP) protected files potentially have missing data and/or inconsistent data
-							if (appConfig.accountType != "personal") {
-								// AIP Protected Files cause issues here, as the online size & hash are not what has been downloaded
-								// There is ZERO way to determine if this is an AIP protected file either from the JSON data
-
-								// Calculate the local file hash and get the local file size
-								string localFileHash = computeQuickXorHash(completedDownloadPath);
-								long downloadFileSize = getSize(completedDownloadPath);
-
-								if ((OneDriveFileXORHash != localFileHash) && (jsonFileSize != downloadFileSize)) {
-									// High potential to be an AIP protected file given the following scenario
-									// Business | SharePoint Account Type (not a personal account)
-									// --disable-download-validation is being used .. meaning the user has specifically configured this due the Microsoft SharePoint Enrichment Feature (bug)
-									// The file downloaded but the XOR hash and file size locally is not as per the provided JSON - both are different
-									//
-									// Update the 'onedriveJSONItem' JSON data with the local values .....
-									if (debugLogging) {
-										string aipLogMessage = format("POTENTIAL AIP FILE (Issue 3070) - Changing the source JSON data provided by Graph API to use actual on-disk values (quickXorHash,size): %s", newItemPath);
-										addLogEntry(aipLogMessage, ["debug"]);
-										addLogEntry(" - Online XOR   : " ~ to!string(OneDriveFileXORHash), ["debug"]);
-										addLogEntry(" - Online Size  : " ~ to!string(jsonFileSize), ["debug"]);
-										addLogEntry(" - Local XOR    : " ~ to!string(computeQuickXorHash(completedDownloadPath)), ["debug"]);
-										addLogEntry(" - Local Size   : " ~ to!string(getSize(completedDownloadPath)), ["debug"]);
-									}
-
-									// Make the change in the JSON using local values
-									onedriveJSONItem["file"]["hashes"]["quickXorHash"] = localFileHash;
-									onedriveJSONItem["size"] = downloadFileSize;
-								}
-							}
-						}	// end of (!disableDownloadValidation)
-					} else if (!downloadFailed) {
-						// Was exitHandlerTriggered flagged
-						if (!exitHandlerTriggered) {
-							// File does not exist locally ... so the download failed
-							if ((verboseLogging)||(debugLogging)) {
-								// If we are doing verbose logging,
-								addLogEntry("ERROR: Download failed (file not present after download): " ~ newItemPath ~ " | expectedSize=" ~ to!string(jsonFileSize) ~ " | resumeOffset=" ~ to!string(resumeOffset), ["verbose"]);
-							} else {
-								addLogEntry("ERROR: File failed to download. Re-run with --verbose for additional diagnostic information to assist with troubleshooting.");
-							}
-
-							// Was this item previously in-sync with the local system?
-							// We previously searched for the file in the DB, we need to use that record
-							if (fileFoundInDB && !exists(newItemPath)) {
-								// Purge DB record only when no canonical local file remains
-								// In a --dry-run scenario, this is being done against a DB copy
-								addLogEntry("Removing existing DB record due to failed file download.");
-								itemDB.deleteById(databaseItem.driveId, databaseItem.id);
-							}
-						} else {
-							// exitHandlerTriggered triggered
-							if (appConfig.getValueBool("force_xfer_abort")) {
-								// this is force abort
-								if ((verboseLogging)||(debugLogging)) {
-									// add log message
-									addLogEntry("Download aborted: " ~ newItemPath, ["verbose"]);
-
-								}
-							}
-						}
-
-						// Flag that the download failed
-						downloadFailed = true;
-					}
 				}
 			}
 
-			// The validated online bytes are still in <path>.partial. Commit them only
-			// after re-evaluating the canonical path at the last possible moment. This
-			// catches local edits (or a newly-created same-name file) made while the
-			// network transfer was in flight.
-			if (!downloadFailed && !dryRun) {
-				bool canonicalExistsAtCommit = exists(newItemPath);
-				string canonicalHashAtCommit;
-
-				// Snapshot the canonical bytes at the commit boundary. A second check
-				// immediately before promotion prevents an edit made while preservation
-				// is being prepared from being overwritten by the validated download.
-				if (canonicalExistsAtCommit) {
-					canonicalHashAtCommit = computeQuickXorHash(newItemPath);
-					if (canonicalHashAtCommit.empty) {
-						addLogEntry("ERROR: Unable to verify canonical file at download commit; refusing replacement: " ~ newItemPath, ["error", "notify"]);
-						safeRemove(completedDownloadPath);
-						downloadFailed = true;
-					}
-				}
-
-				// If this workflow started as a replacement but the canonical file has
-				// disappeared, a genuine local removal/move may have occurred during the
-				// download. Do not silently recreate it and erase that local intent.
-				if (canonicalFileExistedBeforeDownload && !canonicalExistsAtCommit) {
-					addLogEntry("WARNING: Canonical file changed or disappeared while replacement was downloading; discarding staged replacement: " ~ newItemPath, ["info", "notify"]);
-					safeRemove(completedDownloadPath);
-					downloadFailed = true;
-				}
-
-				if (!downloadFailed && canonicalExistsAtCommit && ignoreDataPreservationCheck) {
-					// The caller expects replacement of the file it just uploaded, so do not
-					// create a safeBackup for that known difference. However, if the canonical
-					// bytes changed again while this download was running, that is new local
-					// data and must be preserved. A file that appeared unexpectedly is treated
-					// the same way.
-					if (!canonicalFileExistedBeforeDownload) {
-						preserveCanonicalAsSafeBackup = true;
-					} else {
-						preserveCanonicalAsSafeBackup = canonicalHashBeforeDownload.empty || (canonicalHashAtCommit != canonicalHashBeforeDownload);
-					}
-
-					if (preserveCanonicalAsSafeBackup) {
-						addLogEntry("The canonical file changed while its post-upload replacement was downloading; preserving the new local data before replacement: " ~ newItemPath);
-					}
-				}
-
-				if (!downloadFailed && canonicalExistsAtCommit && !ignoreDataPreservationCheck) {
-					Item commitDatabaseItem;
-					bool commitFileFoundInDB = false;
-					foreach (driveId; onlineDriveDetails.keys) {
-						if (itemDB.selectByPath(newItemPath, driveId, commitDatabaseItem)) {
-							commitFileFoundInDB = true;
-							break;
-						}
-					}
-
-					Item incomingOnlineItem = makeItem(onedriveJSONItem);
-					bool localMatchesIncomingOnline = testFileHash(newItemPath, incomingOnlineItem);
-					bool localMatchesDatabaseBaseline = commitFileFoundInDB && testFileHash(newItemPath, commitDatabaseItem);
-
-					preserveCanonicalAsSafeBackup = !localMatchesIncomingOnline && !localMatchesDatabaseBaseline;
-					if (preserveCanonicalAsSafeBackup) {
-						addLogEntry("The local file to replace (" ~ newItemPath ~ ") contains local data that must be preserved before replacement.");
-					} else if (localMatchesIncomingOnline && debugLogging) {
-						addLogEntry("Canonical file content already matches the validated OneDrive replacement; no safeBackup is required", ["debug"]);
-					}
-				}
-
-				if (!downloadFailed && preserveCanonicalAsSafeBackup) {
-					string backupPath;
-					if (!safeBackupPreserveForReplacement(newItemPath, bypassDataPreservation, backupPath)) {
-						safeRemove(completedDownloadPath);
-						downloadFailed = true;
-					}
-				}
-
-				if (!downloadFailed) {
-					// Recheck the canonical path after any safeBackup preservation. If its existence or
-					// bytes changed while this commit was being prepared, local intent wins and
-					// the staged online replacement is discarded for a later reconciliation.
-					bool canonicalExistsBeforePromotion = exists(newItemPath);
-					bool canonicalChangedBeforePromotion = canonicalExistsBeforePromotion != canonicalExistsAtCommit;
-					if (!canonicalChangedBeforePromotion && canonicalExistsBeforePromotion) {
-						string canonicalHashBeforePromotion = computeQuickXorHash(newItemPath);
-						canonicalChangedBeforePromotion = canonicalHashBeforePromotion.empty || (canonicalHashBeforePromotion != canonicalHashAtCommit);
-					}
-
-					if (canonicalChangedBeforePromotion) {
-						addLogEntry("WARNING: Canonical file changed while the validated replacement was being committed; discarding staged replacement: " ~ newItemPath, ["info", "notify"]);
-						safeRemove(completedDownloadPath);
-						downloadFailed = true;
-					} else if (safeRename(completedDownloadPath, newItemPath, false)) {
-						downloadTransferCompleted = true;
-					} else {
-						addLogEntry("ERROR: Validated download could not be promoted; retaining any existing canonical file: " ~ newItemPath, ["error", "notify"]);
-						safeRemove(completedDownloadPath);
-						downloadFailed = true;
-					}
-				}
-			}
-
-			// File should have been downloaded and, for replacements, committed to
-			// the canonical path.
+			// A successful downloadById() call has already completed the private
+			// .partial -> canonical transaction inside the download subsystem.
 			if (!downloadFailed) {
 				// Download did not fail
 				addLogEntry("Downloading file: " ~ newItemPath ~ " ... done", fileTransferNotifications());
@@ -5135,9 +5005,8 @@ class SyncEngine {
 			}
 		}
 
-		// Publish final-path effects only after the completed download has been
-		// promoted into the canonical path. For replacements this happens here in
-		// the sync layer only after validation and any required safeBackup succeeds.
+		// Publish final-path effects only after the download subsystem completed the
+		// transfer and promoted its private staging file into the canonical path.
 		if (!dryRun && downloadTransferCompleted) {
 			notifyExpectedLocalFileDownload(newItemPath, downloadFailed && !exists(newItemPath));
 		}


### PR DESCRIPTION
This pull request fixes a download concurrency race where multiple parallel download workers targeting the same canonical file could simultaneously operate on the same deterministic:

```text
<canonical-path>.partial
```

staging file.

Under sustained multi-client synchronisation activity this could result in one worker successfully promoting the shared `.partial` file while another worker subsequently attempted to inspect or operate on the same staging pathname and reported:

```text
ERROR: Download failed (file not present after download)
```

More importantly, multiple workers could have the same staging file open at the same time, creating a genuine download-integrity risk rather than merely producing a false failure message.

The issue was reproduced during four-client soak testing across:

```text
Ubuntu
Fedora
FreeBSD
OpenBSD
```

and was observed with both Personal and Business accounts.

## Root Cause

The download lifecycle had gradually moved away from the ownership model used prior to the transactional replacement changes.

The effective download flow had become:

```text
sync.d
    |
    +--> downloadById(... deferFinalRename=true)
            |
            +--> onedrive.d / curlEngine.d
                    |
                    +--> write <canonical>.partial
                    |
                    +--> return without final promotion
    |
    +--> inspect <canonical>.partial
    |
    +--> perform integrity validation
    |
    +--> perform safeBackup / replacement decisions
    |
    +--> safeRename(
            <canonical>.partial,
            <canonical>
         )
```

This meant that:

* the transport layer created and wrote the `.partial` file;
* `sync.d` later became responsible for inspecting and promoting it;
* multiple download workers could independently believe they owned the same deterministic staging pathname.

If two workers targeted the same canonical file, both could open:

```text
file.data.partial
```

at the same time.

One worker could then successfully rename that object to:

```text
file.data
```

while another worker was still processing the same staging object.

This explains both the false:

```text
file not present after download
```

failure and the more serious possibility of concurrent writes to a staging inode that had already become the canonical file.

## Changes

### Restore download staging ownership to the download subsystem

The `.partial` lifecycle is once again exclusively owned by:

```text
onedrive.d
    ->
curlEngine.d
```

`sync.d` no longer:

* constructs the `.partial` pathname;
* checks for the existence of `.partial`;
* removes `.partial`;
* renames `.partial` to the canonical pathname.

The `deferFinalRename` download behaviour has been removed.

A successful `downloadById()` now once again means that the download subsystem has completed the full staging transaction and produced the canonical file.

### Serialize downloads targeting the same canonical path

A per-canonical-path download transaction lock has been added inside `onedrive.d`.

This ensures that two parallel reconciliation workers cannot simultaneously:

```text
open
write
resume
inspect
remove
or promote
```

the same deterministic `.partial` staging file.

This protection is deliberately implemented inside the download subsystem rather than in `sync.d`.

This change does **not** deduplicate the download queue.

If duplicate download requests are scheduled, they may still both execute, but they cannot concurrently own the same staging transaction.

Investigation of why duplicate effective download candidates can be scheduled remains separate from this fix.

## Download integrity boundary

The existing download-integrity policy remains in `sync.d`.

Because `onedrive.d` exclusively owns the private staging file, it generates neutral facts describing the completed transfer:

```text
actual file size
streamed QuickXorHash, when available
generated QuickXorHash, when required
generated SHA256 hash, when required
```

Those values are supplied back to `sync.d` for evaluation.

`onedrive.d` does **not** decide whether the downloaded content matches Microsoft Graph metadata.

The responsibility boundary is therefore:

```text
curlEngine.d
    |
    | HTTP transfer
    | streamed QuickXorHash
    v

onedrive.d
    |
    | owns private .partial staging object
    | generates required local size/hash facts
    v

sync.d
    |
    | compares downloaded facts with Graph metadata
    | performs integrity policy
    | performs SharePoint/AIP handling
    | performs HEIC data-loss handling
    | evaluates --disable-download-validation
    | performs safeBackup preservation decisions
    v

onedrive.d
    |
    | accepted download
    | final canonical-state recheck
    | .partial -> canonical
    v

sync.d
    |
    | authoritative Microsoft timestamp
    | database reconciliation
    | xattr handling
    | monitor expected-effect notification
```

This retains the established distinction between:

```text
onedrive.d:
    "What was downloaded?"

sync.d:
    "Is what was downloaded valid for this Graph DriveItem?"
```

## Data-preservation behaviour retained

The transactional safeBackup protections introduced by earlier work remain in place.

Before an existing canonical file is replaced:

* `sync.d` evaluates whether the local canonical object contains data that must be preserved;
* any required safeBackup is created before replacement;
* `onedrive.d` snapshots and rechecks the canonical file around the inspection callback;
* if the canonical pathname or its content changes during the download/commit preparation window, the staged replacement is rejected rather than overwriting new local activity.

This retains the important guarantee that a validated online replacement must not silently overwrite unique local data.

## HTTP download safety retained

The HTTP-response protections introduced previously are also retained.

An unsuccessful or non-content-bearing HTTP response cannot be promoted into the canonical pathname.

The download subsystem only reaches canonical promotion after the HTTP transfer has been accepted.

## Existing download validation behaviour retained

The existing `sync.d` behaviour remains responsible for:

* streamed QuickXorHash versus generated QuickXorHash selection;
* SHA256 fallback;
* expected versus actual size comparison;
* expected versus actual hash comparison;
* treating hash mismatch as the definitive integrity failure;
* advisory size-mismatch handling;
* HEIC data-loss diagnostics;
* SharePoint download-validation workaround messaging;
* Azure Information Protection / SharePoint enrichment handling;
* `--disable-download-validation`;
* database handling following a failed download.

The existing explanatory comments documenting these behaviours have also been retained.

## Timestamp and reconciliation behaviour retained

The authoritative timestamp changes remain unchanged.

After successful canonical promotion, `sync.d` applies the Microsoft-provided:

```text
fileSystemInfo.lastModifiedDateTime
```

to the downloaded canonical file.

No fabricated local timestamp is introduced.

The monitor/drift expected-effect handling also remains intact:

```text
downloadById() succeeds
    ->
canonical file exists
    ->
downloadTransferCompleted = true
    ->
notifyExpectedLocalFileDownload(...)
```

## Validation

### End-to-end testing

The earlier implementation of this fix successfully completed the existing E2E suites, including:

```text
Business Account Testing
79 / 79 passed

SharePoint Account Testing
79 / 79 passed

Personal Account Testing
79 / 79 passed

Personal Account - 15 Character driveId
79 / 79 passed

Business Shared Folder Testing
5 / 5 passed

Personal Shared Folder Testing
3 / 3 passed
```

The final code revision also passed the Linux build and smoke-test workflows.

### Four-client soak testing

The final implementation:

```text
v2.5.11-34-g86ebe45
```

was tested simultaneously on:

```text
Ubuntu
Fedora
FreeBSD
OpenBSD
```

using a Business account with:

```text
force_session_upload = "true"
```

and four independent high-churn generators performing repeated:

```text
create
modify
move
modify
delete
```

operations.

The soak ran for approximately:

```text
3 hours 47 minutes
```

and completed approximately:

```text
33,313 successful downloads
```

across the four clients.

Results:

```text
Download failed (file not present after download) = 0

download promotion failures                       = 0

canonical-change race warnings                    = 0

canonical verification failures                   = 0
```

For comparison, the pre-fix control run reproduced the Issue #3853 failure:

```text
~17 minutes:
    failure already present on 3 of 4 clients

~33 minutes:
    failure present on all 4 clients

~3 hours 16 minutes:
    25 "file not present after download" failures
```

The fixed implementation therefore materially exceeded the historical reproduction window without reproducing the race.

A small number of integrity rejections were observed during forced session-upload churn where Microsoft Graph temporarily reported:

```text
size = 0
quickXorHash = AAAAAAAAAAAAAAAAAAAAAAAAAAA=
```

for newly uploaded non-zero files.

In each case the staging download was correctly rejected by `sync.d`, was not promoted by `onedrive.d`, and succeeded on the subsequent retry once current Graph metadata became available.

This also validates the restored integrity-inspection boundary.

## Result

The download transaction is now self-contained again:

```text
request download
    ->
serialize canonical-path transaction
    ->
write private .partial
    ->
validate HTTP response
    ->
generate staging facts
    ->
sync.d performs integrity/preservation inspection
    ->
recheck canonical state
    ->
promote .partial -> canonical
    ->
return success
```

The sync layer no longer owns or manipulates the transport staging pathname, and concurrent workers can no longer share ownership of the same deterministic `.partial` transaction.
