### PR TITLE
Quiet expected HTTP 404 errors during timestamp reconciliation

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -6157,9 +6157,14 @@ class SyncEngine {
 				}
 			}
 		} catch (OneDriveException exception) {
-			// Handle a 409 - ETag does not match current item's value
-			// Handle a 412 - A precondition provided in the request (such as an if-match header) does not match the resource's current state.
-			if ((exception.httpStatusCode == 409) || (exception.httpStatusCode == 412)) {
+			// A 404 can legitimately occur when an item disappears online after it was
+			// selected for timestamp reconciliation. The requested metadata update is
+			// no longer applicable; leave current state for normal reconciliation.
+			if (exception.httpStatusCode == 404) {
+				if (debugLogging) {addLogEntry("Remote item no longer exists while attempting to update its modified time; skipping timestamp correction", ["debug"]);}
+			} else if ((exception.httpStatusCode == 409) || (exception.httpStatusCode == 412)) {
+				// Handle a 409 - ETag does not match current item's value
+				// Handle a 412 - A precondition provided in the request (such as an if-match header) does not match the resource's current state.
 				// Handle the 409
 				if (exception.httpStatusCode == 409) {
 					// OneDrive threw a 412 error


### PR DESCRIPTION
Avoid presenting an expected Microsoft OneDrive API HTTP 404 (`itemNotFound`) response as an application error when updating an item's remote modified timestamp.

During reconciliation, `uploadLastModifiedTime()` may attempt to update the timestamp of an item that existed when it was evaluated but has subsequently been moved or deleted online by another client. In this situation, Microsoft Graph returns HTTP 404 because the item is no longer available at the original item ID.

This is a normal reconciliation race and does not require user intervention.

Previously, the 404 was passed to `displayOneDriveErrorMessage()`, producing output such as:

```text
ERROR: Microsoft OneDrive API returned an error with the following message:
  Error Message:       HTTP request returned status code 404 (Not Found)
  Error Reason:        The resource could not be found.
  Error Code:          itemNotFound
  Calling Function:    syncEngine.uploadLastModifiedTime()
```

This can incorrectly suggest that the client has encountered an actionable synchronisation error.

## Change

When `uploadLastModifiedTime()` receives HTTP 404:

* Do not display the generic Microsoft OneDrive API error block.
* Treat the timestamp update as no longer applicable.
* Emit an informational message only when debug logging is enabled.
* Leave the current state for normal reconciliation processing.

Handling of HTTP 409, HTTP 412, transient HTTP errors, and all other Microsoft OneDrive API errors remains unchanged.

## Scope

This change is intentionally limited to `syncEngine.uploadLastModifiedTime()`.

It does not introduce global suppression of HTTP 404 responses and does not alter HTTP 404 handling for file downloads or other Microsoft OneDrive API operations.