### PR TITLE
Improve HTTP 404 messaging during file downloads

### DIFF
--- a/src/sync.d
+++ b/src/sync.d
@@ -5088,8 +5088,14 @@ class SyncEngine {
 							// We attempted to download a file, that was shared with us, but this was shared with us as read-only and no download permission
 							addLogEntry("Unable to download this file as this was shared as read-only without download permission: " ~ newItemPath);
 							downloadFailed = true;
+						} else if (exception.httpStatusCode == 404) {
+							// The online item is no longer available at the time of download. This can legitimately
+							// occur when an item is moved or deleted online after it was queued for download. Keep
+							// the existing failed-download and reconciliation behaviour, but avoid presenting this
+							// expected race as a Microsoft OneDrive API application error.
+							addLogEntry("The online item is no longer available at the time of download; continuing reconciliation: " ~ newItemPath);
 						} else {
-							// Default operation if not a 403 error
+							// Default operation if not a 403 or 404 error
 							// - 408,429,503,504 errors are handled as a retry within downloadFileOneDriveApiInstance
 							// Display what the error is
 							displayOneDriveErrorMessage(exception.msg, thisFunctionName);


### PR DESCRIPTION
Improve how an HTTP 404 (`itemNotFound`) response from Microsoft OneDrive is presented when an item disappears before it can be downloaded.

During normal reconciliation, an item may be queued for download and subsequently be moved or deleted online before the download request is performed. Microsoft Graph then returns HTTP 404 because the previously identified item is no longer available.

Previously, `syncEngine.downloadFileItem()` passed this response to the generic Microsoft OneDrive API error formatter, resulting in output such as:

```text id="h1mbz8"
ERROR: Microsoft OneDrive API returned an error with the following message:
  Error Message:       HTTP request returned status code 404 (Not Found)
  Error Reason:        The resource could not be found.
  Error Code:          itemNotFound
  Calling Function:    syncEngine.downloadFileItem()
```

While the download attempt has failed, this can be a normal reconciliation race and the generic API error output can incorrectly suggest that user intervention is required.

## Change

When `syncEngine.downloadFileItem()` receives HTTP 404, replace the generic Microsoft OneDrive API error block with a concise informational message:

```text id="xnyx8i"
The online item is no longer available at the time of download; continuing reconciliation: <path>
```

This is intentionally a presentation-only change.

The existing download failure and reconciliation behaviour remains unchanged, including:

* The download is still marked as failed.
* Existing `fileDownloadFailures` handling remains unchanged.
* Existing `syncFailures` handling remains unchanged.
* Existing database handling remains unchanged.
* Subsequent Microsoft OneDrive delta and reconciliation processing remains unchanged.
* Existing handling of all other HTTP errors remains unchanged.

## Scope

This change is intentionally limited to HTTP 404 handling within `syncEngine.downloadFileItem()`.

It does not globally suppress HTTP 404 responses or alter the application's existing download, database, retry, or reconciliation semantics.