### PR TITLE
Fix Bug #3862: Fix upload transient retry coverage and fragment retry logging

### DIFF
--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -3014,14 +3014,15 @@ class OneDriveApi {
 						if (debugLogging) {addLogEntry("Using Retry-After Value = " ~ to!string(thisBackOffInterval), ["debug"]);}
 						transientError = true;
 						break;
-					//  Transient errors
-					//	503 - Service Unavailable
+					//  Transient server errors
+					//  500 - Internal Server Error
+					//  502 - Bad Gateway
+					//  503 - Service Unavailable
 					//  504 - Gateway Timeout
-					case 503,504:
-						// The server, while acting as a proxy, did not receive a timely response from the upstream server it needed to access in attempting to complete the request
+					case 500,502,503,504:
 						auto errorArray = splitLines(exception.msg);
 						addLogEntry(to!string(errorArray[0]) ~ " when attempting to query the Microsoft Graph API Service - retrying applicable request in 30 seconds - Internal Thread ID: " ~ to!string(curlEngine.internalThreadId));
-						if (debugLogging) {addLogEntry("Thread sleeping for 30 seconds as the server did not receive a timely response from the upstream server it needed to access in attempting to complete the request", ["debug"]);}
+						if (debugLogging) {addLogEntry("Thread sleeping for 30 seconds before retrying transient Microsoft Graph API server error", ["debug"]);}
 						// Transient error - try again in 30 seconds
 						thisBackOffInterval = 30;
 						transientError = true;
@@ -3242,6 +3243,9 @@ class OneDriveApi {
 			case 406:
 				message = "Not Acceptable";
 				break;
+			case 408:
+				message = "Request Timeout";
+				break;
 			case 409:
 				message = "Conflict";
 				break;
@@ -3277,6 +3281,9 @@ class OneDriveApi {
 				break;
 			case 501:
 				message = "Not Implemented";
+				break;
+			case 502:
+				message = "Bad Gateway";
 				break;
 			case 503:
 				message = "Service Unavailable";

--- a/src/sync.d
+++ b/src/sync.d
@@ -11985,10 +11985,7 @@ class SyncEngine {
 					displayOneDriveErrorMessage(exception.msg, thisFunctionName);
 				}
 
-				// retry fragment upload in case error is transient
-				if (verboseLogging) {addLogEntry("Retrying fragment upload", ["verbose"]);}
-
-				// Retry fragment upload logic
+				// Retry fragment upload in case error is transient
 				try {
 					string effectiveRetryUploadURL;
 					string effectiveLocalPath;
@@ -12006,6 +12003,7 @@ class SyncEngine {
 						}
 
 						// retry the fragment upload
+						if (verboseLogging) {addLogEntry("Retrying fragment upload", ["verbose"]);}
 						uploadResponse = activeOneDriveApiInstance.uploadFragment(
 							effectiveRetryUploadURL,
 							effectiveLocalPath,


### PR DESCRIPTION
### Summary

Improve upload transient-error handling for both simple uploads and session uploads by extending the existing common HTTP retry handling and correcting misleading session-upload logging.

This change is intentionally narrow and does not introduce any new retry mechanism.

### Changes

The common OneDrive API error handler now treats the following server-side responses consistently as transient:

```text
500 Internal Server Error
502 Bad Gateway
503 Service Unavailable
504 Gateway Timeout
```

Previously, `503` and `504` were retried while `500` and `502` were returned immediately.

Because both simple uploads and session fragment uploads use the same common API wrapper, this provides consistent transient handling across both upload methods.

The HTTP status description handling has also been completed for:

```text
408 Request Timeout
502 Bad Gateway
```

### Session upload logging

`performSessionFileUpload()` historically contained:

```text
Retrying fragment upload
```

before determining whether an actual fragment retry would occur.

Repository history shows that this retry logic has existed for many years and has served several different recovery paths, so no functional retry behaviour has been removed or reworked.

Instead, the logging statement has simply been moved to immediately before the actual `uploadFragment()` retry call.

This ensures that:

```text
Retrying fragment upload
```

is only emitted when the client is genuinely about to retry a fragment.

### Scope

This change deliberately does not modify:

* upload-session replacement handling for HTTP 403 or 404
* the existing HTTP 416 upload-session behaviour
* upload offsets or `nextExpectedRanges` processing
* upload-session persistence or resume handling
* fragment retry architecture
* retry-count or backoff architecture
* any synthetic HTTP failure or fault-injection mechanisms

Ordinary transient HTTP retries remain owned by the common OneDrive API error handler, while upload-session-specific recovery remains within the session upload state machine.

### Validation

* Changes compile successfully against the current master codebase.
* Existing simple and session upload paths continue to use the established common HTTP/API retry architecture.
* The `sync.d` change is logging-only and does not alter operational retry behaviour.