### PR TITLE
Fix Bug #3865: Fix graphical authentication reporting success before OAuth token redemption completes

### DIFF
--- a/src/localAuth.d
+++ b/src/localAuth.d
@@ -30,10 +30,19 @@ struct LocalAuthResponse {
 
 private struct LocalAuthServerResult {
 	bool received = false;
+	bool browserResponsePending = false;
 	string responseUri = "";
 	string code = "";
 	string error = "";
 	string errorDescription = "";
+}
+
+private struct LocalAuthCompletionResult {
+	bool success = false;
+}
+
+private struct LocalAuthBrowserResponseResult {
+	bool sent = false;
 }
 
 private enum string LOCAL_AUTH_HOST = "127.0.0.1";
@@ -123,12 +132,16 @@ private string htmlEscape(string input) {
 		.replace("'", "&#39;");
 }
 
-private string buildBrowserResponse(LocalAuthServerResult result) {
-	bool success = !result.code.empty && result.error.empty;
-	string title = success ? "Authentication complete" : "Authentication failed";
-	string message = success ?
-		"Authentication is complete. You may close this browser window and return to the OneDrive Client for Linux." :
-		"Authentication did not complete successfully. Please return to the OneDrive Client for Linux.";
+private string buildBrowserResponse(LocalAuthServerResult result, bool authenticationSucceeded) {
+	string title = authenticationSucceeded ? "Authentication complete" : "Authentication failed";
+	string message;
+	if (authenticationSucceeded) {
+		message = "The OneDrive Client for Linux has been successfully authorised. You may close this browser window and return to the application.";
+	} else if (!result.error.empty) {
+		message = "Microsoft did not return a successful authorisation response. Please return to the OneDrive Client for Linux.";
+	} else {
+		message = "The OneDrive Client for Linux was unable to complete authentication with Microsoft. Please return to the application for additional information.";
+	}
 
 	string body = "<!doctype html><html><head><meta charset=\"utf-8\"><title>" ~ title ~ "</title></head>" ~
 		"<body><h1>" ~ title ~ "</h1><p>" ~ message ~ "</p>";
@@ -180,8 +193,8 @@ private void parseHttpRequestTarget(string requestTarget, ushort port, ref Local
 	result.errorDescription = queryValue(query, "error_description");
 }
 
-private void sendHttpResponse(Socket client, LocalAuthServerResult result) {
-	string body = buildBrowserResponse(result);
+private void sendHttpResponse(Socket client, LocalAuthServerResult result, bool authenticationSucceeded) {
+	string body = buildBrowserResponse(result, authenticationSucceeded);
 	string response = "HTTP/1.1 200 OK\r\n" ~
 		"Content-Type: text/html; charset=utf-8\r\n" ~
 		"Content-Length: " ~ to!string(body.length) ~ "\r\n" ~
@@ -204,6 +217,7 @@ private void localAuthServeOnce(Tid parentTid, ushort port) {
 	LocalAuthServerResult result;
 	Socket listener;
 	Socket client;
+	bool resultSent = false;
 
 	scope(exit) closeSocketNoThrow(client);
 	scope(exit) closeSocketNoThrow(listener);
@@ -236,20 +250,38 @@ private void localAuthServeOnce(Tid parentTid, ushort port) {
 			result.errorDescription = "The local authentication listener received an empty HTTP request.";
 		}
 
-		sendHttpResponse(client, result);
-	} catch (Exception e) {
-		result.received = true;
-		result.error = "local_auth_listener_error";
-		result.errorDescription = e.msg;
-	}
+		// Keep the browser connection open until the normal OneDrive authentication flow
+		// confirms whether token redemption and credential persistence actually succeeded.
+		result.browserResponsePending = true;
+		send(parentTid, result);
+		resultSent = true;
 
-	send(parentTid, result);
+		LocalAuthCompletionResult completionResult;
+		receive(
+			(LocalAuthCompletionResult finalResult) {
+				completionResult = finalResult;
+			}
+		);
+
+		sendHttpResponse(client, result, completionResult.success);
+		send(parentTid, LocalAuthBrowserResponseResult(true));
+	} catch (Exception e) {
+		if (!resultSent) {
+			result.received = true;
+			result.error = "local_auth_listener_error";
+			result.errorDescription = e.msg;
+			send(parentTid, result);
+		} else {
+			send(parentTid, LocalAuthBrowserResponseResult(false));
+		}
+	}
 }
 
-LocalAuthResponse performLocalBrowserAuth(string authorisationUrl, ushort port) {
+LocalAuthResponse performLocalBrowserAuth(string authorisationUrl, ushort port, bool delegate(string) completeAuthentication) {
 	LocalAuthResponse response;
 	Tid ownerTid = thisTid;
-	spawn(&localAuthServeOnce, ownerTid, port);
+	Tid serverTid = spawn(&localAuthServeOnce, ownerTid, port);
+	bool browserResponsePending = false;
 
 	// Give the listener a very small window to bind before launching the browser.
 	Thread.sleep(dur!"msecs"(200));
@@ -266,12 +298,36 @@ LocalAuthResponse performLocalBrowserAuth(string authorisationUrl, ushort port) 
 			response.code = decodeComponent(serverResult.code);
 			response.error = decodeComponent(serverResult.error);
 			response.errorDescription = decodeComponent(serverResult.errorDescription);
-			response.success = response.received && !response.code.empty && response.error.empty;
+			browserResponsePending = serverResult.browserResponsePending;
 		}
 	);
 
 	if (!gotMessage) {
 		response.error = "local_auth_timeout";
+		return response;
 	}
+
+	bool callbackSucceeded = response.received && !response.code.empty && response.error.empty;
+	if (callbackSucceeded) {
+		try {
+			response.success = completeAuthentication(response.code);
+		} catch (Exception e) {
+			addLogEntry("Local browser authentication could not be completed: " ~ e.msg);
+			response.success = false;
+		}
+	}
+
+	if (browserResponsePending) {
+		send(serverTid, LocalAuthCompletionResult(response.success));
+
+		receive(
+			(LocalAuthBrowserResponseResult browserResult) {
+				if (!browserResult.sent) {
+					addLogEntry("Unable to send the final authentication result to the browser.", ["debug"]);
+				}
+			}
+		);
+	}
+
 	return response;
 }

--- a/src/onedrive.d
+++ b/src/onedrive.d
@@ -931,11 +931,18 @@ class OneDriveApi {
 									addLogEntry();
 									addLogEntry("Opening the Microsoft authorisation URL in your default browser ...", ["consoleOnly"]);
 									addLogEntry("Waiting for the Microsoft authorisation response on " ~ redirectUrl, ["consoleOnly"]);
-									LocalAuthResponse localAuthResponse = performLocalBrowserAuth(url, localAuthPort);
+									LocalAuthResponse localAuthResponse = performLocalBrowserAuth(url, localAuthPort,
+										(string authCode) {
+											return redeemToken(authCode, true);
+										}
+									);
 									if (localAuthResponse.success) {
 										appConfig.applicationAuthoriseResponseURIReceived = true;
-										redeemToken(localAuthResponse.code);
 										return true;
+									}
+									if (localAuthResponse.received && !localAuthResponse.code.empty && localAuthResponse.error.empty) {
+										addLogEntry("Local browser authentication failed while completing OAuth token processing.", ["consoleOnly"]);
+										return false;
 									}
 									addLogEntry("Local browser authentication did not complete successfully; falling back to manual redirect URI entry.", ["consoleOnly"]);
 									if (!localAuthResponse.error.empty) {
@@ -1948,16 +1955,16 @@ class OneDriveApi {
 		(*headers)["Prefer"] = "Include-Feature=AddToOneDrive";
 	}
 
-	private void redeemToken(string authCode) {
+	private bool redeemToken(string authCode, bool returnOnAuthenticationFailure = false) {
 		string postData =
 			"client_id=" ~ clientId ~
 			"&redirect_uri=" ~ encodeComponent(redirectUrl) ~
 			"&code=" ~ encodeComponent(authCode) ~
 			"&grant_type=authorization_code";
-		acquireToken(postData.dup);
+		return acquireToken(postData.dup, returnOnAuthenticationFailure);
 	}
 
-	private void acquireToken(char[] postData) {
+	private bool acquireToken(char[] postData, bool returnOnAuthenticationFailure = false) {
 		// Set this function name
 		string thisFunctionName = format("%s.%s", strip(__MODULE__) , strip(getFunctionName!({})));
 
@@ -1979,14 +1986,23 @@ class OneDriveApi {
 				releaseCurlEngine();
 				// Handle an unauthorised client
 				handleClientUnauthorised(exception.httpStatusCode, exception.error);
+				if (returnOnAuthenticationFailure) {
+					return false;
+				}
 				// Must force exit here, allow logging to be done
 				forceExit();
 			} else {
 				if (exception.httpStatusCode >= 500) {
 					// There was a HTTP 5xx Server Side Error - retry
+					if (returnOnAuthenticationFailure) {
+						return acquireToken(postData, true);
+					}
 					acquireToken(postData);
 				} else {
 					displayOneDriveErrorMessage(exception.msg, thisFunctionName);
+					if (returnOnAuthenticationFailure) {
+						return false;
+					}
 				}
 			}
 		}
@@ -2019,6 +2035,9 @@ class OneDriveApi {
 						addLogEntry();
 						// force exit
 						releaseCurlEngine();
+						if (returnOnAuthenticationFailure) {
+							return false;
+						}
 						// Must force exit here, allow logging to be done
 						forceExit();
 					}
@@ -2026,27 +2045,47 @@ class OneDriveApi {
 			}
 
 			if ("access_token" in response) {
+				if (returnOnAuthenticationFailure) {
+					try {
+						if (strip(response["access_token"].str).empty || !("refresh_token" in response) || strip(response["refresh_token"].str).empty || !("expires_in" in response)) {
+							addLogEntry("Invalid authentication response from OneDrive. Required authentication token data was missing.");
+							return false;
+						}
+					} catch (JSONException exception) {
+						addLogEntry("Invalid authentication response from OneDrive. Required authentication token data could not be processed.");
+						return false;
+					}
+				}
 				// Process the response JSON
-				processAuthenticationJSON(response);
+				return processAuthenticationJSON(response);
 			} else {
 				// Release curl engine
 				releaseCurlEngine();
 				// Log error message
 				addLogEntry("\nInvalid authentication response from OneDrive. Please check the response uri\n");
+				if (returnOnAuthenticationFailure) {
+					return false;
+				}
 				// re-authorize
 				authorise();
+				return false;
 			}
 		} else {
 			// Release curl engine
 			releaseCurlEngine();
 			addLogEntry("Invalid response from the Microsoft Graph API. Unable to initialise OneDrive API instance.");
+			if (returnOnAuthenticationFailure) {
+				return false;
+			}
 			// Must force exit here, allow logging to be done
 			forceExit();
 		}
+
+		return false;
 	}
 
 	// Process the authentication JSON
-	private void processAuthenticationJSON(JSONValue response) {
+	private bool processAuthenticationJSON(JSONValue response) {
 		// Set this function name
 		string thisFunctionName = format("%s.%s", strip(__MODULE__) , strip(getFunctionName!({})));
 
@@ -2062,6 +2101,8 @@ class OneDriveApi {
 
 		// Debug this response
 		if (debugLogging) {addLogEntry("appConfig.accessTokenExpiration = " ~ to!string(appConfig.accessTokenExpiration), ["debug"]);}
+
+		bool authenticationStatePersisted = true;
 
 		if (!dryRun) {
 			// Update the refreshToken in appConfig so that we can reuse it
@@ -2087,8 +2128,11 @@ class OneDriveApi {
 			} catch (FileException exception) {
 				// display the error message
 				displayFileSystemErrorMessage(exception.msg, thisFunctionName, appConfig.refreshTokenFilePath);
+				authenticationStatePersisted = false;
 			}
 		}
+
+		return authenticationStatePersisted;
 	}
 
 	private void generateNewAccessToken() {


### PR DESCRIPTION
Fix graphical browser-based authentication reporting success before OAuth token redemption and credential persistence have actually completed.

Previously, the local loopback authentication listener treated receipt of a Microsoft OAuth authorisation code as successful authentication and immediately returned an `Authentication complete` page to the browser.

However, receipt of the authorisation code is only an intermediate stage of the authentication flow. The code must still be redeemed against Microsoft's token endpoint, the returned authentication data processed, and the required refresh token successfully persisted locally.

This meant that the browser could report:

```text
Authentication complete
```

even if the subsequent token redemption or credential persistence failed.

This change corrects that lifecycle/state-reporting behaviour.

## Changes

The graphical authentication flow now keeps the browser connection open until the normal OneDrive authentication code has completed the remaining OAuth transaction.

The flow is now effectively:

```text
Microsoft redirects to localhost with ?code=...
        |
        v
Local authentication listener parses callback
        |
        v
Authorisation code passed to existing authentication flow
        |
        v
OAuth token redemption
        |
        v
Authentication response processing
        |
        v
Refresh token persistence
        |
        v
Final authentication result returned to local listener
        |
        +--> success: Authentication complete
        |
        +--> failure: Authentication failed
```

The existing separation of responsibilities is retained:

* `localAuth.d` continues to manage the local loopback listener, browser callback parsing and browser HTTP response.
* `onedrive.d` continues to manage OAuth token redemption, authentication response processing and credential persistence.

No OAuth/token handling has been moved into the local authentication module.

## Authentication failure handling

For graphical authentication, token acquisition can now return a failure result to the local browser authentication flow rather than terminating the process before the browser can be given an accurate result.

This allows the browser to report authentication failure when, for example:

* the returned authorisation code is rejected during token redemption;
* the token endpoint returns an unsuccessful response;
* the returned authentication response cannot be processed into usable authentication state;
* required authentication credentials cannot be persisted locally.

Refresh-token persistence failures are also now propagated as authentication failure for this flow rather than being logged without affecting the final graphical authentication result.

## Behavioural scope

The change is deliberately limited to graphical browser authentication.

Existing behaviour is preserved for:

* manual/paste-the-redirect-URI authentication;
* normal refresh-token based access-token renewal;
* device authentication;
* Intune authentication;
* other non-GUI authentication paths.

Graphical `--reauth` uses the same corrected completion semantics as initial graphical authentication.

## Expected Result

The graphical browser authentication success page is now displayed only after the OneDrive Client for Linux has genuinely completed:

1. receipt of the Microsoft authorisation code;
2. successful OAuth token redemption;
3. authentication response processing;
4. required authentication-state creation;
5. successful refresh-token persistence.

If any required stage fails, the browser must not display `Authentication complete`.

## Validation

GUI validation will cover:

* successful initial graphical authentication;
* Microsoft callback cancellation/error;
* authorisation code received but rejected during token redemption;
* refresh-token persistence failure;
* graphical `--reauth`;
* manual/headless authentication regression testing;
* existing token refresh;
* graphical authentication using the `BROWSER` environment variable.

This change is intentionally narrow and does not include unrelated authentication refactoring or sponsorship functionality.