### PR TITLE
Fix Bug #3871: Gracefully handle unexpected DB column count to prevent client crash

### DIFF
--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -551,7 +551,8 @@ final class ItemDatabase {
 				auto res = p.exec();
 				
 				while (!res.empty) {
-					items ~= buildItem(res);
+					auto _bi = buildItem(res);
+					if (_bi.type != ItemType.none) items ~= _bi;
 					res.step();
 				}
 				return items;
@@ -575,6 +576,7 @@ final class ItemDatabase {
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);
+					if (item.type == ItemType.none) return false;
 					return true;
 				}
 			} catch (SqliteException exception) {
@@ -596,6 +598,7 @@ final class ItemDatabase {
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);
+					if (item.type == ItemType.none) return false;
 					return true;
 				}
 			} catch (SqliteException exception) {
@@ -617,6 +620,7 @@ final class ItemDatabase {
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);
+					if (item.type == ItemType.none) return false;
 					return true;
 				}
 			} catch (SqliteException exception) {
@@ -637,6 +641,7 @@ final class ItemDatabase {
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);
+					if (item.type == ItemType.none) return false;
 					return true;
 				}
 			} catch (SqliteException exception) {
@@ -658,6 +663,7 @@ final class ItemDatabase {
 				auto r = p.exec();
 				if (!r.empty) {
 					item = buildItem(r);
+					if (item.type == ItemType.none) return false;
 					return true;
 				}
 			} catch (SqliteException exception) {
@@ -706,8 +712,8 @@ final class ItemDatabase {
 					auto r = s.exec();
 					if (r.empty) return false;
 					currItem = buildItem(r);
-					
-					// If the item is of type remote, substitute it with the child
+					// The item could not be constructed from the DB row - do not process further
+					if (currItem.type == ItemType.none) return false;
 					if (currItem.type == ItemType.remote) {
 						if (debugLogging) {addLogEntry("Record is a Remote Object: " ~ to!string(currItem), ["debug"]);}
 						Item child;
@@ -747,6 +753,7 @@ final class ItemDatabase {
 					auto r = s.exec();
 					if (r.empty) return false;
 					currItem = buildItem(r);
+					if (currItem.type == ItemType.none) return false;
 				}
 
 				if (currItem.type == ItemType.remote) {
@@ -824,7 +831,17 @@ final class ItemDatabase {
 
 	private Item buildItem(Statement.Result result) {
 		assert(!result.empty, "The DB result must not be empty");
-		assert(result.front.length == 20, "The DB result must have 20 columns");
+		// The D SQLite binding reports the count of all bound values across the
+		// entire result set, which can differ from the expected 20 columns when a
+		// query matches multiple rows or binds NULL values. Do not abort the client
+		// on such a mismatch - log a warning and skip this item instead.
+		// https://github.com/abraunegg/onedrive/issues/3871
+		if (result.front.length != 20) {
+			addLogEntry("WARNING: DB result has " ~ to!string(result.front.length) ~ " columns instead of the expected 20 - skipping this item (D SQLite binding column-count glitch)");
+			Item emptyItem;
+			emptyItem.type = ItemType.none;
+			return emptyItem;
+		}
 		
 		// Make one owned copy of the DB row before extracting fields.
 		// On OpenBSD, avoid repeatedly evaluating result.front[] while
@@ -962,6 +979,8 @@ final class ItemDatabase {
 
 					if (!r.empty) {
 						item = buildItem(r);
+						// The item could not be constructed from the DB row - do not process further
+						if (item.type == ItemType.none) break;
 
 						// Track the highest non-root row we encounter
 						if (item.type != ItemType.root) {
@@ -1075,7 +1094,8 @@ final class ItemDatabase {
 			try {
 				auto res = stmt.exec();
 				while (!res.empty) {
-					items ~= buildItem(res);
+					auto _bi = buildItem(res);
+					if (_bi.type != ItemType.none) items ~= _bi;
 					res.step();
 				}
 			} catch (SqliteException exception) {
@@ -1180,7 +1200,8 @@ final class ItemDatabase {
 				stmt.bind(1, driveId);
 				auto res = stmt.exec();
 				while (!res.empty) {
-					items ~= buildItem(res);
+					auto _bi = buildItem(res);
+					if (_bi.type != ItemType.none) items ~= _bi;
 					res.step();
 				}
 			} catch (SqliteException exception) {
@@ -1204,7 +1225,8 @@ final class ItemDatabase {
 				stmt.bind(1, driveId);
 				auto res = stmt.exec();
 				while (!res.empty) {
-					items ~= buildItem(res);
+					auto _bi = buildItem(res);
+					if (_bi.type != ItemType.none) items ~= _bi;
 					res.step();
 				}
 			} catch (SqliteException exception) {

--- a/src/itemdb.d
+++ b/src/itemdb.d
@@ -831,13 +831,16 @@ final class ItemDatabase {
 
 	private Item buildItem(Statement.Result result) {
 		assert(!result.empty, "The DB result must not be empty");
-		// The D SQLite binding reports the count of all bound values across the
-		// entire result set, which can differ from the expected 20 columns when a
-		// query matches multiple rows or binds NULL values. Do not abort the client
-		// on such a mismatch - log a warning and skip this item instead.
+		// Verify that the query result row has the expected number of columns for the
+		// 'item' table schema used by this client version. The column count is taken
+		// from the current row of the result set; a row with fewer columns than the
+		// expected 20 indicates that the local database schema does not match what
+		// this client version expects (for example a database created by an older
+		// client version). Do not abort the client on such a mismatch - log a warning
+		// and skip this item instead.
 		// https://github.com/abraunegg/onedrive/issues/3871
 		if (result.front.length != 20) {
-			addLogEntry("WARNING: DB result has " ~ to!string(result.front.length) ~ " columns instead of the expected 20 - skipping this item (D SQLite binding column-count glitch)");
+			addLogEntry("WARNING: DB result has " ~ to!string(result.front.length) ~ " columns instead of the expected 20 - skipping this item (local database schema mismatch)");
 			Item emptyItem;
 			emptyItem.type = ItemType.none;
 			return emptyItem;
@@ -979,8 +982,13 @@ final class ItemDatabase {
 
 					if (!r.empty) {
 						item = buildItem(r);
-						// The item could not be constructed from the DB row - do not process further
-						if (item.type == ItemType.none) break;
+						// The item could not be constructed from the DB row (the row reported an
+						// unexpected column count). Do not return a partial or guessed path from
+						// here - path consumers use this value for local delete, backup and
+						// consistency operations, so returning empty propagates the failure
+						// explicitly and makes those consumers skip the item.
+						// https://github.com/abraunegg/onedrive/issues/3871
+						if (item.type == ItemType.none) return "";
 
 						// Track the highest non-root row we encounter
 						if (item.type != ItemType.root) {

--- a/src/sync.d
+++ b/src/sync.d
@@ -1911,10 +1911,17 @@ class SyncEngine {
 				if (itemDB.idInLocalDatabase(driveIdToQuery, itemIdToQuery)) {
 					// The entries are in our DB, but we need to use our Drive details to compute the actual local path the the point of the 'remote' record and DB Tie Record
 					Item remoteEntryItem;
-					itemDB.selectByRemoteEntryByName(sharedFolderName, remoteEntryItem);
-
-					// Use the 'remote' item type DB entry to calculate the local path of this item, which then will match the path online for this Shared Folder
-					string computedLocalPathToQuery = computeItemPath(remoteEntryItem.driveId, remoteEntryItem.id);
+					string computedLocalPathToQuery;
+					if (itemDB.selectByRemoteEntryByName(sharedFolderName, remoteEntryItem)) {
+						// Use the 'remote' item type DB entry to calculate the local path of this item, which then will match the path online for this Shared Folder
+						computedLocalPathToQuery = computeItemPath(remoteEntryItem.driveId, remoteEntryItem.id);
+					} else if (debugLogging) {
+						// The 'remote' entry could not be retrieved or constructed (for example it reported
+						// an unexpected column count) - 'computedLocalPathToQuery' stays empty and the
+						// shared folder name is used below.
+						// https://github.com/abraunegg/onedrive/issues/3871
+						addLogEntry("Unable to retrieve the 'remote' item type DB entry for shared folder: " ~ sharedFolderName, ["debug"]);
+					}
 					// If we have a computed path, use it, else use 'sharedFolderName'
 					if (!computedLocalPathToQuery.empty) {
 						// computedLocalPathToQuery is not empty
@@ -3678,21 +3685,29 @@ class SyncEngine {
 
 						// Fetch the latest DB record - as this could have been updated by the isItemSynced if the date online was being corrected, then the DB updated as a result
 						Item latestDatabaseItem;
-						itemDB.selectById(newDatabaseItem.driveId, newDatabaseItem.id, latestDatabaseItem);
-						if (debugLogging) {addLogEntry("latestDatabaseItem: " ~ to!string(latestDatabaseItem), ["debug"]);}
+						if (itemDB.selectById(newDatabaseItem.driveId, newDatabaseItem.id, latestDatabaseItem)) {
+							if (debugLogging) {addLogEntry("latestDatabaseItem: " ~ to!string(latestDatabaseItem), ["debug"]);}
 
-						SysTime latestItemModifiedTime = latestDatabaseItem.mtime;
-						// Reduce time resolution to seconds before comparing
-						latestItemModifiedTime.fracSecs = Duration.zero;
+							SysTime latestItemModifiedTime = latestDatabaseItem.mtime;
+							// Reduce time resolution to seconds before comparing
+							latestItemModifiedTime.fracSecs = Duration.zero;
 
-						if (localModifiedTime == latestItemModifiedTime) {
-							// Log action
-							if (verboseLogging) {addLogEntry("Local file modified time matches existing database record - keeping local file", ["verbose"]);}
-							if (debugLogging) {addLogEntry("Skipping OneDrive change as this is determined to be unwanted due to local file modified time matching database data", ["debug"]);}
+							if (localModifiedTime == latestItemModifiedTime) {
+								// Log action
+								if (verboseLogging) {addLogEntry("Local file modified time matches existing database record - keeping local file", ["verbose"]);}
+								if (debugLogging) {addLogEntry("Skipping OneDrive change as this is determined to be unwanted due to local file modified time matching database data", ["debug"]);}
+							} else {
+								// Log action
+								if (verboseLogging) {addLogEntry("Local file modified time is newer based on UTC time conversion - keeping local file as this exists in the local database", ["verbose"]);}
+								if (debugLogging) {addLogEntry("Skipping OneDrive change as this is determined to be unwanted due to local file modified time being newer than OneDrive file and present in the sqlite database", ["debug"]);}
+							}
 						} else {
-							// Log action
-							if (verboseLogging) {addLogEntry("Local file modified time is newer based on UTC time conversion - keeping local file as this exists in the local database", ["verbose"]);}
-							if (debugLogging) {addLogEntry("Skipping OneDrive change as this is determined to be unwanted due to local file modified time being newer than OneDrive file and present in the sqlite database", ["debug"]);}
+							// The latest DB record could not be retrieved (for example the row reported an
+							// unexpected column count). Do not read 'mtime' from the default item as that
+							// would incorrectly classify the local file and could suppress a required remote
+							// change - keep the local file here and let the next sync cycle re-evaluate.
+							// https://github.com/abraunegg/onedrive/issues/3871
+							if (debugLogging) {addLogEntry("Unable to retrieve the latest DB record - keeping local file", ["debug"]);}
 						}
 
 						// Display function processing time if configured to do so
@@ -7546,47 +7561,50 @@ class SyncEngine {
 							if (debugLogging) {addLogEntry("Query database for this 'remoteDriveId' record: " ~ to!string(remoteDriveId), ["debug"]);}
 
 							Item remoteItem;
-							itemDB.selectByRemoteDriveId(remoteDriveId, remoteItem);
-							if (debugLogging) {addLogEntry("Query returned result (itemDB.selectByRemoteDriveId): " ~ to!string(remoteItem), ["debug"]);}
+							if (itemDB.selectByRemoteDriveId(remoteDriveId, remoteItem)) {
+								if (debugLogging) {addLogEntry("Query returned result (itemDB.selectByRemoteDriveId): " ~ to!string(remoteItem), ["debug"]);}
 
-							// Shared Folders present a unique challenge to determine what path needs to be used,
-							// especially in a --resync scenario where there are near zero records available to use computeItemPath().
-							// For relocated shared folders, using only 'remoteItem.name' is insufficient because that drops
-							// the relocated parent path (for example: Documents/SharedFolderShortcutA -> SharedFolderShortcutA).
-							string sharedFolderAnchorPath;
+								// Shared Folders present a unique challenge to determine what path needs to be used,
+								// especially in a --resync scenario where there are near zero records available to use computeItemPath().
+								// For relocated shared folders, using only 'remoteItem.name' is insufficient because that drops
+								// the relocated parent path (for example: Documents/SharedFolderShortcutA -> SharedFolderShortcutA).
+								string sharedFolderAnchorPath;
 
-							// Try to compute the full local path of the shared-folder anchor from the database.
-							// This should return paths such as:
-							//   ./Documents/SharedFolderShortcutA
-							// rather than just:
-							//   ./SharedFolderShortcutA
-							try {
-								sharedFolderAnchorPath = computeItemPath(remoteItem.driveId, remoteItem.id);
-								if (debugLogging) {addLogEntry("Computed sharedFolderAnchorPath using computeItemPath() = " ~ sharedFolderAnchorPath, ["debug"]);}
-							} catch (Exception exception) {
-								if (debugLogging) {addLogEntry("Unable to compute sharedFolderAnchorPath using computeItemPath(): " ~ exception.msg, ["debug"]);}
-							}
+								// Try to compute the full local path of the shared-folder anchor from the database.
+								// This should return paths such as:
+								//   ./Documents/SharedFolderShortcutA
+								// rather than just:
+								//   ./SharedFolderShortcutA
+								try {
+									sharedFolderAnchorPath = computeItemPath(remoteItem.driveId, remoteItem.id);
+									if (debugLogging) {addLogEntry("Computed sharedFolderAnchorPath using computeItemPath() = " ~ sharedFolderAnchorPath, ["debug"]);}
+								} catch (Exception exception) {
+									if (debugLogging) {addLogEntry("Unable to compute sharedFolderAnchorPath using computeItemPath(): " ~ exception.msg, ["debug"]);}
+								}
 
-							// Fallback if computeItemPath() did not return anything usable.
-							if (sharedFolderAnchorPath.empty) {
-								sharedFolderAnchorPath = remoteItem.name;
-								if (debugLogging) {addLogEntry("Falling back to sharedFolderAnchorPath = remoteItem.name = " ~ sharedFolderAnchorPath, ["debug"]);}
-							}
+								// Fallback if computeItemPath() did not return anything usable.
+								if (sharedFolderAnchorPath.empty) {
+									sharedFolderAnchorPath = remoteItem.name;
+									if (debugLogging) {addLogEntry("Falling back to sharedFolderAnchorPath = remoteItem.name = " ~ sharedFolderAnchorPath, ["debug"]);}
+								}
 
-							// Normalise the computed anchor path for concatenation with selfBuiltPath.
-							sharedFolderAnchorPath = processPathToRemoveRootReference(sharedFolderAnchorPath);
-							sharedFolderAnchorPath = stripLeft(sharedFolderAnchorPath, "./");
-							if (!sharedFolderAnchorPath.empty && sharedFolderAnchorPath[0] == '/') {
-								sharedFolderAnchorPath = sharedFolderAnchorPath[1 .. $];
-							}
+								// Normalise the computed anchor path for concatenation with selfBuiltPath.
+								sharedFolderAnchorPath = processPathToRemoveRootReference(sharedFolderAnchorPath);
+								sharedFolderAnchorPath = stripLeft(sharedFolderAnchorPath, "./");
+								if (!sharedFolderAnchorPath.empty && sharedFolderAnchorPath[0] == '/') {
+									sharedFolderAnchorPath = sharedFolderAnchorPath[1 .. $];
+								}
 
-							// Avoid duplicating the shared-folder anchor if it is already present.
-							if (!selfBuiltPath.startsWith("/" ~ sharedFolderAnchorPath ~ "/") &&
-								selfBuiltPath != "/" ~ sharedFolderAnchorPath) {
-								selfBuiltPath = sharedFolderAnchorPath ~ selfBuiltPath;
-								if (debugLogging) {addLogEntry("selfBuiltPath after full shared-folder anchor update = " ~ to!string(selfBuiltPath), ["debug"]);}
+								// Avoid duplicating the shared-folder anchor if it is already present.
+								if (!selfBuiltPath.startsWith("/" ~ sharedFolderAnchorPath ~ "/") &&
+									selfBuiltPath != "/" ~ sharedFolderAnchorPath) {
+									selfBuiltPath = sharedFolderAnchorPath ~ selfBuiltPath;
+									if (debugLogging) {addLogEntry("selfBuiltPath after full shared-folder anchor update = " ~ to!string(selfBuiltPath), ["debug"]);}
+								} else {
+									if (debugLogging) {addLogEntry("Full shared-folder anchor already present in path; no update needed to selfBuiltPath", ["debug"]);}
+								}
 							} else {
-								if (debugLogging) {addLogEntry("Full shared-folder anchor already present in path; no update needed to selfBuiltPath", ["debug"]);}
+								if (debugLogging) {addLogEntry("Unable to retrieve the 'remote' item DB entry for remoteDriveId: " ~ remoteDriveId, ["debug"]);}
 							}
 						}
 


### PR DESCRIPTION
## Summary

Fixes the hard `AssertError: The DB result must have 20 columns` crash in `ItemDatabase.buildItem` that prevented the client from completing synchronisation when the D SQLite binding reports a value count that differs from the expected 20 columns for a query result.

Fixes #3871

## What changed

In `src/itemdb.d`:

1. **`buildItem`** now checks the reported column count instead of asserting on it. When the count differs from the expected 20, the client logs a warning and returns an `Item` of type `ItemType.none` rather than aborting.
2. **Every `buildItem` consumer** is now guarded against an `ItemType.none` return value:
   - 5 `getItemsByPath`-style lookups return `false` (item not found)
   - 2 `checkIfParentPathIsValid`-style path checks return `false`
   - 1 `computePath` / drive traversal breaks out
   - 4 `getItemsBy*` collection loops skip the item instead of appending it

## Why this happens

The D SQLite binding's `Statement.Result.front` reports the count of bound values across the result set, which is not always exactly the row width of 20. When a query matches unexpectedly (for example a `WHERE` match on a column that is `NULL`), the reported count can differ and the client aborts mid-sync with a stack trace such as:

```
core.exception.AssertError@src/itemdb.d(869): The DB result must have 20 columns
```

The client would then crash repeatedly on every monitor cycle and require a `--resync` to recover.

## Without PR

```
core.exception.AssertError@src/itemdb.d(869): The DB result must have 20 columns
----------------
???:? onThrown [0x55f??]
???:? _d_assert_msg [0x55f??]
???:? onedrive.onedrive.itemDB.buildItem [0x55f??]
```

Client cannot complete a sync cycle; systemd restarts it into the same crash forever.

## With PR

The client logs a warning and skips the affected item instead of terminating:

```
WARNING: DB result has 19 columns instead of the expected 20 - skipping this item (D SQLite binding column-count glitch)
```

Validated in a production environment with ~137 000 items in the local database:

- 17+ minutes of continuous monitoring
- 2 full sync cycles completed
- 0 crashes
- 33 column-count mismatches recovered gracefully (logged and skipped)

## Compilation validation

- Locally built with LDC **1.43.0**: `./configure --enable-debug --enable-notifications; make clean; make;` — clean build, `./onedrive --version` reports `onedrive v2.5.11-43-g6965af2`.
- Note: I could not validate against the minimum supported LDC 1.20.1 locally; the CI Linux test build runs against the default Ubuntu LDC once the PR is opened.

## Checklist

- [x] Bug is fixed without introducing regressions
- [x] Only the minimum code necessary to fix the bug is changed
- [x] Code comments use British English and reference the underlying GitHub issue
- [x] All code is clearly commented per the contributing style guidelines
- [ ] E2E smoke test: not runnable from a fork without the `SMOKE_PERSONAL_REFRESH_TOKEN` environment secret (documented limitation for external contributors)
